### PR TITLE
fix: regression where cell selection included trailing whitespace

### DIFF
--- a/src/contentScript/__tests__/activeCellResolver.test.ts
+++ b/src/contentScript/__tests__/activeCellResolver.test.ts
@@ -103,7 +103,7 @@ describe('activeCellResolver', () => {
         expect(state.doc.sliceString(resolved!.cellFrom, resolved!.cellTo)).toBe('foo  ');
     });
 
-    it('extends the resolved cell range across trailing whitespace when the selection is exactly at cell end', () => {
+    it('does not expand when the selection is exactly at the trimmed cell end', () => {
         const doc = ['| foo  |', '| --- |'].join('\n');
         const cellEndCursor = doc.indexOf('foo') + 'foo'.length;
         const state = createState(doc, {
@@ -119,8 +119,8 @@ describe('activeCellResolver', () => {
 
         expect(resolved).not.toBeNull();
         expect(resolved?.cellFrom).toBe(doc.indexOf('foo'));
-        expect(resolved?.cellTo).toBe(doc.indexOf('|', doc.indexOf('foo')));
-        expect(state.doc.sliceString(resolved!.cellFrom, resolved!.cellTo)).toBe('foo  ');
+        expect(resolved?.cellTo).toBe(doc.indexOf('foo') + 'foo'.length);
+        expect(state.doc.sliceString(resolved!.cellFrom, resolved!.cellTo)).toBe('foo');
     });
 
     it('resolves the anchored table from tableFrom when another table follows', () => {

--- a/src/contentScript/__tests__/tableRuntimePolicies.test.ts
+++ b/src/contentScript/__tests__/tableRuntimePolicies.test.ts
@@ -15,6 +15,7 @@ import { searchForceSourceModeField, setSearchForceSourceModeEffect } from '../t
 import {
     buildTableRuntimeEvent,
     planTableLifecycleActions,
+    transactionRequiresTableRebuild,
     type TableRuntimeEvent,
     type TableRuntimeSnapshot,
 } from '../tableRuntime/lifecycle/lifecyclePolicy';
@@ -451,6 +452,23 @@ describe('tableRuntimePolicies', () => {
         expect(planTableLifecycleActions(snapshot, event, { cursorInsideTableAfterUndoRedo: false })).toContainEqual({
             type: 'clearActiveCell',
         });
+    });
+
+    it('does not require rebuild when undo change range falls within trailing cell padding', () => {
+        // `| H1 | H2 |` — "H1" is at positions 2-3 (trimmed), but the raw cell is `| H1 |`
+        // so position 4 is a trailing space, position 5 is the pipe. An undo that produces
+        // a change touching positions 2-4 (content + one trailing space) should not rebuild.
+        const activeCell = getHeaderCell();
+        const state = createState({ activeCell });
+        const resolved = requireResolvedActiveCell(state);
+
+        // Simulate an undo transaction whose change range extends one position into trailing padding
+        const tr = state.update({
+            changes: { from: resolved.cellFrom, to: resolved.cellTo + 1, insert: 'H1' },
+            annotations: Transaction.userEvent.of('undo'),
+        });
+
+        expect(transactionRequiresTableRebuild(tr, resolved)).toBe(false);
     });
 
     it('clears stale active cell when the resolver cannot find the table', () => {

--- a/src/contentScript/tableRuntime/activeCell/activeCellResolver.ts
+++ b/src/contentScript/tableRuntime/activeCell/activeCellResolver.ts
@@ -19,7 +19,7 @@ function expandCellEndForTrailingWhitespace(
     const selection = state.selection.main;
     const maxSelectionPos = Math.max(selection.anchor, selection.head);
 
-    if (maxSelectionPos < range.cellTo) {
+    if (maxSelectionPos <= range.cellTo) {
         return range;
     }
 

--- a/src/contentScript/tableRuntime/lifecycle/lifecyclePolicy.ts
+++ b/src/contentScript/tableRuntime/lifecycle/lifecyclePolicy.ts
@@ -1,4 +1,4 @@
-import { ChangeSet, EditorSelection, SelectionRange, Transaction } from '@codemirror/state';
+import { ChangeSet, EditorSelection, SelectionRange, Text, Transaction } from '@codemirror/state';
 import { ViewUpdate } from '@codemirror/view';
 import { getActiveCell, isSameActiveCell, type ActiveCell } from '../../tableState/activeCellState';
 import { cellSelectionTransitionAnnotation } from '../../tableState/cellSelectionState';
@@ -282,13 +282,23 @@ function shouldRepositionCellAfterUndoRedo(
     return isUndoRedo && cursorInsideTableAfterUndoRedo;
 }
 
+function expandCellToThroughTrailingPadding(doc: Text, cellTo: number): number {
+    const line = doc.lineAt(cellTo);
+    let pos = cellTo;
+    while (pos < line.to && /\s/.test(doc.sliceString(pos, pos + 1))) {
+        pos++;
+    }
+    return pos;
+}
+
 function transactionChangesOutsideCell(tr: Transaction, activeCell: ResolvedActiveCell): boolean {
+    const effectiveCellTo = expandCellToThroughTrailingPadding(tr.startState.doc, activeCell.cellTo);
     let outsideCell = false;
     tr.changes.iterChanges((fromA, toA) => {
         if (outsideCell) {
             return;
         }
-        if (fromA < activeCell.cellFrom || toA > activeCell.cellTo) {
+        if (fromA < activeCell.cellFrom || toA > effectiveCellTo) {
             outsideCell = true;
         }
     });


### PR DESCRIPTION
fixes the regression while still fixing the unnecessary widget rebuild that the change from commit 6b05df74b58a74f4f6ff1200d182bf8e0c7a0c71 was preventing