### PR TITLE
refactor: scrolling behavior and improve cell width handling

### DIFF
--- a/src/contentScript/nestedEditor/nestedCellEditor.ts
+++ b/src/contentScript/nestedEditor/nestedCellEditor.ts
@@ -69,11 +69,18 @@ class NestedCellEditorManager {
         this.mainView = params.mainView;
         this.cellFrom = params.cellFrom;
         this.cellTo = params.cellTo;
+        this.cellElement = params.cellElement;
+
+        // Lock cell width before switching to edit mode to prevent horizontal
+        // expansion when raw markdown (e.g., long URLs) is shown instead of
+        // rendered content. Height will still adjust as text wraps.
+        // Use max-width (not just width) because table cells treat width as a minimum.
+        const cellWidth = this.cellElement.offsetWidth;
+        this.cellElement.style.maxWidth = `${cellWidth}px`;
 
         const { content, editorHost } = ensureCellWrapper(params.cellElement);
         this.contentEl = content;
         this.editorHostEl = editorHost;
-        this.cellElement = params.cellElement;
 
         // Add active class to cell for styling
         this.cellElement.classList.add(CLASS_CELL_ACTIVE);
@@ -324,6 +331,8 @@ class NestedCellEditorManager {
 
         if (this.cellElement) {
             this.cellElement.classList.remove(CLASS_CELL_ACTIVE);
+            // Remove the width lock set during open()
+            this.cellElement.style.maxWidth = '';
             this.cellElement = null;
         }
 

--- a/src/contentScript/tableWidget/tableStyles.ts
+++ b/src/contentScript/tableWidget/tableStyles.ts
@@ -48,6 +48,8 @@ export const tableStyles = EditorView.baseTheme({
         lineHeight: 'inherit',
         fontFamily: 'inherit',
         fontSize: 'inherit',
+        // Prevent horizontal scroll - text should wrap within the locked cell width
+        overflowX: 'hidden',
     },
     [`.${CLASS_CELL_EDITOR} .cm-content`]: {
         margin: '0',
@@ -55,6 +57,9 @@ export const tableStyles = EditorView.baseTheme({
         minHeight: 'unset',
         lineHeight: 'inherit',
         color: 'inherit',
+        // Ensure long text (URLs, etc.) breaks to wrap within the cell
+        overflowWrap: 'break-word',
+        wordBreak: 'break-word',
     },
     [`.${CLASS_CELL_EDITOR} .cm-line`]: {
         padding: '0',
@@ -74,6 +79,11 @@ export const tableStyles = EditorView.baseTheme({
         outline: '2px solid var(--joplin-divider-color, #dddddd)',
         outlineOffset: '-1px', // Draw inside existing border
         zIndex: '5', // Ensure on top of neighbors
+        // Allow long text (e.g., raw markdown URLs) to break within the locked width
+        overflowWrap: 'break-word',
+        wordBreak: 'break-word',
+        // Ensure max-width set via JS matches offsetWidth (which includes padding/border)
+        boxSizing: 'border-box',
     },
     [`.${CLASS_CELL_EDITOR} .cm-fat-cursor`]: {
         backgroundColor: 'currentColor',


### PR DESCRIPTION
- Improve scrolling stability when switching cells by deferring scroll actions until after codemirror layout measurements. 
- Lock the cell's maxWidth to its current pixel width when the nested editor opens. This prevents the "jumping" effect where a column suddenly expands horizontally (which could also significantly reduce the cell height, resulting in a large vertical scroll jump) when switching from rendered HTML to raw Markdown (e.g., long URLs). The width is unlocked when the editor closes.
- Replace complex manual scroll calculations for cell switching with simple scrollIntoView, which now works reliably after other scroll stability improvements.