### PR TITLE
refactor: less hacky whitespace handling

### DIFF
--- a/docs/Architecture/Nested-Editor-Architecture.md
+++ b/docs/Architecture/Nested-Editor-Architecture.md
@@ -41,7 +41,7 @@ The lifecycle plugin remains responsible only for executing nested-editor side e
 2. `NestedEditorSession` uses `editorBridge/cellTextCodec.ts` to sanitize local display text (`\n` -> `<br>`, `|` -> `\|`) and map the local selection into root cell coordinates.
 3. The main editor applies the cell-only replacement transaction tagged with `editorBridge/syncAnnotation.ts`.
 4. If normalization rewrites the whole table first, it also dispatches a reopen intent so lifecycle can reopen after rebuild.
-5. After root dispatch, the session refreshes its derived absolute ranges from the current active-cell identity.
+5. After root dispatch, the session refreshes its derived semantic/editable ranges from the current active-cell identity.
 6. External non-sync root changes re-resolve the logical cell and rebase the isolated editor from authoritative root text.
 
 ### Selection Sync
@@ -52,6 +52,10 @@ Joplin toolbar reads main editor selection, so nested must mirror upward.
 2. It mirrors the mapped absolute selection to the main editor (`syncAnnotation` + `addToHistory: false`).
 3. Root-owned commands update the authoritative root selection/doc.
 4. The session rebases the isolated editor selection from the resulting root cell text.
+
+Selection mirroring uses the cell's editable span, not the fully trimmed semantic content span. This keeps toolbar and
+formatting commands aligned with user-entered leading/trailing whitespace while still hiding canonical delimiter padding
+from the local editor.
 
 ### Undo/Redo
 
@@ -85,6 +89,7 @@ Blocks unintended main editor edits during cell editing (Android IME focus issue
 
 - Uses the shared transition policy to allow, reject, or sanitize main-editor transactions.
 - Rejects changes touching active table but outside cell range.
+- Treats the editable span as the allowed in-cell edit range while the semantic span remains the render/parse source.
 - Allows external updates not overlapping table.
 - Whitelists `syncAnnotation` transactions.
 - Whitelists structural operations with `rebuildTableWidgetsEffect`.

--- a/docs/Architecture/Overview.md
+++ b/docs/Architecture/Overview.md
@@ -59,7 +59,7 @@ Cell click / navigation / selection focus → widget/runtime logic resolves row/
 
 `ActiveCell` is logical-first state: it persists `tableFrom` plus `section/row/col`. Cursor placement such as
 the main-editor selection anchor is transient request data, not part of persisted active-cell identity. Raw offsets
-such as `tableTo` and `cellFrom/cellTo` are derived on demand through the shared active-cell resolver.
+such as `tableTo` plus semantic/editable cell spans are derived on demand through the shared active-cell resolver.
 
 Before lifecycle opens the nested editor for user-driven entry, `tableRuntime/lifecycle/nestedEditorLifecycle.ts` checks whether the table markdown
 is already in the plugin's canonical serialized form. If not, it rewrites the whole table once, preserves the logical
@@ -73,6 +73,9 @@ Typing in the isolated cell editor goes through the `NestedEditorSession` bridge
 - `editorBridge/cellTextCodec.ts` sanitizes local display text and selection into authoritative root cell text and selection.
 - The main editor applies the change with `editorBridge/syncAnnotation.ts`.
 - Non-sync root changes re-resolve the logical cell from the persisted active-cell identity and rebase the isolated editor.
+- `cellRanges` expose both trimmed semantic bounds and editable bounds; nested-editor sync and Joplin formatting-command
+  selection mirroring use the editable span so user-entered edge whitespace stays addressable without exposing canonical
+  delimiter padding in the local editor.
 - The nested editor is cell-local, not a clipped whole-document subview.
 
 ### 4. Table Runtime Model

--- a/docs/Architecture/Table-Parsing.md
+++ b/docs/Architecture/Table-Parsing.md
@@ -22,13 +22,17 @@ Everything else in the table model layer builds on this scanner (don’t split o
 - Filters to non-empty lines (matching the parser’s behavior).
 - Validates the separator row with `isSeparatorRow()`, but intentionally does not return ranges for the separator row.
 - Trims outer whitespace and ignores leading/trailing pipes.
-- Trims per-cell whitespace; for whitespace-only cells it chooses a stable insertion point so edits don’t “stick” directly to a pipe in the plugin’s canonical padded format.
+- Produces two bounds per cell:
+    - `from/to`: trimmed semantic content bounds used for parsing/rendering.
+    - `editableFrom/editableTo`: editing bounds used by the nested editor and selection sync.
+- Editable bounds hide one delimiter-adjacent pad character per side while preserving any additional leading/trailing whitespace the user typed into the cell.
+- For empty or whitespace-only cells, editable bounds collapse to a stable insertion point so edits don’t “stick” directly to a pipe in the plugin’s canonical padded format.
 
 These ranges are used for:
 
-- Mapping positions back to cell coordinates (`findCellForPos()`).
-- Resolving a cell’s `from/to` range (`getCellRange()`).
-- Deriving live `cellFrom/cellTo` values for logical active-cell state.
+- Mapping positions back to cell coordinates (`findCellForPos()`), using the editable span.
+- Resolving a cell’s semantic/editable ranges (`getCellRange()`).
+- Deriving live semantic/editable document spans for logical active-cell state.
 
 ## Parsing to a Structured Table Model
 
@@ -73,7 +77,7 @@ the current editor state through the shared active-cell resolver. That resolver:
 
 - Re-resolves the anchored table from `tableFrom`.
 - Rebuilds `TableContext`.
-- Derives `tableTo` and `cellFrom/cellTo` from current `cellRanges`.
+- Derives `tableTo`, trimmed content bounds, and editable bounds from current `cellRanges`.
 
 If resolution fails, the active cell is treated as stale and cleared rather than clamped to a nearby cell.
 

--- a/src/contentScript/__tests__/activeCellResolver.test.ts
+++ b/src/contentScript/__tests__/activeCellResolver.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from '@jest/globals';
 import { activeCellField, getActiveCell, setActiveCellEffect, type ActiveCell } from '../tableState/activeCellState';
 import { resolveActiveCell } from '../tableRuntime/activeCell/activeCellResolver';
+import { getResolvedActiveCell, resolvedActiveCellField } from '../tableRuntime/activeCell/resolvedActiveCellField';
 import { createMarkdownState } from './testMarkdownState';
 
 function createState(doc: string, activeCell?: ActiveCell) {
@@ -26,8 +27,10 @@ describe('activeCellResolver', () => {
         const resolved = resolveActiveCell(state, getActiveCell(state));
 
         expect(resolved).not.toBeNull();
-        expect(resolved?.cellFrom).toBe(doc.indexOf('H2'));
-        expect(resolved?.cellTo).toBe(doc.indexOf('H2') + 2);
+        expect(resolved?.contentFrom).toBe(doc.indexOf('H2'));
+        expect(resolved?.contentTo).toBe(doc.indexOf('H2') + 2);
+        expect(resolved?.editableFrom).toBe(doc.indexOf('H2'));
+        expect(resolved?.editableTo).toBe(doc.indexOf('H2') + 2);
     });
 
     it('tracks tableFrom when text is inserted before the table', () => {
@@ -47,7 +50,7 @@ describe('activeCellResolver', () => {
         expect(resolved).not.toBeNull();
         expect(tr.state.field(activeCellField)?.tableFrom).toBe('before\n'.length);
         expect(resolved?.tableFrom).toBe('before\n'.length);
-        expect(tr.state.doc.sliceString(resolved!.cellFrom, resolved!.cellTo)).toBe('H1');
+        expect(tr.state.doc.sliceString(resolved!.contentFrom, resolved!.contentTo)).toBe('H1');
     });
 
     it('returns null when the anchored table no longer exists', () => {
@@ -83,44 +86,65 @@ describe('activeCellResolver', () => {
         expect(resolveActiveCell(tr.state, tr.state.field(activeCellField))).toBeNull();
     });
 
-    it('extends the resolved cell range across trailing whitespace that contains the selection', () => {
-        const doc = ['| foo  |', '| --- |'].join('\n');
-        const trailingSpaceCursor = doc.indexOf('foo') + 'foo '.length;
+    it('returns separate content and editable spans for edge whitespace', () => {
+        const doc = ['|  foo  |', '| --- |'].join('\n');
         const state = createState(doc, {
             tableFrom: 0,
             section: 'header',
             row: 0,
             col: 0,
-        }).update({
-            selection: { anchor: trailingSpaceCursor },
-        }).state;
+        });
 
         const resolved = resolveActiveCell(state, getActiveCell(state));
 
         expect(resolved).not.toBeNull();
-        expect(resolved?.cellFrom).toBe(doc.indexOf('foo'));
-        expect(resolved?.cellTo).toBe(doc.indexOf('|', doc.indexOf('foo')));
-        expect(state.doc.sliceString(resolved!.cellFrom, resolved!.cellTo)).toBe('foo  ');
+        expect(resolved?.contentFrom).toBe(doc.indexOf('foo'));
+        expect(resolved?.contentTo).toBe(doc.indexOf('foo') + 'foo'.length);
+        expect(resolved?.editableFrom).toBe(doc.indexOf('foo') - 1);
+        expect(resolved?.editableTo).toBe(doc.indexOf('foo') + 'foo '.length);
+        expect(state.doc.sliceString(resolved!.contentFrom, resolved!.contentTo)).toBe('foo');
+        expect(state.doc.sliceString(resolved!.editableFrom, resolved!.editableTo)).toBe(' foo ');
     });
 
-    it('does not expand when the selection is exactly at the trimmed cell end', () => {
+    it('is selection-independent even when the cursor moves into editable edge whitespace', () => {
         const doc = ['| foo  |', '| --- |'].join('\n');
-        const cellEndCursor = doc.indexOf('foo') + 'foo'.length;
         const state = createState(doc, {
             tableFrom: 0,
             section: 'header',
             row: 0,
             col: 0,
-        }).update({
-            selection: { anchor: cellEndCursor },
+        });
+        const withSelection = state.update({
+            selection: { anchor: doc.indexOf('foo') + 'foo '.length },
         }).state;
 
         const resolved = resolveActiveCell(state, getActiveCell(state));
+        const resolvedWithSelection = resolveActiveCell(withSelection, getActiveCell(withSelection));
 
         expect(resolved).not.toBeNull();
-        expect(resolved?.cellFrom).toBe(doc.indexOf('foo'));
-        expect(resolved?.cellTo).toBe(doc.indexOf('foo') + 'foo'.length);
-        expect(state.doc.sliceString(resolved!.cellFrom, resolved!.cellTo)).toBe('foo');
+        expect(resolvedWithSelection).not.toBeNull();
+        expect(resolvedWithSelection).toEqual(resolved);
+    });
+
+    it('reuses the cached resolved active cell across selection-only updates', () => {
+        let state = createMarkdownState(['| foo  |', '| --- |'].join('\n'), [activeCellField, resolvedActiveCellField]);
+        state = state.update({
+            effects: setActiveCellEffect.of({
+                tableFrom: 0,
+                section: 'header',
+                row: 0,
+                col: 0,
+            }),
+        }).state;
+
+        const initialResolved = getResolvedActiveCell(state);
+        const nextState = state.update({
+            selection: { anchor: state.doc.toString().indexOf('foo') + 'foo '.length },
+        }).state;
+        const nextResolved = getResolvedActiveCell(nextState);
+
+        expect(initialResolved).not.toBeNull();
+        expect(nextResolved).toBe(initialResolved);
     });
 
     it('resolves the anchored table from tableFrom when another table follows', () => {
@@ -147,6 +171,6 @@ describe('activeCellResolver', () => {
         expect(resolved?.activeCell.section).toBe('body');
         expect(resolved?.activeCell.row).toBe(0);
         expect(resolved?.activeCell.col).toBe(1);
-        expect(state.doc.sliceString(resolved!.cellFrom, resolved!.cellTo)).toBe('');
+        expect(state.doc.sliceString(resolved!.contentFrom, resolved!.contentTo)).toBe('');
     });
 });

--- a/src/contentScript/__tests__/cellTextCodec.test.ts
+++ b/src/contentScript/__tests__/cellTextCodec.test.ts
@@ -80,6 +80,13 @@ describe('selection mapping', () => {
         expect(rootSelection).toEqual({ anchor: localText.length, head: localText.length });
     });
 
+    it('keeps leading-space cursor positions stable for root-owned commands', () => {
+        const localText = ' sometext';
+        const rootSelection = toRootSelection({ anchor: 1, head: 1 }, localText);
+
+        expect(rootSelection).toEqual({ anchor: 1, head: 1 });
+    });
+
     it('keeps trailing-space cursor positions stable after normalizing a non-canonical table first', () => {
         const canonicalTable = MarkdownTable.parse(['|SOMETEXT|', '|---|'].join('\n'))?.serialize();
         expect(canonicalTable).toBe(['| SOMETEXT |', '| --- |'].join('\n'));

--- a/src/contentScript/__tests__/markdownTableCellRanges.test.ts
+++ b/src/contentScript/__tests__/markdownTableCellRanges.test.ts
@@ -66,6 +66,71 @@ describe('computeMarkdownTableCellRanges', () => {
         expect(sliceRange(text, r.from, r.to)).toBe('');
     });
 
+    it('hides canonical delimiter padding from editable bounds', () => {
+        const text = ['| foo |', '| --- |'].join('\n');
+        const ranges = computeMarkdownTableCellRanges(text);
+        expect(ranges).not.toBeNull();
+        if (!ranges) return;
+
+        const header = ranges.headers[0];
+        expect(sliceRange(text, header.from, header.to)).toBe('foo');
+        expect(sliceRange(text, header.editableFrom, header.editableTo)).toBe('foo');
+    });
+
+    it('preserves user-entered trailing whitespace in editable bounds', () => {
+        const text = ['| foo  |', '| --- |'].join('\n');
+        const ranges = computeMarkdownTableCellRanges(text);
+        expect(ranges).not.toBeNull();
+        if (!ranges) return;
+
+        const header = ranges.headers[0];
+        expect(sliceRange(text, header.from, header.to)).toBe('foo');
+        expect(sliceRange(text, header.editableFrom, header.editableTo)).toBe('foo ');
+    });
+
+    it('preserves user-entered leading whitespace in editable bounds', () => {
+        const text = ['|  foo |', '| --- |'].join('\n');
+        const ranges = computeMarkdownTableCellRanges(text);
+        expect(ranges).not.toBeNull();
+        if (!ranges) return;
+
+        const header = ranges.headers[0];
+        expect(sliceRange(text, header.from, header.to)).toBe('foo');
+        expect(sliceRange(text, header.editableFrom, header.editableTo)).toBe(' foo');
+    });
+
+    it('preserves user-entered leading and trailing whitespace in editable bounds', () => {
+        const text = ['|  foo  |', '| --- |'].join('\n');
+        const ranges = computeMarkdownTableCellRanges(text);
+        expect(ranges).not.toBeNull();
+        if (!ranges) return;
+
+        const header = ranges.headers[0];
+        expect(sliceRange(text, header.from, header.to)).toBe('foo');
+        expect(sliceRange(text, header.editableFrom, header.editableTo)).toBe(' foo ');
+    });
+
+    it('uses a zero-width editable span for canonical empty cells', () => {
+        const text = ['|  |', '| --- |'].join('\n');
+        const ranges = computeMarkdownTableCellRanges(text);
+        expect(ranges).not.toBeNull();
+        if (!ranges) return;
+
+        const header = ranges.headers[0];
+        expect(header.editableFrom).toBe(header.editableTo);
+        expect(sliceRange(text, header.editableFrom, header.editableTo)).toBe('');
+    });
+
+    it('returns stable editable bounds for cells without canonical pad spaces', () => {
+        const text = ['|foo|bar|', '|---|---|'].join('\n');
+        const ranges = computeMarkdownTableCellRanges(text);
+        expect(ranges).not.toBeNull();
+        if (!ranges) return;
+
+        expect(sliceRange(text, ranges.headers[0].editableFrom, ranges.headers[0].editableTo)).toBe('foo');
+        expect(sliceRange(text, ranges.headers[1].editableFrom, ranges.headers[1].editableTo)).toBe('bar');
+    });
+
     it('allows uneven row lengths', () => {
         const text = ['| a | b |', '| --- | --- |', '| c |'].join('\n');
         const ranges = computeMarkdownTableCellRanges(text);
@@ -144,6 +209,19 @@ describe('findCellForPos', () => {
         // Position in middle of cell
         const coordsMiddle = findCellForPos(ranges, headerCell.from + 1);
         expect(coordsMiddle).toEqual({ section: 'header', row: 0, col: 0 });
+    });
+
+    it('finds cells for positions in editable edge whitespace but not structural pad space', () => {
+        const text = ['|  foo  |', '| --- |'].join('\n');
+        const ranges = computeMarkdownTableCellRanges(text);
+        expect(ranges).not.toBeNull();
+        if (!ranges) return;
+
+        const headerCell = ranges.headers[0];
+
+        expect(findCellForPos(ranges, headerCell.editableFrom)).toEqual({ section: 'header', row: 0, col: 0 });
+        expect(findCellForPos(ranges, headerCell.editableTo)).toEqual({ section: 'header', row: 0, col: 0 });
+        expect(findCellForPos(ranges, headerCell.editableFrom - 1)).toBeNull();
     });
 
     it('returns null for positions outside any cell', () => {

--- a/src/contentScript/__tests__/nestedEditorLifecycle.test.ts
+++ b/src/contentScript/__tests__/nestedEditorLifecycle.test.ts
@@ -158,8 +158,8 @@ describe('nestedEditorLifecycle', () => {
         }
 
         expect(nestedEditorControllerMock.closeNestedEditor).toHaveBeenCalledWith(view, {
-            cellFrom: resolved.cellFrom,
-            cellTo: resolved.cellTo,
+            contentFrom: resolved.contentFrom,
+            contentTo: resolved.contentTo,
         });
 
         view.destroy();

--- a/src/contentScript/__tests__/tableNavigation.test.ts
+++ b/src/contentScript/__tests__/tableNavigation.test.ts
@@ -88,8 +88,10 @@ describe('navigateCell', () => {
         };
 
         (resolveCellDocRange as jest.Mock).mockReturnValue({
-            cellFrom: 10,
-            cellTo: 20,
+            contentFrom: 10,
+            contentTo: 20,
+            editableFrom: 10,
+            editableTo: 20,
         });
         (resolveActiveCell as jest.Mock).mockReturnValue({
             ctx,

--- a/src/contentScript/__tests__/tableRuntimePolicies.test.ts
+++ b/src/contentScript/__tests__/tableRuntimePolicies.test.ts
@@ -86,7 +86,7 @@ describe('tableRuntimePolicies', () => {
         const state = createState({ activeCell });
         const resolved = requireResolvedActiveCell(state);
         const tr = state.update({
-            changes: { from: resolved.cellFrom, to: resolved.cellFrom, insert: 'x' },
+            changes: { from: resolved.editableFrom, to: resolved.editableFrom, insert: 'x' },
         });
 
         expect(decideTableDecorationUpdate(tr)).toEqual({ type: 'mapDecorations' });
@@ -133,7 +133,7 @@ describe('tableRuntimePolicies', () => {
         const state = createState({ activeCell });
         const resolved = requireResolvedActiveCell(state);
         const tr = state.update({
-            changes: { from: resolved.cellFrom, to: resolved.cellFrom, insert: 'x' },
+            changes: { from: resolved.editableFrom, to: resolved.editableFrom, insert: 'x' },
             annotations: syncAnnotation.of(true),
         });
 
@@ -154,18 +154,38 @@ describe('tableRuntimePolicies', () => {
         });
     });
 
+    it('allows guard changes inside editable edge whitespace', () => {
+        const paddedDoc = ['| H1  | H2 |', '| --- | --- |', '| a1 | a2 |'].join('\n');
+        let state = createMarkdownState(paddedDoc, [
+            activeCellField,
+            cellSelectionField,
+            sourceModeField,
+            searchForceSourceModeField,
+        ]);
+        state = state.update({ effects: setActiveCellEffect.of(getHeaderCell()) }).state;
+        const resolved = requireResolvedActiveCell(state);
+
+        const tr = state.update({
+            changes: { from: resolved.editableTo, to: resolved.editableTo, insert: ' ' },
+        });
+
+        expect(decideMainEditorGuardTransaction(tr, { nestedEditorOpen: true })).toEqual({
+            type: 'allowTransaction',
+        });
+    });
+
     it('returns a clipboard rewrite decision for markdown-table paste while nested editor is open', () => {
         const activeCell = getHeaderCell();
         let state = createState({ activeCell });
         const resolved = requireResolvedActiveCell(state);
         state = state.update({
-            selection: { anchor: resolved.cellFrom, head: resolved.cellFrom },
+            selection: { anchor: resolved.editableFrom, head: resolved.editableFrom },
         }).state;
 
         const tr = state.update({
             changes: {
-                from: resolved.cellFrom,
-                to: resolved.cellFrom,
+                from: resolved.editableFrom,
+                to: resolved.editableFrom,
                 insert: ['| P1 | P2 |', '| :--- | ---: |', '| Q1 | Q2 |'].join('\n'),
             },
             userEvent: 'input.paste',
@@ -259,10 +279,10 @@ describe('tableRuntimePolicies', () => {
         let state = createState({ activeCell });
         const resolved = requireResolvedActiveCell(state);
         state = state.update({
-            selection: { anchor: resolved.cellFrom, head: resolved.cellFrom },
+            selection: { anchor: resolved.editableFrom, head: resolved.editableFrom },
         }).state;
         const tr = state.update({
-            changes: { from: resolved.cellFrom, to: resolved.cellFrom, insert: 'a\nb|c' },
+            changes: { from: resolved.editableFrom, to: resolved.editableFrom, insert: 'a\nb|c' },
         });
 
         const decision = decideMainEditorGuardTransaction(tr, { nestedEditorOpen: true });
@@ -271,7 +291,7 @@ describe('tableRuntimePolicies', () => {
             throw new Error('Expected sanitize decision');
         }
 
-        expect(decision.selection.main.head).toBe(resolved.cellFrom + 'a<br>b\\|c'.length);
+        expect(decision.selection.main.head).toBe(resolved.editableFrom + 'a<br>b\\|c'.length);
     });
 
     it('plans raw mode exit as cursor reactivation', () => {
@@ -436,7 +456,7 @@ describe('tableRuntimePolicies', () => {
         const startState = createState({ activeCell });
         const resolved = requireResolvedActiveCell(startState);
         const { event } = createViewUpdate(startState, {
-            changes: { from: resolved.cellFrom, to: resolved.cellFrom, insert: 'x' },
+            changes: { from: resolved.editableFrom, to: resolved.editableFrom, insert: 'x' },
         });
         const snapshot: TableRuntimeSnapshot = {
             activeCell,
@@ -454,17 +474,19 @@ describe('tableRuntimePolicies', () => {
         });
     });
 
-    it('does not require rebuild when undo change range falls within trailing cell padding', () => {
-        // `| H1 | H2 |` — "H1" is at positions 2-3 (trimmed), but the raw cell is `| H1 |`
-        // so position 4 is a trailing space, position 5 is the pipe. An undo that produces
-        // a change touching positions 2-4 (content + one trailing space) should not rebuild.
-        const activeCell = getHeaderCell();
-        const state = createState({ activeCell });
+    it('does not require rebuild when undo change range stays within the editable span', () => {
+        const paddedDoc = ['| H1  | H2 |', '| --- | --- |', '| a1 | a2 |'].join('\n');
+        let state = createMarkdownState(paddedDoc, [
+            activeCellField,
+            cellSelectionField,
+            sourceModeField,
+            searchForceSourceModeField,
+        ]);
+        state = state.update({ effects: setActiveCellEffect.of(getHeaderCell()) }).state;
         const resolved = requireResolvedActiveCell(state);
 
-        // Simulate an undo transaction whose change range extends one position into trailing padding
         const tr = state.update({
-            changes: { from: resolved.cellFrom, to: resolved.cellTo + 1, insert: 'H1' },
+            changes: { from: resolved.editableFrom, to: resolved.editableTo, insert: 'H1 ' },
             annotations: Transaction.userEvent.of('undo'),
         });
 

--- a/src/contentScript/__tests__/tableTransactionHelpers.test.ts
+++ b/src/contentScript/__tests__/tableTransactionHelpers.test.ts
@@ -35,8 +35,10 @@ describe('tableTransactionHelpers', () => {
             activeCell: cell,
             tableFrom: 0,
             tableTo: currentTableText.length,
-            cellFrom: 0,
-            cellTo: 0,
+            contentFrom: 0,
+            contentTo: 0,
+            editableFrom: 0,
+            editableTo: 0,
             ctx: {
                 from: 0,
                 to: currentTableText.length,

--- a/src/contentScript/editorBridge/mainEditorGuardPolicy.ts
+++ b/src/contentScript/editorBridge/mainEditorGuardPolicy.ts
@@ -155,7 +155,7 @@ export function decideMainEditorGuardTransaction(
         return { type: 'allowTransaction' };
     }
 
-    const sanitized = sanitizeCellChanges(tr, resolvedActiveCell.cellFrom, resolvedActiveCell.cellTo);
+    const sanitized = sanitizeCellChanges(tr, resolvedActiveCell.editableFrom, resolvedActiveCell.editableTo);
     if (sanitized.rejected) {
         return { type: 'rejectTransaction' };
     }

--- a/src/contentScript/nestedEditor/nestedEditorController.ts
+++ b/src/contentScript/nestedEditor/nestedEditorController.ts
@@ -32,8 +32,10 @@ const SYNTAX_TREE_PARSE_TIMEOUT = 500;
 export interface NestedEditorCellRange {
     tableFrom: number;
     tableTo: number;
-    cellFrom: number;
-    cellTo: number;
+    contentFrom: number;
+    contentTo: number;
+    editableFrom: number;
+    editableTo: number;
 }
 
 export interface NestedEditorLocalState {
@@ -66,19 +68,19 @@ function scrollCellIntoViewWithinEditor(mainView: EditorView, cellElement: HTMLE
     });
 }
 
-function toAbsoluteSelection(selection: LocalSelection, cellFrom: number): LocalSelection {
+function toAbsoluteSelection(selection: LocalSelection, editableFrom: number): LocalSelection {
     return {
-        anchor: cellFrom + selection.anchor,
-        head: cellFrom + selection.head,
+        anchor: editableFrom + selection.anchor,
+        head: editableFrom + selection.head,
     };
 }
 
-function toRelativeSelection(selection: EditorSelection, cellFrom: number, cellTo: number): LocalSelection {
+function toRelativeSelection(selection: EditorSelection, editableFrom: number, editableTo: number): LocalSelection {
     const main = selection.main;
-    const clamp = (pos: number) => Math.max(cellFrom, Math.min(cellTo, pos));
+    const clamp = (pos: number) => Math.max(editableFrom, Math.min(editableTo, pos));
     return {
-        anchor: clamp(main.anchor) - cellFrom,
-        head: clamp(main.head) - cellFrom,
+        anchor: clamp(main.anchor) - editableFrom,
+        head: clamp(main.head) - editableFrom,
     };
 }
 
@@ -122,9 +124,13 @@ class NestedEditorController {
         this.cellElement.classList.add(CLASS_CELL_ACTIVE);
         editorHost.textContent = '';
 
-        const rootText = params.mainView.state.doc.sliceString(resolved.cellFrom, resolved.cellTo);
+        const rootText = params.mainView.state.doc.sliceString(resolved.editableFrom, resolved.editableTo);
         const localText = unsanitizeRootText(rootText);
-        const rootSelection = toRelativeSelection(params.mainView.state.selection, resolved.cellFrom, resolved.cellTo);
+        const rootSelection = toRelativeSelection(
+            params.mainView.state.selection,
+            resolved.editableFrom,
+            resolved.editableTo
+        );
         let localSelection = toLocalSelection(rootSelection, rootText);
 
         if (params.initialCursorPos === 'start') {
@@ -142,8 +148,10 @@ class NestedEditorController {
             range: {
                 tableFrom: resolved.tableFrom,
                 tableTo: resolved.tableTo,
-                cellFrom: resolved.cellFrom,
-                cellTo: resolved.cellTo,
+                contentFrom: resolved.contentFrom,
+                contentTo: resolved.contentTo,
+                editableFrom: resolved.editableFrom,
+                editableTo: resolved.editableTo,
             },
             local: { text: localText, selection: localSelection },
             root: { text: rootText, selection: rootSelection },
@@ -240,12 +248,14 @@ class NestedEditorController {
         this.session.range = {
             tableFrom: resolved.tableFrom,
             tableTo: resolved.tableTo,
-            cellFrom: resolved.cellFrom,
-            cellTo: resolved.cellTo,
+            contentFrom: resolved.contentFrom,
+            contentTo: resolved.contentTo,
+            editableFrom: resolved.editableFrom,
+            editableTo: resolved.editableTo,
         };
 
-        const rootText = update.state.doc.sliceString(resolved.cellFrom, resolved.cellTo);
-        const rootSelection = toRelativeSelection(update.state.selection, resolved.cellFrom, resolved.cellTo);
+        const rootText = update.state.doc.sliceString(resolved.editableFrom, resolved.editableTo);
+        const rootSelection = toRelativeSelection(update.state.selection, resolved.editableFrom, resolved.editableTo);
 
         this.session.root = {
             text: rootText,
@@ -255,7 +265,7 @@ class NestedEditorController {
         this.rebaseLocalEditorFromRoot();
     }
 
-    close(params?: { cellFrom?: number; cellTo?: number }): void {
+    close(params?: { contentFrom?: number; contentTo?: number }): void {
         const session = this.session;
         const mainView = this.mainView;
 
@@ -271,10 +281,10 @@ class NestedEditorController {
             this.cellElement.classList.remove(CLASS_CELL_ACTIVE);
         }
 
-        const { cellFrom, cellTo } = this.resolveCellRangeForClose(params, session, mainView);
+        const { contentFrom, contentTo } = this.resolveCellRangeForClose(params, session, mainView);
 
         if (this.contentEl && mainView) {
-            const cellText = mainView.state.doc.sliceString(cellFrom, cellTo).trim();
+            const cellText = mainView.state.doc.sliceString(contentFrom, contentTo).trim();
             const definitions = mainView.state.field(documentDefinitionsField);
             const { displayText, cacheKey } = buildRenderableContent(cellText, definitions.definitionBlock);
             const cached = renderer.getCached(cacheKey);
@@ -314,24 +324,24 @@ class NestedEditorController {
      * picking up any position shifts from undo/redo.
      */
     private resolveCellRangeForClose(
-        params: { cellFrom?: number; cellTo?: number } | undefined,
+        params: { contentFrom?: number; contentTo?: number } | undefined,
         session: NestedEditorSession | null,
         mainView: EditorView | null
-    ): { cellFrom: number; cellTo: number } {
-        if (params?.cellFrom != null && params?.cellTo != null) {
-            return { cellFrom: params.cellFrom, cellTo: params.cellTo };
+    ): { contentFrom: number; contentTo: number } {
+        if (params?.contentFrom != null && params?.contentTo != null) {
+            return { contentFrom: params.contentFrom, contentTo: params.contentTo };
         }
 
         if (session && mainView) {
             const resolved = resolveActiveCell(mainView.state, session.activeCell);
             if (resolved) {
-                return { cellFrom: resolved.cellFrom, cellTo: resolved.cellTo };
+                return { contentFrom: resolved.contentFrom, contentTo: resolved.contentTo };
             }
         }
 
         return {
-            cellFrom: session?.range.cellFrom ?? 0,
-            cellTo: session?.range.cellTo ?? 0,
+            contentFrom: session?.range.contentFrom ?? 0,
+            contentTo: session?.range.contentTo ?? 0,
         };
     }
 
@@ -380,7 +390,7 @@ class NestedEditorController {
 
         const rootText = sanitizeLocalText(this.session.local.text);
         const rootSelection = toRootSelection(this.session.local.selection, this.session.local.text);
-        const absoluteSelection = toAbsoluteSelection(rootSelection, this.session.range.cellFrom);
+        const absoluteSelection = toAbsoluteSelection(rootSelection, this.session.range.editableFrom);
         const currentMainSelection = this.mainView.state.selection.main;
 
         const textChanged = rootText !== this.session.root.text;
@@ -396,8 +406,8 @@ class NestedEditorController {
             changes:
                 includeChanges && textChanged
                     ? {
-                          from: this.session.range.cellFrom,
-                          to: this.session.range.cellTo,
+                          from: this.session.range.editableFrom,
+                          to: this.session.range.editableTo,
                           insert: rootText,
                       }
                     : undefined,
@@ -444,7 +454,7 @@ class NestedEditorController {
         mirrorLocalSelectionToMain({
             nestedView,
             mainView: this.mainView,
-            selection: toAbsoluteSelection(rootSelection, this.session.range.cellFrom),
+            selection: toAbsoluteSelection(rootSelection, this.session.range.editableFrom),
         });
     }
 
@@ -467,12 +477,14 @@ class NestedEditorController {
         this.session.range = {
             tableFrom: resolved.tableFrom,
             tableTo: resolved.tableTo,
-            cellFrom: resolved.cellFrom,
-            cellTo: resolved.cellTo,
+            contentFrom: resolved.contentFrom,
+            contentTo: resolved.contentTo,
+            editableFrom: resolved.editableFrom,
+            editableTo: resolved.editableTo,
         };
         this.session.root = {
-            text: this.mainView.state.doc.sliceString(resolved.cellFrom, resolved.cellTo),
-            selection: toRelativeSelection(this.mainView.state.selection, resolved.cellFrom, resolved.cellTo),
+            text: this.mainView.state.doc.sliceString(resolved.editableFrom, resolved.editableTo),
+            selection: toRelativeSelection(this.mainView.state.selection, resolved.editableFrom, resolved.editableTo),
         };
     }
 
@@ -541,7 +553,7 @@ export function openNestedEditor(params: {
     getController(params.mainView)?.open(params);
 }
 
-export function closeNestedEditor(view: EditorView, params?: { cellFrom?: number; cellTo?: number }): void {
+export function closeNestedEditor(view: EditorView, params?: { contentFrom?: number; contentTo?: number }): void {
     getController(view)?.close(params);
 }
 

--- a/src/contentScript/tableModel/activeCellForTableText.ts
+++ b/src/contentScript/tableModel/activeCellForTableText.ts
@@ -50,7 +50,7 @@ export function computeCellAnchorFromRanges(params: {
     }
 
     return {
-        anchorOffset: relRange.from,
+        anchorOffset: relRange.editableFrom,
         section: clamped.section,
         row: clamped.section === 'header' ? 0 : clamped.row,
         col: clamped.col,

--- a/src/contentScript/tableModel/markdownTableCellRanges.ts
+++ b/src/contentScript/tableModel/markdownTableCellRanges.ts
@@ -10,6 +10,8 @@ import type { CellCoords } from './types';
 export interface CellRange {
     from: number;
     to: number;
+    editableFrom: number;
+    editableTo: number;
 }
 
 export interface TableCellRanges {
@@ -88,6 +90,25 @@ function trimCellBounds(line: string, from: number, to: number): { from: number;
     return { from: start, to: end };
 }
 
+function editableCellBounds(line: string, from: number, to: number): { from: number; to: number } {
+    let start = from;
+    let end = to;
+
+    if (start < end && /\s/.test(line[start])) {
+        start++;
+    }
+    if (end > start && /\s/.test(line[end - 1])) {
+        end--;
+    }
+
+    if (start === end && from < to) {
+        const insertion = Math.min(from + 1, to);
+        return { from: insertion, to: insertion };
+    }
+
+    return { from: start, to: end };
+}
+
 function parseLineCellRanges(line: string, lineFromInTable: number): CellRange[] {
     const { from: trimFrom, to: trimTo } = findTrimBounds(line);
     if (trimTo <= trimFrom) {
@@ -115,18 +136,24 @@ function parseLineCellRanges(line: string, lineFromInTable: number): CellRange[]
     for (const delimiterIndex of delimiters) {
         const segmentEnd = delimiterIndex;
         const trimmed = trimCellBounds(line, segmentStart, segmentEnd);
+        const editable = editableCellBounds(line, segmentStart, segmentEnd);
         ranges.push({
             from: lineFromInTable + trimmed.from,
             to: lineFromInTable + trimmed.to,
+            editableFrom: lineFromInTable + editable.from,
+            editableTo: lineFromInTable + editable.to,
         });
         segmentStart = delimiterIndex + 1;
     }
 
     // Last segment
     const lastTrimmed = trimCellBounds(line, segmentStart, innerTo);
+    const lastEditable = editableCellBounds(line, segmentStart, innerTo);
     ranges.push({
         from: lineFromInTable + lastTrimmed.from,
         to: lineFromInTable + lastTrimmed.to,
+        editableFrom: lineFromInTable + lastEditable.from,
+        editableTo: lineFromInTable + lastEditable.to,
     });
 
     return ranges;
@@ -138,7 +165,8 @@ function parseLineCellRanges(line: string, lineFromInTable: number): CellRange[]
  * Notes:
  * - Uses the same "non-empty line" behavior as the table parser.
  * - Treats unescaped pipes as delimiters; escaped pipes (\|) stay inside a cell.
- * - Trims whitespace inside each cell so the returned ranges map to the rendered cell text.
+ * - Exposes both trimmed semantic bounds (`from/to`) and editable bounds
+ *   (`editableFrom/editableTo`) for nested editing and selection sync.
  */
 export function computeMarkdownTableCellRanges(text: string): TableCellRanges | null {
     const lines = getNonEmptyLinesWithOffsets(text);
@@ -182,7 +210,7 @@ export function findCellForPos(ranges: TableCellRanges, relativePos: number): Ce
     // Check header cells
     for (let col = 0; col < ranges.headers.length; col++) {
         const r = ranges.headers[col];
-        if (relativePos >= r.from && relativePos <= r.to) {
+        if (relativePos >= r.editableFrom && relativePos <= r.editableTo) {
             return { section: 'header', row: 0, col };
         }
     }
@@ -192,7 +220,7 @@ export function findCellForPos(ranges: TableCellRanges, relativePos: number): Ce
         const rowCells = ranges.rows[row];
         for (let col = 0; col < rowCells.length; col++) {
             const r = rowCells[col];
-            if (relativePos >= r.from && relativePos <= r.to) {
+            if (relativePos >= r.editableFrom && relativePos <= r.editableTo) {
                 return { section: 'body', row, col };
             }
         }

--- a/src/contentScript/tableRuntime/activeCell/activeCellResolver.ts
+++ b/src/contentScript/tableRuntime/activeCell/activeCellResolver.ts
@@ -8,48 +8,10 @@ export interface ResolvedActiveCell {
     ctx: TableContext;
     tableFrom: number;
     tableTo: number;
-    cellFrom: number;
-    cellTo: number;
-}
-
-function expandCellEndForTrailingWhitespace(
-    state: EditorState,
-    range: { cellFrom: number; cellTo: number }
-): { cellFrom: number; cellTo: number } {
-    const selection = state.selection.main;
-    const maxSelectionPos = Math.max(selection.anchor, selection.head);
-
-    if (maxSelectionPos <= range.cellTo) {
-        return range;
-    }
-
-    const line = state.doc.lineAt(range.cellTo);
-    if (maxSelectionPos > line.to) {
-        return range;
-    }
-
-    let expandedCellTo = range.cellTo;
-    while (expandedCellTo < line.to && /\s/.test(state.doc.sliceString(expandedCellTo, expandedCellTo + 1))) {
-        expandedCellTo++;
-    }
-
-    if (expandedCellTo === range.cellTo) {
-        return range;
-    }
-
-    const nextChar = expandedCellTo < line.to ? state.doc.sliceString(expandedCellTo, expandedCellTo + 1) : '';
-    if (nextChar && nextChar !== '|') {
-        return range;
-    }
-
-    if (maxSelectionPos > expandedCellTo) {
-        return range;
-    }
-
-    return {
-        cellFrom: range.cellFrom,
-        cellTo: expandedCellTo,
-    };
+    contentFrom: number;
+    contentTo: number;
+    editableFrom: number;
+    editableTo: number;
 }
 
 export function resolveActiveCell(state: EditorState, activeCell: ActiveCell | null): ResolvedActiveCell | null {
@@ -62,8 +24,6 @@ export function resolveActiveCell(state: EditorState, activeCell: ActiveCell | n
         return null;
     }
 
-    const expandedRange = expandCellEndForTrailingWhitespace(state, resolved);
-
     return {
         activeCell: {
             ...activeCell,
@@ -72,7 +32,9 @@ export function resolveActiveCell(state: EditorState, activeCell: ActiveCell | n
         ctx: resolved.ctx,
         tableFrom: resolved.tableFrom,
         tableTo: resolved.tableTo,
-        cellFrom: expandedRange.cellFrom,
-        cellTo: expandedRange.cellTo,
+        contentFrom: resolved.contentFrom,
+        contentTo: resolved.contentTo,
+        editableFrom: resolved.editableFrom,
+        editableTo: resolved.editableTo,
     };
 }

--- a/src/contentScript/tableRuntime/activeCell/cellActivation.ts
+++ b/src/contentScript/tableRuntime/activeCell/cellActivation.ts
@@ -106,7 +106,7 @@ export function activateCellAtPosition(view: EditorView, pos: number, options?: 
         activeCell: newActiveCell.activeCell,
         normalizeIfNeeded: options?.normalizeIfNeeded ?? true,
         preserveMainSelection: options?.preserveMainSelection ?? false,
-        selectionAnchor: pos,
+        selectionAnchor: newActiveCell.selectionAnchor,
     });
 
     return true;

--- a/src/contentScript/tableRuntime/activeCell/resolvedActiveCellField.ts
+++ b/src/contentScript/tableRuntime/activeCell/resolvedActiveCellField.ts
@@ -8,21 +8,16 @@ import type { EditorState } from '@codemirror/state';
  * CodeMirror reuses this cached value for all readers of the same state, eliminating the
  * 4–5 redundant resolveActiveCell calls that otherwise occur on every keystroke.
  *
- * Resolution depends on the active cell identity, document content, and selection
- * (expandCellEndForTrailingWhitespace reads state.selection.main), so it is re-derived
- * whenever any of these change.
+ * Resolution depends on the active cell identity and document content, so it is re-derived
+ * whenever either changes.
  */
 export const resolvedActiveCellField = StateField.define<ResolvedActiveCell | null>({
     create(state) {
         return resolveActiveCell(state, getActiveCell(state));
     },
     update(value, tr) {
-        // Re-derive when doc, selection, or active cell identity changes.
-        // All three affect resolveActiveCell's output:
-        //   - doc: syntax tree positions
-        //   - selection: expandCellEndForTrailingWhitespace
-        //   - activeCellField: cell identity
-        if (!tr.docChanged && !tr.selection) {
+        // Re-derive when doc or active cell identity changes.
+        if (!tr.docChanged) {
             // Use the false flag so states without activeCellField (e.g. nested editor
             // states, autocomplete states) return undefined instead of throwing.
             if (tr.startState.field(activeCellField, false) === tr.state.field(activeCellField, false)) {

--- a/src/contentScript/tableRuntime/lifecycle/lifecyclePolicy.ts
+++ b/src/contentScript/tableRuntime/lifecycle/lifecyclePolicy.ts
@@ -1,4 +1,4 @@
-import { ChangeSet, EditorSelection, SelectionRange, Text, Transaction } from '@codemirror/state';
+import { ChangeSet, EditorSelection, SelectionRange, Transaction } from '@codemirror/state';
 import { ViewUpdate } from '@codemirror/view';
 import { getActiveCell, isSameActiveCell, type ActiveCell } from '../../tableState/activeCellState';
 import { cellSelectionTransitionAnnotation } from '../../tableState/cellSelectionState';
@@ -282,23 +282,13 @@ function shouldRepositionCellAfterUndoRedo(
     return isUndoRedo && cursorInsideTableAfterUndoRedo;
 }
 
-function expandCellToThroughTrailingPadding(doc: Text, cellTo: number): number {
-    const line = doc.lineAt(cellTo);
-    let pos = cellTo;
-    while (pos < line.to && /\s/.test(doc.sliceString(pos, pos + 1))) {
-        pos++;
-    }
-    return pos;
-}
-
 function transactionChangesOutsideCell(tr: Transaction, activeCell: ResolvedActiveCell): boolean {
-    const effectiveCellTo = expandCellToThroughTrailingPadding(tr.startState.doc, activeCell.cellTo);
     let outsideCell = false;
     tr.changes.iterChanges((fromA, toA) => {
         if (outsideCell) {
             return;
         }
-        if (fromA < activeCell.cellFrom || toA > effectiveCellTo) {
+        if (fromA < activeCell.editableFrom || toA > activeCell.editableTo) {
             outsideCell = true;
         }
     });

--- a/src/contentScript/tableRuntime/lifecycle/nestedEditorLifecycle.ts
+++ b/src/contentScript/tableRuntime/lifecycle/nestedEditorLifecycle.ts
@@ -293,7 +293,7 @@ export const nestedEditorLifecyclePlugin = ViewPlugin.fromClass(
     }
 );
 
-function snapshotResolvedCellRange(state: EditorView['state']): { cellFrom: number; cellTo: number } | null {
+function snapshotResolvedCellRange(state: EditorView['state']): { contentFrom: number; contentTo: number } | null {
     const activeCell = getActiveCell(state);
     const resolved = resolveActiveCell(state, activeCell);
     if (!resolved) {
@@ -301,7 +301,7 @@ function snapshotResolvedCellRange(state: EditorView['state']): { cellFrom: numb
     }
 
     return {
-        cellFrom: resolved.cellFrom,
-        cellTo: resolved.cellTo,
+        contentFrom: resolved.contentFrom,
+        contentTo: resolved.contentTo,
     };
 }

--- a/src/contentScript/tableRuntime/navigation/tableNavigation.ts
+++ b/src/contentScript/tableRuntime/navigation/tableNavigation.ts
@@ -161,7 +161,7 @@ export function navigateCell(
         normalizeIfNeeded: true,
         initialCursorPos: options.cursorPos,
         onFocused: releaseNavigationLock,
-        selectionAnchor: resolvedRange.cellFrom,
+        selectionAnchor: resolvedRange.editableFrom,
     });
 
     return true;

--- a/src/contentScript/tableRuntime/selection/cellSelectionController.ts
+++ b/src/contentScript/tableRuntime/selection/cellSelectionController.ts
@@ -56,7 +56,7 @@ function dispatchSelection(view: EditorView, selection: CellSelection, options: 
     }
 
     view.dispatch({
-        selection: EditorSelection.single(focusRange.cellFrom),
+        selection: EditorSelection.single(focusRange.editableFrom),
         effects: [
             setCellSelectionEffect.of({
                 tableFrom: ctx.from,

--- a/src/contentScript/tableRuntime/tablePositioning.ts
+++ b/src/contentScript/tableRuntime/tablePositioning.ts
@@ -114,8 +114,10 @@ export function resolveTableForActiveCell(
     ctx: TableContext;
     tableFrom: number;
     tableTo: number;
-    cellFrom: number;
-    cellTo: number;
+    contentFrom: number;
+    contentTo: number;
+    editableFrom: number;
+    editableTo: number;
 } | null {
     const ctx = resolveTableContextAtPos(state, clampDocPos(state, activeCell.tableFrom));
     if (!ctx) {
@@ -135,8 +137,10 @@ export function resolveTableForActiveCell(
         ctx,
         tableFrom: ctx.from,
         tableTo: ctx.to,
-        cellFrom: range.cellFrom,
-        cellTo: range.cellTo,
+        contentFrom: range.contentFrom,
+        contentTo: range.contentTo,
+        editableFrom: range.editableFrom,
+        editableTo: range.editableTo,
     };
 }
 
@@ -195,11 +199,13 @@ export function resolveTableContextFromEventTarget(view: EditorView, target: HTM
     return null;
 }
 
-export function resolveCellDocRange(params: {
-    tableFrom: number;
-    ranges: TableCellRanges;
-    coords: CellCoords;
-}): { cellFrom: number; cellTo: number; relRange: CellRange } | null {
+export function resolveCellDocRange(params: { tableFrom: number; ranges: TableCellRanges; coords: CellCoords }): {
+    contentFrom: number;
+    contentTo: number;
+    editableFrom: number;
+    editableTo: number;
+    relRange: CellRange;
+} | null {
     const { tableFrom, ranges, coords } = params;
 
     const relRange = getCellRange(ranges, coords);
@@ -208,8 +214,10 @@ export function resolveCellDocRange(params: {
     }
 
     return {
-        cellFrom: tableFrom + relRange.from,
-        cellTo: tableFrom + relRange.to,
+        contentFrom: tableFrom + relRange.from,
+        contentTo: tableFrom + relRange.to,
+        editableFrom: tableFrom + relRange.editableFrom,
+        editableTo: tableFrom + relRange.editableTo,
         relRange,
     };
 }

--- a/src/contentScript/tableWidget/tableWidgetInteractions.ts
+++ b/src/contentScript/tableWidget/tableWidgetInteractions.ts
@@ -217,7 +217,7 @@ export function handleTableInteraction(view: EditorView, event: Event): boolean 
             return false;
         }
 
-        const { cellFrom } = resolvedRange;
+        const { editableFrom } = resolvedRange;
 
         event.preventDefault();
         event.stopPropagation();
@@ -245,7 +245,7 @@ export function handleTableInteraction(view: EditorView, event: Event): boolean 
             },
             clearCellSelection: hasSelection,
             normalizeIfNeeded: true,
-            selectionAnchor: cellFrom,
+            selectionAnchor: editableFrom,
         });
 
         return true;


### PR DESCRIPTION
Keep a trimmed content span for parsing/semantic reads and add an editable span for nested editing, main-selection sync, and in-cell edit guards

hide one delimiter-adjacent pad character per side from the nested editor while treating any additional adjacent whitespace as user content.