### PR TITLE
fix: unreliable scrollIntoView on mobile

### DIFF
--- a/src/contentScript/__tests__/nestedEditorController.test.ts
+++ b/src/contentScript/__tests__/nestedEditorController.test.ts
@@ -1,0 +1,459 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { beforeEach, afterEach, describe, expect, it, jest } from '@jest/globals';
+import { EditorState } from '@codemirror/state';
+import { EditorView } from '@codemirror/view';
+import { markdown } from '@codemirror/lang-markdown';
+import { GFM } from '@lezer/markdown';
+import { closeNestedEditor, nestedEditorPlugin, openNestedEditor } from '../nestedEditor/nestedEditorController';
+import { documentDefinitionsField } from '../services/documentDefinitions';
+import type { ActiveCell } from '../tableState/activeCellState';
+import type { NestedEditorFeatureSettings } from '../../contentScriptBridge/editorSettingsBridge';
+import { CLASS_TABLE_WIDGET } from '../tableWidget/domHelpers';
+
+jest.mock('../nestedEditor/decorationPlugins', () => ({
+    inlineCodePlugin: [],
+    insertPlugin: [],
+    markPlugin: [],
+}));
+
+jest.mock('../nestedEditor/domHandlers', () => ({
+    createNestedEditorDomHandlers: jest.fn(() => []),
+    createNestedEditorKeymap: jest.fn(() => []),
+    mirrorLocalSelectionToMain: jest.fn(),
+}));
+
+jest.mock('../nestedEditor/joplinHighlightStyle', () => ({
+    createJoplinSyntaxHighlighting: jest.fn(() => []),
+}));
+
+jest.mock('../nestedEditor/nestedEditorMarkdown', () => ({
+    createNestedEditorMarkdownExtension: jest.fn(() => []),
+}));
+
+jest.mock('../nestedEditor/nestedEditorTheme', () => ({
+    createNestedEditorTheme: jest.fn(() => []),
+}));
+
+jest.mock('../nestedEditor/nestedEditorFeatureConfig', () => ({
+    createNestedEditorFeatureExtensions: jest.fn(() => []),
+}));
+
+const DOC = ['| H1 | H2 |', '| --- | --- |', '| a | b |'].join('\n');
+const ACTIVE_CELL: ActiveCell = {
+    tableFrom: 0,
+    section: 'body',
+    row: 0,
+    col: 0,
+};
+const DEFAULT_FEATURE_SETTINGS = {
+    autoMatchingBraces: true,
+} satisfies NestedEditorFeatureSettings;
+
+interface MockVisualViewport {
+    height: number;
+    width: number;
+    addEventListener: jest.Mock;
+    removeEventListener: jest.Mock;
+    dispatchEventType: (type: 'resize' | 'scroll') => void;
+}
+
+function createRect(top: number, bottom: number, left = 0, right = 100): DOMRect {
+    return {
+        x: left,
+        y: top,
+        top,
+        bottom,
+        left,
+        right,
+        width: right - left,
+        height: bottom - top,
+        toJSON: () => '',
+    } as DOMRect;
+}
+
+function createMockVisualViewport(height: number, width = 400): MockVisualViewport {
+    const listeners = new Map<'resize' | 'scroll', Set<EventListener>>();
+
+    const addEventListener = jest.fn((type: 'resize' | 'scroll', listener: EventListener) => {
+        const existing = listeners.get(type) ?? new Set<EventListener>();
+        existing.add(listener);
+        listeners.set(type, existing);
+    });
+
+    const removeEventListener = jest.fn((type: 'resize' | 'scroll', listener: EventListener) => {
+        listeners.get(type)?.delete(listener);
+    });
+
+    return {
+        height,
+        width,
+        addEventListener,
+        removeEventListener,
+        dispatchEventType: (type) => {
+            for (const listener of listeners.get(type) ?? []) {
+                listener(new Event(type));
+            }
+        },
+    };
+}
+
+function flushNextAnimationFrame(queue: FrameRequestCallback[]): void {
+    const callback = queue.shift();
+    callback?.(0);
+}
+
+function flushAllAnimationFrames(queue: FrameRequestCallback[]): void {
+    while (queue.length > 0) {
+        flushNextAnimationFrame(queue);
+    }
+}
+
+function createMainView(params: {
+    scrollHeight: number;
+    clientHeight: number;
+    cellRect: DOMRect;
+    scrollDOMRect?: DOMRect;
+    widgetRect?: DOMRect;
+}) {
+    const parent = document.createElement('div');
+    document.body.appendChild(parent);
+
+    const view = new EditorView({
+        parent,
+        state: EditorState.create({
+            doc: DOC,
+            extensions: [markdown({ extensions: [GFM] }), documentDefinitionsField, nestedEditorPlugin],
+        }),
+    });
+
+    Object.defineProperty(view.scrollDOM, 'scrollHeight', {
+        configurable: true,
+        get: () => params.scrollHeight,
+    });
+    Object.defineProperty(view.scrollDOM, 'clientHeight', {
+        configurable: true,
+        get: () => params.clientHeight,
+    });
+
+    const scrollDOMRect = params.scrollDOMRect ?? createRect(0, params.clientHeight);
+    jest.spyOn(view.scrollDOM, 'getBoundingClientRect').mockImplementation(() => scrollDOMRect);
+
+    const requestMeasureSpy = jest.spyOn(view, 'requestMeasure').mockImplementation((request) => {
+        if (!request) {
+            return;
+        }
+
+        const measurement = request.read(view);
+        request.write?.(measurement, view);
+    });
+
+    const widgetElement = document.createElement('div');
+    widgetElement.className = CLASS_TABLE_WIDGET;
+    document.body.appendChild(widgetElement);
+    jest.spyOn(widgetElement, 'getBoundingClientRect').mockImplementation(() => params.widgetRect ?? createRect(0, 100, 0, 300));
+
+    const cellElement = document.createElement('td');
+    widgetElement.appendChild(cellElement);
+    jest.spyOn(cellElement, 'getBoundingClientRect').mockImplementation(() => params.cellRect);
+    Object.defineProperty(cellElement, 'scrollIntoView', {
+        configurable: true,
+        value: jest.fn(),
+    });
+    const scrollIntoViewSpy = jest.spyOn(cellElement, 'scrollIntoView').mockImplementation(() => undefined);
+
+    return { view, cellElement, scrollIntoViewSpy, requestMeasureSpy };
+}
+
+describe('nestedEditorController deferred reveal', () => {
+    const originalRequestAnimationFrame = global.requestAnimationFrame;
+    const originalVisualViewport = window.visualViewport;
+    const originalInnerHeight = window.innerHeight;
+    const originalRangeGetClientRects = Range.prototype.getClientRects;
+    const originalRangeGetBoundingClientRect = Range.prototype.getBoundingClientRect;
+    let animationFrameQueue: FrameRequestCallback[] = [];
+    let focusSpy: jest.SpiedFunction<typeof HTMLElement.prototype.focus>;
+
+    beforeEach(() => {
+        jest.useFakeTimers();
+        animationFrameQueue = [];
+        global.requestAnimationFrame = ((callback: FrameRequestCallback) => {
+            animationFrameQueue.push(callback);
+            return animationFrameQueue.length;
+        }) as typeof requestAnimationFrame;
+        focusSpy = jest.spyOn(HTMLElement.prototype, 'focus').mockImplementation(() => undefined);
+        Object.defineProperty(window, 'innerHeight', {
+            configurable: true,
+            value: 800,
+        });
+        Object.defineProperty(window, 'visualViewport', {
+            configurable: true,
+            value: undefined,
+        });
+        Range.prototype.getClientRects = () =>
+            ({
+                0: createRect(0, 0),
+                length: 1,
+                item: () => createRect(0, 0),
+            }) as unknown as DOMRectList;
+        Range.prototype.getBoundingClientRect = () => createRect(0, 0);
+    });
+
+    afterEach(() => {
+        focusSpy.mockRestore();
+        global.requestAnimationFrame = originalRequestAnimationFrame;
+        Object.defineProperty(window, 'visualViewport', {
+            configurable: true,
+            value: originalVisualViewport,
+        });
+        Object.defineProperty(window, 'innerHeight', {
+            configurable: true,
+            value: originalInnerHeight,
+        });
+        Range.prototype.getClientRects = originalRangeGetClientRects;
+        Range.prototype.getBoundingClientRect = originalRangeGetBoundingClientRect;
+        jest.useRealTimers();
+        document.body.innerHTML = '';
+    });
+
+    it('focuses the nested editor before any deferred reveal scroll runs', () => {
+        const visualViewport = createMockVisualViewport(240);
+        Object.defineProperty(window, 'visualViewport', {
+            configurable: true,
+            value: visualViewport,
+        });
+
+        const { view, cellElement, scrollIntoViewSpy } = createMainView({
+            scrollHeight: 300,
+            clientHeight: 300,
+            cellRect: createRect(260, 300),
+        });
+
+        openNestedEditor({
+            mainView: view,
+            cellElement,
+            activeCell: ACTIVE_CELL,
+            featureSettings: DEFAULT_FEATURE_SETTINGS,
+        });
+
+        expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true });
+        expect(scrollIntoViewSpy).not.toHaveBeenCalled();
+
+        view.destroy();
+    });
+
+    it('waits for viewport events to settle before scrolling in external-scroll mode', () => {
+        const visualViewport = createMockVisualViewport(240);
+        Object.defineProperty(window, 'visualViewport', {
+            configurable: true,
+            value: visualViewport,
+        });
+
+        const { view, cellElement, scrollIntoViewSpy } = createMainView({
+            scrollHeight: 300,
+            clientHeight: 300,
+            cellRect: createRect(260, 300),
+        });
+
+        openNestedEditor({
+            mainView: view,
+            cellElement,
+            activeCell: ACTIVE_CELL,
+            featureSettings: DEFAULT_FEATURE_SETTINGS,
+        });
+        flushAllAnimationFrames(animationFrameQueue);
+
+        visualViewport.dispatchEventType('resize');
+        jest.advanceTimersByTime(99);
+        expect(scrollIntoViewSpy).not.toHaveBeenCalled();
+
+        jest.advanceTimersByTime(1);
+        expect(scrollIntoViewSpy).not.toHaveBeenCalled();
+
+        flushNextAnimationFrame(animationFrameQueue);
+        expect(scrollIntoViewSpy).not.toHaveBeenCalled();
+
+        flushAllAnimationFrames(animationFrameQueue);
+        expect(scrollIntoViewSpy).toHaveBeenCalledTimes(1);
+
+        view.destroy();
+    });
+
+    it('falls back after 150ms when no viewport event fires', () => {
+        const visualViewport = createMockVisualViewport(240);
+        Object.defineProperty(window, 'visualViewport', {
+            configurable: true,
+            value: visualViewport,
+        });
+
+        const { view, cellElement, scrollIntoViewSpy } = createMainView({
+            scrollHeight: 300,
+            clientHeight: 300,
+            cellRect: createRect(260, 300),
+        });
+
+        openNestedEditor({
+            mainView: view,
+            cellElement,
+            activeCell: ACTIVE_CELL,
+            featureSettings: DEFAULT_FEATURE_SETTINGS,
+        });
+        flushAllAnimationFrames(animationFrameQueue);
+
+        jest.advanceTimersByTime(149);
+        expect(scrollIntoViewSpy).not.toHaveBeenCalled();
+
+        jest.advanceTimersByTime(1);
+        expect(scrollIntoViewSpy).toHaveBeenCalledTimes(1);
+
+        view.destroy();
+    });
+
+    it('uses the current visual viewport for the no-event fallback when the IME is already open', () => {
+        const visualViewport = createMockVisualViewport(260);
+        Object.defineProperty(window, 'visualViewport', {
+            configurable: true,
+            value: visualViewport,
+        });
+
+        const { view, cellElement, scrollIntoViewSpy } = createMainView({
+            scrollHeight: 300,
+            clientHeight: 300,
+            cellRect: createRect(220, 250),
+        });
+
+        openNestedEditor({
+            mainView: view,
+            cellElement,
+            activeCell: ACTIVE_CELL,
+            featureSettings: DEFAULT_FEATURE_SETTINGS,
+        });
+        flushAllAnimationFrames(animationFrameQueue);
+
+        jest.advanceTimersByTime(150);
+        expect(scrollIntoViewSpy).toHaveBeenCalledTimes(1);
+
+        view.destroy();
+    });
+
+    it('scrolls when the cell is horizontally clipped within the table widget', () => {
+        const visualViewport = createMockVisualViewport(260);
+        Object.defineProperty(window, 'visualViewport', {
+            configurable: true,
+            value: visualViewport,
+        });
+
+        const { view, cellElement, scrollIntoViewSpy } = createMainView({
+            scrollHeight: 300,
+            clientHeight: 300,
+            widgetRect: createRect(0, 100, 0, 120),
+            cellRect: createRect(40, 70, 180, 260),
+        });
+
+        openNestedEditor({
+            mainView: view,
+            cellElement,
+            activeCell: ACTIVE_CELL,
+            featureSettings: DEFAULT_FEATURE_SETTINGS,
+        });
+        flushAllAnimationFrames(animationFrameQueue);
+
+        jest.advanceTimersByTime(150);
+        expect(scrollIntoViewSpy).toHaveBeenCalledTimes(1);
+
+        view.destroy();
+    });
+
+    it('does not scroll when the cell is already safely visible', () => {
+        const visualViewport = createMockVisualViewport(260);
+        Object.defineProperty(window, 'visualViewport', {
+            configurable: true,
+            value: visualViewport,
+        });
+
+        const { view, cellElement, scrollIntoViewSpy } = createMainView({
+            scrollHeight: 300,
+            clientHeight: 300,
+            cellRect: createRect(40, 70, 20, 80),
+        });
+
+        openNestedEditor({
+            mainView: view,
+            cellElement,
+            activeCell: ACTIVE_CELL,
+            featureSettings: DEFAULT_FEATURE_SETTINGS,
+        });
+        flushAllAnimationFrames(animationFrameQueue);
+
+        visualViewport.dispatchEventType('resize');
+        jest.advanceTimersByTime(100);
+        flushAllAnimationFrames(animationFrameQueue);
+
+        expect(scrollIntoViewSpy).not.toHaveBeenCalled();
+
+        view.destroy();
+    });
+
+    it('uses a single next-frame reveal and skips viewport listeners in internal-scroll mode', () => {
+        const visualViewport = createMockVisualViewport(260);
+        Object.defineProperty(window, 'visualViewport', {
+            configurable: true,
+            value: visualViewport,
+        });
+
+        const { view, cellElement, scrollIntoViewSpy } = createMainView({
+            scrollHeight: 600,
+            clientHeight: 300,
+            scrollDOMRect: createRect(0, 180),
+            widgetRect: createRect(0, 100, 0, 120),
+            cellRect: createRect(40, 70, 180, 260),
+        });
+
+        openNestedEditor({
+            mainView: view,
+            cellElement,
+            activeCell: ACTIVE_CELL,
+            featureSettings: DEFAULT_FEATURE_SETTINGS,
+        });
+
+        expect(visualViewport.addEventListener).not.toHaveBeenCalled();
+        expect(scrollIntoViewSpy).not.toHaveBeenCalled();
+
+        flushAllAnimationFrames(animationFrameQueue);
+        expect(scrollIntoViewSpy).toHaveBeenCalledTimes(1);
+
+        view.destroy();
+    });
+
+    it('cancels pending timers and viewport listeners on close', () => {
+        const visualViewport = createMockVisualViewport(240);
+        Object.defineProperty(window, 'visualViewport', {
+            configurable: true,
+            value: visualViewport,
+        });
+
+        const { view, cellElement, scrollIntoViewSpy } = createMainView({
+            scrollHeight: 300,
+            clientHeight: 300,
+            cellRect: createRect(260, 300),
+        });
+
+        openNestedEditor({
+            mainView: view,
+            cellElement,
+            activeCell: ACTIVE_CELL,
+            featureSettings: DEFAULT_FEATURE_SETTINGS,
+        });
+        closeNestedEditor(view);
+
+        jest.advanceTimersByTime(500);
+        flushAllAnimationFrames(animationFrameQueue);
+
+        expect(scrollIntoViewSpy).not.toHaveBeenCalled();
+        expect(visualViewport.removeEventListener).toHaveBeenCalledTimes(2);
+
+        view.destroy();
+    });
+});

--- a/src/contentScript/nestedEditor/nestedEditorController.ts
+++ b/src/contentScript/nestedEditor/nestedEditorController.ts
@@ -25,8 +25,14 @@ import { documentDefinitionsField } from '../services/documentDefinitions';
 import { renderer } from '../services/markdownRenderer';
 import type { NestedEditorFeatureSettings } from '../../contentScriptBridge/editorSettingsBridge';
 import { createNestedEditorFeatureExtensions } from './nestedEditorFeatureConfig';
+import { getWidgetSelector } from '../tableWidget/domHelpers';
 
 const SYNTAX_TREE_PARSE_TIMEOUT = 500;
+const CELL_REVEAL_VIEWPORT_PADDING_PX = 12;
+const CELL_REVEAL_DEBOUNCE_MS = 100;
+const CELL_REVEAL_FALLBACK_MS = 150;
+const CELL_REVEAL_SETTLE_RAF_COUNT = 2;
+const INTERNAL_SCROLL_THRESHOLD_PX = 1;
 
 export interface NestedEditorCellRange {
     tableFrom: number;
@@ -58,13 +64,79 @@ export interface NestedEditorSession {
 
 function scrollCellIntoViewWithinEditor(mainView: EditorView, cellElement: HTMLElement): void {
     mainView.requestMeasure({
-        read: () => cellElement.isConnected,
-        write: (isConnected) => {
-            if (isConnected) {
+        read: () => {
+            if (!cellElement.isConnected) {
+                return null;
+            }
+
+            const cellRect = cellElement.getBoundingClientRect();
+            const scrollDOM = mainView.scrollDOM;
+            const hasInternalScroll = scrollDOM.scrollHeight > scrollDOM.clientHeight + INTERNAL_SCROLL_THRESHOLD_PX;
+            const scrollDOMRect = hasInternalScroll ? scrollDOM.getBoundingClientRect() : null;
+            const widgetRect = cellElement.closest(getWidgetSelector())?.getBoundingClientRect() ?? null;
+
+            if (hasInternalScroll) {
+                return {
+                    cellRect,
+                    viewportTop: scrollDOMRect!.top,
+                    viewportBottom: scrollDOMRect!.bottom,
+                    viewportLeft: widgetRect?.left ?? scrollDOMRect!.left,
+                    viewportRight: widgetRect?.right ?? scrollDOMRect!.right,
+                };
+            }
+
+            return {
+                cellRect,
+                viewportTop: 0,
+                viewportBottom: window.visualViewport?.height ?? window.innerHeight,
+                viewportLeft: widgetRect?.left ?? 0,
+                viewportRight: widgetRect?.right ?? (window.visualViewport?.width ?? window.innerWidth),
+            };
+        },
+        write: (measurement) => {
+            if (!measurement) {
+                return;
+            }
+
+            const viewportTop = measurement.viewportTop + CELL_REVEAL_VIEWPORT_PADDING_PX;
+            const viewportBottom = measurement.viewportBottom - CELL_REVEAL_VIEWPORT_PADDING_PX;
+            const viewportLeft = measurement.viewportLeft + CELL_REVEAL_VIEWPORT_PADDING_PX;
+            const viewportRight = measurement.viewportRight - CELL_REVEAL_VIEWPORT_PADDING_PX;
+            const verticallyVisible = measurement.cellRect.top >= viewportTop && measurement.cellRect.bottom <= viewportBottom;
+            const horizontallyVisible =
+                measurement.cellRect.left >= viewportLeft && measurement.cellRect.right <= viewportRight;
+            const safelyVisible = verticallyVisible && horizontallyVisible;
+
+            if (!safelyVisible) {
                 cellElement.scrollIntoView({ block: 'nearest', inline: 'nearest' });
             }
         },
     });
+}
+
+function scheduleAfterAnimationFrames(frameCount: number, callback: () => void): () => void {
+    let active = true;
+
+    const scheduleNext = (remainingFrames: number): void => {
+        requestAnimationFrame(() => {
+            if (!active) {
+                return;
+            }
+
+            if (remainingFrames <= 1) {
+                callback();
+                return;
+            }
+
+            scheduleNext(remainingFrames - 1);
+        });
+    };
+
+    scheduleNext(frameCount);
+
+    return () => {
+        active = false;
+    };
 }
 
 function toAbsoluteSelection(selection: LocalSelection, editableFrom: number): LocalSelection {
@@ -97,6 +169,7 @@ class NestedEditorController {
     private editorHostEl: HTMLElement | null = null;
     private cellElement: HTMLElement | null = null;
     private mainView: EditorView | null = null;
+    private pendingCellRevealCleanup: (() => void) | null = null;
 
     open(params: {
         mainView: EditorView;
@@ -207,8 +280,8 @@ class NestedEditorController {
         this.session = session;
 
         this.flushSelectionToRoot();
-        scrollCellIntoViewWithinEditor(params.mainView, params.cellElement);
         session.editor.contentDOM.focus({ preventScroll: true });
+        this.scheduleCellRevealAfterFocus(params.mainView, params.cellElement);
 
         requestAnimationFrame(() => {
             params.onFocused?.();
@@ -264,6 +337,7 @@ class NestedEditorController {
     close(params?: { contentFrom?: number; contentTo?: number }): void {
         const session = this.session;
         const mainView = this.mainView;
+        this.cancelPendingCellReveal();
 
         if (session?.editor) {
             session.editor.destroy();
@@ -353,6 +427,107 @@ class NestedEditorController {
         if (this.editorHostEl && container.contains(this.editorHostEl)) {
             this.close();
         }
+    }
+
+    private cancelPendingCellReveal(): void {
+        this.pendingCellRevealCleanup?.();
+        this.pendingCellRevealCleanup = null;
+    }
+
+    private scheduleCellRevealAfterFocus(mainView: EditorView, cellElement: HTMLElement): void {
+        this.cancelPendingCellReveal();
+
+        let active = true;
+        let sawViewportEvent = false;
+        let fallbackTimeoutId: ReturnType<typeof setTimeout> | null = null;
+        let debounceTimeoutId: ReturnType<typeof setTimeout> | null = null;
+        let cancelSettledReveal: (() => void) | null = null;
+        let visualViewportCleanup: (() => void) | null = null;
+
+        const cleanup = (): void => {
+            if (!active) {
+                return;
+            }
+
+            active = false;
+
+            if (fallbackTimeoutId !== null) {
+                clearTimeout(fallbackTimeoutId);
+                fallbackTimeoutId = null;
+            }
+
+            if (debounceTimeoutId !== null) {
+                clearTimeout(debounceTimeoutId);
+                debounceTimeoutId = null;
+            }
+
+            cancelSettledReveal?.();
+            cancelSettledReveal = null;
+            visualViewportCleanup?.();
+            visualViewportCleanup = null;
+
+            if (this.pendingCellRevealCleanup === cleanup) {
+                this.pendingCellRevealCleanup = null;
+            }
+        };
+
+        const runReveal = (): void => {
+            if (!active) {
+                return;
+            }
+
+            scrollCellIntoViewWithinEditor(mainView, cellElement);
+            cleanup();
+        };
+
+        this.pendingCellRevealCleanup = cleanup;
+
+        const hasInternalScroll =
+            mainView.scrollDOM.scrollHeight > mainView.scrollDOM.clientHeight + INTERNAL_SCROLL_THRESHOLD_PX;
+        if (hasInternalScroll) {
+            cancelSettledReveal = scheduleAfterAnimationFrames(1, runReveal);
+            return;
+        }
+
+        const visualViewport = window.visualViewport;
+        if (visualViewport) {
+            const scheduleSettledReveal = (): void => {
+                if (debounceTimeoutId !== null) {
+                    clearTimeout(debounceTimeoutId);
+                }
+
+                debounceTimeoutId = setTimeout(() => {
+                    debounceTimeoutId = null;
+                    cancelSettledReveal?.();
+                    cancelSettledReveal = scheduleAfterAnimationFrames(CELL_REVEAL_SETTLE_RAF_COUNT, runReveal);
+                }, CELL_REVEAL_DEBOUNCE_MS);
+            };
+
+            const handleViewportChange = (): void => {
+                if (!active) {
+                    return;
+                }
+
+                sawViewportEvent = true;
+                scheduleSettledReveal();
+            };
+
+            visualViewport.addEventListener('resize', handleViewportChange);
+            visualViewport.addEventListener('scroll', handleViewportChange);
+            visualViewportCleanup = () => {
+                visualViewport.removeEventListener('resize', handleViewportChange);
+                visualViewport.removeEventListener('scroll', handleViewportChange);
+            };
+        }
+
+        fallbackTimeoutId = setTimeout(() => {
+            fallbackTimeoutId = null;
+            if (!active || sawViewportEvent) {
+                return;
+            }
+
+            runReveal();
+        }, CELL_REVEAL_FALLBACK_MS);
     }
 
     private handleLocalUpdate(update: ViewUpdate): void {

--- a/src/contentScript/nestedEditor/nestedEditorController.ts
+++ b/src/contentScript/nestedEditor/nestedEditorController.ts
@@ -34,6 +34,16 @@ const CELL_REVEAL_FALLBACK_MS = 150;
 const CELL_REVEAL_SETTLE_RAF_COUNT = 2;
 const INTERNAL_SCROLL_THRESHOLD_PX = 1;
 
+type CellRevealMode = 'internal-scroll' | 'visual-viewport';
+
+interface CellRevealViewport {
+    mode: CellRevealMode;
+    top: number;
+    bottom: number;
+    left: number;
+    right: number;
+}
+
 export interface NestedEditorCellRange {
     tableFrom: number;
     tableTo: number;
@@ -62,6 +72,31 @@ export interface NestedEditorSession {
     applyingRootToLocal: boolean;
 }
 
+function getCellRevealViewport(mainView: EditorView, cellElement: HTMLElement): CellRevealViewport {
+    const scrollDOM = mainView.scrollDOM;
+    const hasInternalScroll = scrollDOM.scrollHeight > scrollDOM.clientHeight + INTERNAL_SCROLL_THRESHOLD_PX;
+    const scrollDOMRect = scrollDOM.getBoundingClientRect();
+    const widgetRect = cellElement.closest(getWidgetSelector())?.getBoundingClientRect() ?? null;
+
+    if (hasInternalScroll) {
+        return {
+            mode: 'internal-scroll',
+            top: scrollDOMRect.top,
+            bottom: scrollDOMRect.bottom,
+            left: widgetRect?.left ?? scrollDOMRect.left,
+            right: widgetRect?.right ?? scrollDOMRect.right,
+        };
+    }
+
+    return {
+        mode: 'visual-viewport',
+        top: 0,
+        bottom: window.visualViewport?.height ?? window.innerHeight,
+        left: widgetRect?.left ?? 0,
+        right: widgetRect?.right ?? window.visualViewport?.width ?? window.innerWidth,
+    };
+}
+
 function scrollCellIntoViewWithinEditor(mainView: EditorView, cellElement: HTMLElement): void {
     mainView.requestMeasure({
         read: () => {
@@ -70,27 +105,14 @@ function scrollCellIntoViewWithinEditor(mainView: EditorView, cellElement: HTMLE
             }
 
             const cellRect = cellElement.getBoundingClientRect();
-            const scrollDOM = mainView.scrollDOM;
-            const hasInternalScroll = scrollDOM.scrollHeight > scrollDOM.clientHeight + INTERNAL_SCROLL_THRESHOLD_PX;
-            const scrollDOMRect = hasInternalScroll ? scrollDOM.getBoundingClientRect() : null;
-            const widgetRect = cellElement.closest(getWidgetSelector())?.getBoundingClientRect() ?? null;
-
-            if (hasInternalScroll) {
-                return {
-                    cellRect,
-                    viewportTop: scrollDOMRect!.top,
-                    viewportBottom: scrollDOMRect!.bottom,
-                    viewportLeft: widgetRect?.left ?? scrollDOMRect!.left,
-                    viewportRight: widgetRect?.right ?? scrollDOMRect!.right,
-                };
-            }
+            const viewport = getCellRevealViewport(mainView, cellElement);
 
             return {
                 cellRect,
-                viewportTop: 0,
-                viewportBottom: window.visualViewport?.height ?? window.innerHeight,
-                viewportLeft: widgetRect?.left ?? 0,
-                viewportRight: widgetRect?.right ?? (window.visualViewport?.width ?? window.innerWidth),
+                viewportTop: viewport.top,
+                viewportBottom: viewport.bottom,
+                viewportLeft: viewport.left,
+                viewportRight: viewport.right,
             };
         },
         write: (measurement) => {
@@ -102,7 +124,8 @@ function scrollCellIntoViewWithinEditor(mainView: EditorView, cellElement: HTMLE
             const viewportBottom = measurement.viewportBottom - CELL_REVEAL_VIEWPORT_PADDING_PX;
             const viewportLeft = measurement.viewportLeft + CELL_REVEAL_VIEWPORT_PADDING_PX;
             const viewportRight = measurement.viewportRight - CELL_REVEAL_VIEWPORT_PADDING_PX;
-            const verticallyVisible = measurement.cellRect.top >= viewportTop && measurement.cellRect.bottom <= viewportBottom;
+            const verticallyVisible =
+                measurement.cellRect.top >= viewportTop && measurement.cellRect.bottom <= viewportBottom;
             const horizontallyVisible =
                 measurement.cellRect.left >= viewportLeft && measurement.cellRect.right <= viewportRight;
             const safelyVisible = verticallyVisible && horizontallyVisible;
@@ -482,9 +505,8 @@ class NestedEditorController {
 
         this.pendingCellRevealCleanup = cleanup;
 
-        const hasInternalScroll =
-            mainView.scrollDOM.scrollHeight > mainView.scrollDOM.clientHeight + INTERNAL_SCROLL_THRESHOLD_PX;
-        if (hasInternalScroll) {
+        const revealViewport = getCellRevealViewport(mainView, cellElement);
+        if (revealViewport.mode === 'internal-scroll') {
             cancelSettledReveal = scheduleAfterAnimationFrames(1, runReveal);
             return;
         }


### PR DESCRIPTION
Improve the scrolling behavior of cells to ensure they are properly brought into view when activated, even if the mobile IME is not already open.