### PR TITLE
Refactor to use official types for ContentScriptContext and CodeMirrorControl

### DIFF
--- a/src/contentScript/tableWidget/tableWidgetExtension.ts
+++ b/src/contentScript/tableWidget/tableWidgetExtension.ts
@@ -1,6 +1,7 @@
 import { EditorView, Decoration, DecorationSet } from '@codemirror/view';
-import { EditorState, Range, StateField, ChangeSet, Facet } from '@codemirror/state';
-import { ContentScriptContext, CodeMirrorControl } from 'api/types';
+import { EditorState, Range, StateField, ChangeSet } from '@codemirror/state';
+import type { Facet } from '@codemirror/state';
+import type { ContentScriptContext, CodeMirrorControl } from 'api/types';
 import { TableWidget } from './TableWidget';
 import { parseMarkdownTable, TableData } from '../tableModel/markdownTableParsing';
 import { initRenderer } from '../services/markdownRenderer';


### PR DESCRIPTION
Replace local type definitions with official types from the API to improve code consistency and maintainability.