### PR TITLE
fix: unable to interact with tables when opening note in separate (maximized) window

### DIFF
--- a/src/contentScript/__tests__/domContext.test.ts
+++ b/src/contentScript/__tests__/domContext.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import type { EditorView } from '@codemirror/view';
+import { getDocumentWindow, requestViewAnimationFrame } from '../shared/domContext';
+
+describe('domContext', () => {
+    it('prefers the document defaultView over the ambient window', () => {
+        const callback = jest.fn();
+        const rafSpy = jest.fn((frameCallback: FrameRequestCallback) => {
+            void frameCallback;
+            return 42;
+        });
+        const fakeWindow = { requestAnimationFrame: rafSpy } as unknown as Window;
+        const fakeDocument = { defaultView: fakeWindow } as Document;
+        const fakeView = {
+            dom: {
+                ownerDocument: fakeDocument,
+            },
+        } as EditorView;
+
+        expect(getDocumentWindow(fakeDocument)).toBe(fakeWindow);
+        expect(requestViewAnimationFrame(fakeView, callback)).toBe(42);
+        expect(rafSpy).toHaveBeenCalledTimes(1);
+        expect(rafSpy.mock.calls[0]).toEqual([callback]);
+    });
+});

--- a/src/contentScript/nestedEditor/mounting.ts
+++ b/src/contentScript/nestedEditor/mounting.ts
@@ -2,9 +2,10 @@ import { CLASS_CELL_CONTENT, CLASS_CELL_EDITOR } from '../shared/tableDomClasses
 
 /** Ensures the cell element has the required structure (content div and editor host div). */
 export function ensureCellWrapper(cell: HTMLElement): { content: HTMLElement; editorHost: HTMLElement } {
+    const doc = cell.ownerDocument;
     let content = cell.querySelector(`:scope > .${CLASS_CELL_CONTENT}`) as HTMLElement | null;
     if (!content) {
-        content = document.createElement('div');
+        content = doc.createElement('div');
         content.className = CLASS_CELL_CONTENT;
 
         while (cell.firstChild) {
@@ -15,7 +16,7 @@ export function ensureCellWrapper(cell: HTMLElement): { content: HTMLElement; ed
 
     let editorHost = cell.querySelector(`:scope > .${CLASS_CELL_EDITOR}`) as HTMLElement | null;
     if (!editorHost) {
-        editorHost = document.createElement('div');
+        editorHost = doc.createElement('div');
         editorHost.className = CLASS_CELL_EDITOR;
         // Visibility is controlled via CSS: hidden by default, shown when the parent
         // cell has CLASS_CELL_ACTIVE.

--- a/src/contentScript/nestedEditor/nestedEditorController.ts
+++ b/src/contentScript/nestedEditor/nestedEditorController.ts
@@ -25,6 +25,7 @@ import { documentDefinitionsField } from '../services/documentDefinitions';
 import { renderer } from '../services/markdownRenderer';
 import type { NestedEditorFeatureSettings } from '../../contentScriptBridge/editorSettingsBridge';
 import { createNestedEditorFeatureExtensions } from './nestedEditorFeatureConfig';
+import { requestViewAnimationFrame } from '../shared/domContext';
 
 const SYNTAX_TREE_PARSE_TIMEOUT = 500;
 
@@ -199,7 +200,7 @@ class NestedEditorController {
         this.flushSelectionToRoot();
         session.editor.contentDOM.focus();
 
-        requestAnimationFrame(() => {
+        requestViewAnimationFrame(params.mainView, () => {
             params.onFocused?.();
             consumePendingNavigationCallback()?.();
         });
@@ -516,8 +517,9 @@ class NestedEditorController {
         this.session.applyingRootToLocal = false;
         this.session.local = { text: nextLocalText, selection: nextLocalSelection };
 
-        if (shouldRefocus) {
-            requestAnimationFrame(() => editor.contentDOM.focus());
+        const mainView = this.mainView;
+        if (shouldRefocus && mainView) {
+            requestViewAnimationFrame(mainView, () => editor.contentDOM.focus());
         }
     }
 }

--- a/src/contentScript/shared/domContext.ts
+++ b/src/contentScript/shared/domContext.ts
@@ -1,0 +1,21 @@
+import type { EditorView } from '@codemirror/view';
+
+export function getNodeDocument(node: Node): Document {
+    return node.ownerDocument ?? document;
+}
+
+export function getDocumentWindow(doc: Document): Window {
+    return doc.defaultView ?? window;
+}
+
+export function getViewDocument(view: EditorView): Document {
+    return getNodeDocument(view.dom);
+}
+
+export function getViewWindow(view: EditorView): Window {
+    return getDocumentWindow(getViewDocument(view));
+}
+
+export function requestViewAnimationFrame(view: EditorView, callback: FrameRequestCallback): number {
+    return getViewWindow(view).requestAnimationFrame(callback);
+}

--- a/src/contentScript/tableRuntime/activeCell/cellActivation.ts
+++ b/src/contentScript/tableRuntime/activeCell/cellActivation.ts
@@ -10,6 +10,7 @@ import { findCellForPos } from '../../tableModel/markdownTableCellRanges';
 import { buildTableContext } from '../../tableModel/tableContext';
 import { createActiveCellFromRanges } from './activeCellFactory';
 import { selectAndRequestOpenActiveCell } from './activeCellOpen';
+import { requestViewAnimationFrame } from '../../shared/domContext';
 
 export interface ActivateCellOptions {
     /** If true and position is outside any table, clears active cell and focuses main editor (default: false) */
@@ -122,7 +123,7 @@ export function activateTableCell(
     tableFrom: number,
     coords: { section: 'header' | 'body'; row: number; col: number }
 ): void {
-    requestAnimationFrame(() => {
+    requestViewAnimationFrame(view, () => {
         if (!view.dom.isConnected) return;
 
         // Don't activate cells in source mode (no widgets exist)

--- a/src/contentScript/tableRuntime/lifecycle/nestedEditorLifecycle.ts
+++ b/src/contentScript/tableRuntime/lifecycle/nestedEditorLifecycle.ts
@@ -35,6 +35,7 @@ import {
     planTableLifecycleActions,
     type TableRuntimeAction,
 } from './lifecyclePolicy';
+import { requestViewAnimationFrame } from '../../shared/domContext';
 
 // ============================================================================
 // Utilities
@@ -164,7 +165,7 @@ export const nestedEditorLifecyclePlugin = ViewPlugin.fromClass(
                 return;
             }
 
-            requestAnimationFrame(() => {
+            requestViewAnimationFrame(this.view, () => {
                 if (!this.view.dom.isConnected) return;
 
                 activateTableCell(this.view, activationRequest.tableFrom, activationRequest.target);
@@ -181,7 +182,7 @@ export const nestedEditorLifecyclePlugin = ViewPlugin.fromClass(
                 switch (action.type) {
                     case 'scheduleRebuildAllAfterFullReplace':
                         this.pendingFullReplaceRebuild = true;
-                        requestAnimationFrame(() => {
+                        requestViewAnimationFrame(this.view, () => {
                             this.pendingFullReplaceRebuild = false;
                             if (!this.view.dom.isConnected) return;
                             this.view.dispatch({ effects: rebuildAllTableWidgetsEffect.of(undefined) });
@@ -189,7 +190,7 @@ export const nestedEditorLifecyclePlugin = ViewPlugin.fromClass(
                         break;
                     case 'scheduleActivateCellAtCursor': {
                         const cursorPos = update.state.selection.main.head;
-                        requestAnimationFrame(() => {
+                        requestViewAnimationFrame(this.view, () => {
                             if (!this.view.dom.isConnected) return;
                             if (!action.clearIfOutside && isEffectiveRawMode(this.view.state)) return;
                             activateCellAtPosition(this.view, cursorPos, {
@@ -204,7 +205,7 @@ export const nestedEditorLifecyclePlugin = ViewPlugin.fromClass(
                         break;
                     }
                     case 'scheduleEnsureCursorVisible':
-                        requestAnimationFrame(() => {
+                        requestViewAnimationFrame(this.view, () => {
                             if (!this.view.dom.isConnected) return;
                             if (action.mode === 'enteredRawMode' && !isEffectiveRawMode(this.view.state)) return;
                             if (
@@ -224,7 +225,7 @@ export const nestedEditorLifecyclePlugin = ViewPlugin.fromClass(
                         }
                         break;
                     case 'openNestedEditor':
-                        requestAnimationFrame(() => {
+                        requestViewAnimationFrame(this.view, () => {
                             if (!this.view.dom.isConnected) {
                                 abortPendingOpen();
                                 return;

--- a/src/contentScript/tableRuntime/sourceModeController.ts
+++ b/src/contentScript/tableRuntime/sourceModeController.ts
@@ -4,9 +4,10 @@ import { clearActiveCellEffect, getActiveCell } from '../tableState/activeCellSt
 import { isSearchForceSourceModeEnabled } from '../tableState/searchForceSourceMode';
 import { exitSourceModeEffect, isSourceModeEnabled, toggleSourceModeEffect } from '../tableState/sourceMode';
 import { focusMainEditorWithoutScroll } from '../shared/mainEditorFocus';
+import { requestViewAnimationFrame } from '../shared/domContext';
 
 function focusMainEditorForExplicitSourceModeEntry(view: EditorView): void {
-    requestAnimationFrame(() => {
+    requestViewAnimationFrame(view, () => {
         if (!view.dom.isConnected) {
             return;
         }

--- a/src/contentScript/tableWidget/TableWidget.ts
+++ b/src/contentScript/tableWidget/TableWidget.ts
@@ -18,12 +18,19 @@ import {
 } from './domHelpers';
 import { estimateTableHeight } from './tableHeightEstimation';
 import { buildRenderableContent, containsMarkdown, escapeHtmlPreservingBr } from '../shared/cellContentUtils';
+import { getViewDocument, getViewWindow } from '../shared/domContext';
 
 /** Associates widget DOM elements with their EditorView for cleanup during destroy. */
 const widgetViews = new WeakMap<HTMLElement, EditorView>();
 
 /** Associates widget DOM elements with their ResizeObserver for safe DOM reuse. */
 const widgetResizeObservers = new WeakMap<HTMLElement, ResizeObserver>();
+
+function getViewResizeObserver(view: EditorView): typeof ResizeObserver {
+    return (
+        (getViewWindow(view) as Window & { ResizeObserver?: typeof ResizeObserver }).ResizeObserver ?? ResizeObserver
+    );
+}
 
 function requestTableMeasurement(view: EditorView, container: HTMLElement, tableFrom: number, tableText: string): void {
     view.requestMeasure({
@@ -93,7 +100,8 @@ export class TableWidget extends WidgetType {
 
         // Ensure a ResizeObserver exists for this DOM, even when it was reused.
         if (!widgetResizeObservers.has(dom)) {
-            const observer = new ResizeObserver(() => {
+            const ResizeObserverCtor = getViewResizeObserver(view);
+            const observer = new ResizeObserverCtor(() => {
                 requestTableMeasurement(view, dom, this.tableFrom, this.tableText);
             });
             observer.observe(dom);
@@ -108,7 +116,9 @@ export class TableWidget extends WidgetType {
     }
 
     toDOM(view: EditorView): HTMLElement {
-        const container = document.createElement('div');
+        const doc = getViewDocument(view);
+        const ResizeObserverCtor = getViewResizeObserver(view);
+        const container = doc.createElement('div');
         container.className = CLASS_TABLE_WIDGET;
 
         // Used by extension-level interaction handlers as a reliable fallback.
@@ -117,24 +127,24 @@ export class TableWidget extends WidgetType {
         // Store content hash for updateDOM() to detect content vs position-only changes.
         container.dataset.tableTextHash = this.contentHash;
 
-        const table = document.createElement('table');
+        const table = doc.createElement('table');
         table.className = CLASS_TABLE_WIDGET_TABLE;
         const headerCells = this.tableData.headerCells;
         const bodyRows = this.tableData.bodyRows;
         const alignments = this.tableData.alignments;
 
         // Render header — skip synthetic cells that have no source range
-        const thead = document.createElement('thead');
-        const headerRow = document.createElement('tr');
+        const thead = doc.createElement('thead');
+        const headerRow = doc.createElement('tr');
         const headerCount = this.cellRanges.headers.length;
         for (let i = 0; i < headerCount; i++) {
-            const th = document.createElement('th');
+            const th = doc.createElement('th');
             th.dataset[DATA_SECTION] = SECTION_HEADER;
             th.dataset[DATA_ROW] = '0';
             th.dataset[DATA_COL] = String(i);
 
             const content = headerCells[i];
-            this.renderCellContent(th, content);
+            this.renderCellContent(th, content, doc);
 
             const align = alignments[i];
             if (align) {
@@ -146,19 +156,19 @@ export class TableWidget extends WidgetType {
         table.appendChild(thead);
 
         // Render body — skip synthetic cells that have no source range
-        const tbody = document.createElement('tbody');
+        const tbody = doc.createElement('tbody');
         for (let r = 0; r < bodyRows.length; r++) {
             const row = bodyRows[r];
-            const tr = document.createElement('tr');
+            const tr = doc.createElement('tr');
             const colCount = this.cellRanges.rows[r]?.length ?? row.length;
             for (let c = 0; c < colCount; c++) {
-                const td = document.createElement('td');
+                const td = doc.createElement('td');
                 td.dataset[DATA_SECTION] = SECTION_BODY;
                 td.dataset[DATA_ROW] = String(r);
                 td.dataset[DATA_COL] = String(c);
 
                 const content = row[c];
-                this.renderCellContent(td, content);
+                this.renderCellContent(td, content, doc);
 
                 const align = alignments[c];
                 if (align) {
@@ -174,7 +184,7 @@ export class TableWidget extends WidgetType {
 
         // Use ResizeObserver to notify CodeMirror whenever the table height changes.
         // This eliminates the race condition between async rendering and CM6's coordinate system.
-        const observer = new ResizeObserver(() => {
+        const observer = new ResizeObserverCtor(() => {
             // requestMeasure is debounced internally by CM6, so safe to call frequently.
             requestTableMeasurement(view, container, this.tableFrom, this.tableText);
         });
@@ -194,12 +204,12 @@ export class TableWidget extends WidgetType {
      * Render cell content with markdown support
      * Uses cached HTML if available, otherwise shows text and updates async
      */
-    private renderCellContent(cell: HTMLElement, markdown: string): void {
+    private renderCellContent(cell: HTMLElement, markdown: string, doc: Document): void {
         const { displayText, cacheKey } = buildRenderableContent(markdown, this.definitionBlock);
 
         // Create a wrapper div for the content. This matches the structure ensureCellWrapper()
         // creates on activation, ensuring CSS rules (like white-space: normal) apply consistently.
-        const contentWrapper = document.createElement('div');
+        const contentWrapper = doc.createElement('div');
         contentWrapper.className = CLASS_CELL_CONTENT;
         cell.appendChild(contentWrapper);
 

--- a/src/contentScript/toolbar/icons.ts
+++ b/src/contentScript/toolbar/icons.ts
@@ -1,5 +1,5 @@
-const createSvg = (paths: Array<{ d: string; fill?: string; stroke?: string }>) => {
-    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+const createSvg = (doc: Document, paths: Array<{ d: string; fill?: string; stroke?: string }>) => {
+    const svg = doc.createElementNS('http://www.w3.org/2000/svg', 'svg');
     svg.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
     svg.setAttribute('width', '24');
     svg.setAttribute('height', '24');
@@ -12,7 +12,7 @@ const createSvg = (paths: Array<{ d: string; fill?: string; stroke?: string }>) 
     svg.classList.add('cm-table-toolbar-icon');
 
     for (const pathSpec of paths) {
-        const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+        const path = doc.createElementNS('http://www.w3.org/2000/svg', 'path');
         path.setAttribute('d', pathSpec.d);
         if (pathSpec.fill) path.setAttribute('fill', pathSpec.fill);
         if (pathSpec.stroke) path.setAttribute('stroke', pathSpec.stroke);
@@ -23,112 +23,112 @@ const createSvg = (paths: Array<{ d: string; fill?: string; stroke?: string }>) 
 };
 
 // Tabler icons
-export const rowInsertTopIcon = () =>
-    createSvg([
+export const rowInsertTopIcon = (doc: Document) =>
+    createSvg(doc, [
         { d: 'M0 0h24v24H0z', fill: 'none', stroke: 'none' },
         { d: 'M4 18v-4a1 1 0 0 1 1 -1h14a1 1 0 0 1 1 1v4a1 1 0 0 1 -1 1h-14a1 1 0 0 1 -1 -1z' },
         { d: 'M12 9v-4' },
         { d: 'M10 7l4 0' },
     ]);
 
-export const rowInsertBottomIcon = () =>
-    createSvg([
+export const rowInsertBottomIcon = (doc: Document) =>
+    createSvg(doc, [
         { d: 'M0 0h24v24H0z', fill: 'none', stroke: 'none' },
         { d: 'M20 6v4a1 1 0 0 1 -1 1h-14a1 1 0 0 1 -1 -1v-4a1 1 0 0 1 1 -1h14a1 1 0 0 1 1 1z' },
         { d: 'M12 15l0 4' },
         { d: 'M14 17l-4 0' },
     ]);
 
-export const rowRemoveIcon = () =>
-    createSvg([
+export const rowRemoveIcon = (doc: Document) =>
+    createSvg(doc, [
         { d: 'M0 0h24v24H0z', fill: 'none', stroke: 'none' },
         { d: 'M20 6v4a1 1 0 0 1 -1 1h-14a1 1 0 0 1 -1 -1v-4a1 1 0 0 1 1 -1h14a1 1 0 0 1 1 1z' },
         { d: 'M10 16l4 4' },
         { d: 'M10 20l4 -4' },
     ]);
 
-export const columnInsertLeftIcon = () =>
-    createSvg([
+export const columnInsertLeftIcon = (doc: Document) =>
+    createSvg(doc, [
         { d: 'M0 0h24v24H0z', fill: 'none', stroke: 'none' },
         { d: 'M14 4h4a1 1 0 0 1 1 1v14a1 1 0 0 1 -1 1h-4a1 1 0 0 1 -1 -1v-14a1 1 0 0 1 1 -1z' },
         { d: 'M5 12l4 0' },
         { d: 'M7 10l0 4' },
     ]);
 
-export const columnInsertRightIcon = () =>
-    createSvg([
+export const columnInsertRightIcon = (doc: Document) =>
+    createSvg(doc, [
         { d: 'M0 0h24v24H0z', fill: 'none', stroke: 'none' },
         { d: 'M6 4h4a1 1 0 0 1 1 1v14a1 1 0 0 1 -1 1h-4a1 1 0 0 1 -1 -1v-14a1 1 0 0 1 1 -1z' },
         { d: 'M15 12l4 0' },
         { d: 'M17 10l0 4' },
     ]);
 
-export const columnRemoveIcon = () =>
-    createSvg([
+export const columnRemoveIcon = (doc: Document) =>
+    createSvg(doc, [
         { d: 'M0 0h24v24H0z', fill: 'none', stroke: 'none' },
         { d: 'M6 4h4a1 1 0 0 1 1 1v14a1 1 0 0 1 -1 1h-4a1 1 0 0 1 -1 -1v-14a1 1 0 0 1 1 -1z' },
         { d: 'M16 10l4 4' },
         { d: 'M16 14l4 -4' },
     ]);
 
-export const alignLeftIcon = () =>
-    createSvg([
+export const alignLeftIcon = (doc: Document) =>
+    createSvg(doc, [
         { d: 'M0 0h24v24H0z', fill: 'none', stroke: 'none' },
         { d: 'M4 6l16 0' },
         { d: 'M4 12l10 0' },
         { d: 'M4 18l14 0' },
     ]);
 
-export const alignCenterIcon = () =>
-    createSvg([
+export const alignCenterIcon = (doc: Document) =>
+    createSvg(doc, [
         { d: 'M0 0h24v24H0z', fill: 'none', stroke: 'none' },
         { d: 'M4 6l16 0' },
         { d: 'M8 12l8 0' },
         { d: 'M6 18l12 0' },
     ]);
 
-export const alignRightIcon = () =>
-    createSvg([
+export const alignRightIcon = (doc: Document) =>
+    createSvg(doc, [
         { d: 'M0 0h24v24H0z', fill: 'none', stroke: 'none' },
         { d: 'M4 6l16 0' },
         { d: 'M10 12l10 0' },
         { d: 'M6 18l14 0' },
     ]);
 
-export const moveColumnLeftIcon = () =>
-    createSvg([
+export const moveColumnLeftIcon = (doc: Document) =>
+    createSvg(doc, [
         { d: 'M0 0h24v24H0z', fill: 'none', stroke: 'none' },
         { d: 'M5 12l14 0' },
         { d: 'M5 12l4 4' },
         { d: 'M5 12l4 -4' },
     ]);
 
-export const moveColumnRightIcon = () =>
-    createSvg([
+export const moveColumnRightIcon = (doc: Document) =>
+    createSvg(doc, [
         { d: 'M0 0h24v24H0z', fill: 'none', stroke: 'none' },
         { d: 'M5 12l14 0' },
         { d: 'M15 16l4 -4' },
         { d: 'M15 8l4 4' },
     ]);
 
-export const moveRowUpIcon = () =>
-    createSvg([
+export const moveRowUpIcon = (doc: Document) =>
+    createSvg(doc, [
         { d: 'M0 0h24v24H0z', fill: 'none', stroke: 'none' },
         { d: 'M12 5l0 14' },
         { d: 'M16 9l-4 -4' },
         { d: 'M8 9l4 -4' },
     ]);
 
-export const moveRowDownIcon = () =>
-    createSvg([
+export const moveRowDownIcon = (doc: Document) =>
+    createSvg(doc, [
         { d: 'M0 0h24v24H0z', fill: 'none', stroke: 'none' },
         { d: 'M12 5l0 14' },
         { d: 'M16 15l-4 4' },
         { d: 'M8 15l4 4' },
     ]);
 
-export const clearTableIcon = () =>
-    createSvg([
+export const clearTableIcon = (doc: Document) =>
+    createSvg(doc, [
         { d: 'M0 0h24v24H0z', fill: 'none', stroke: 'none' },
         {
             d: 'M19 20h-10.5l-4.21 -4.3a1 1 0 0 1 0 -1.41l10 -10a1 1 0 0 1 1.41 0l5 5a1 1 0 0 1 0 1.41l-9.2 9.3',
@@ -136,8 +136,8 @@ export const clearTableIcon = () =>
         { d: 'M18 13.3l-6.3 -6.3' },
     ]);
 
-export const deleteTableIcon = () =>
-    createSvg([
+export const deleteTableIcon = (doc: Document) =>
+    createSvg(doc, [
         { d: 'M0 0h24v24H0z', fill: 'none', stroke: 'none' },
         {
             d: 'M20 6a1 1 0 0 1 .117 1.993l-.117 .007h-.081l-.919 11a3 3 0 0 1 -2.824 2.995l-.176 .005h-8c-1.598 0 -2.904 -1.249 -2.992 -2.75l-.005 -.167l-.923 -11.083h-.08a1 1 0 0 1 -.117 -1.993l.117 -.007h16zm-9.489 5.14a1 1 0 0 0 -1.218 1.567l1.292 1.293l-1.292 1.293l-.083 .094a1 1 0 0 0 1.497 1.32l1.293 -1.292l1.293 1.292l.094 .083a1 1 0 0 0 1.32 -1.497l-1.292 -1.293l1.292 -1.293l.083 -.094a1 1 0 0 0 -1.497 -1.32l-1.293 1.292l-1.293 -1.292l-.094 -.083z',

--- a/src/contentScript/toolbar/tableToolbarPlugin.ts
+++ b/src/contentScript/toolbar/tableToolbarPlugin.ts
@@ -26,6 +26,7 @@ import { findTableWidgetElement } from '../tableWidget/domHelpers';
 import { makeTableId } from '../tableModel/types';
 import { getToolbarSettings, waitForToolbarSettings } from '../services/toolbarSettings';
 import { getToolbarButtonGroups, renderToolbarButtonGroups, type ToolbarActionId } from './toolbarLayout';
+import { getDocumentWindow, getViewDocument } from '../shared/domContext';
 
 class TableToolbarPlugin {
     dom: HTMLElement;
@@ -37,7 +38,8 @@ class TableToolbarPlugin {
     private destroyed = false;
 
     constructor(private view: EditorView) {
-        this.dom = document.createElement('div');
+        const doc = getViewDocument(view);
+        this.dom = doc.createElement('div');
         this.dom.className = CLASS_FLOATING_TOOLBAR;
         this.dom.style.position = 'absolute';
         this.dom.style.display = 'none';
@@ -113,10 +115,11 @@ class TableToolbarPlugin {
     }
 
     private createButtons() {
+        const doc = getViewDocument(this.view);
         this.dom.replaceChildren();
 
         const createIconBtn = (title: string, ariaLabel: string, svg: SVGSVGElement, onClick: () => void) => {
-            const btn = document.createElement('button');
+            const btn = doc.createElement('button');
             btn.title = title;
             btn.className = 'cm-table-toolbar-btn';
             btn.type = 'button';
@@ -133,7 +136,7 @@ class TableToolbarPlugin {
         };
 
         const createSeparator = () => {
-            const sep = document.createElement('span');
+            const sep = doc.createElement('span');
             sep.className = 'cm-table-toolbar-separator';
             this.dom.appendChild(sep);
         };
@@ -144,7 +147,7 @@ class TableToolbarPlugin {
                 createIconBtn(
                     button.title,
                     button.ariaLabel,
-                    button.iconFactory(),
+                    button.iconFactory(doc),
                     this.getActionHandler(button.actionId)
                 );
             },
@@ -288,6 +291,8 @@ class TableToolbarPlugin {
         this.prepareToolbarForPositioning();
 
         const scrollDOM = this.view.scrollDOM;
+        const doc = getViewDocument(this.view);
+        const viewWindow = getDocumentWindow(doc);
         const isInternalScroll = scrollDOM.scrollHeight > scrollDOM.clientHeight + 1;
         if (!isInternalScroll) {
             // External scroll (mobile) doesn't reliably trigger autoUpdate's ancestor scroll handlers.
@@ -315,10 +320,10 @@ class TableToolbarPlugin {
                 // Desktop uses internal CM scrolling; mobile uses external WebView scrolling.
                 // For internal scroll, the visible viewport is the scrollDOM rect.
                 // For external scroll, use visualViewport/window dimensions anchored to the page.
-                const visualViewport = window.visualViewport;
+                const visualViewport = viewWindow.visualViewport;
                 const viewportHeight = isInternalScroll
                     ? scrollDOMRect.height
-                    : (visualViewport?.height ?? window.innerHeight);
+                    : (visualViewport?.height ?? viewWindow.innerHeight);
                 const viewportTop = isInternalScroll ? scrollDOMRect.top : 0;
                 const viewportBottom = isInternalScroll ? scrollDOMRect.bottom : viewportHeight;
 
@@ -361,7 +366,7 @@ class TableToolbarPlugin {
                         // Desktop (internal scroll): use position: absolute with offset parent calculations
                         // to keep the toolbar within the editor panel bounds.
                         const viewRect = this.view.dom.getBoundingClientRect();
-                        const offsetParent = (this.dom.offsetParent ?? document.body) as HTMLElement;
+                        const offsetParent = (this.dom.offsetParent ?? doc.body) as HTMLElement;
                         const offsetParentRect = offsetParent.getBoundingClientRect();
 
                         const minX = TOOLBAR_VIEWPORT_PADDING_PX;
@@ -380,7 +385,7 @@ class TableToolbarPlugin {
                         // Mobile (external scroll): use position: fixed with viewport-relative coordinates
                         // to avoid jitter caused by offset parent recalculations during scroll.
                         // Mobile editor disables pinch-zoom (maximum-scale=1), so pageLeft should be 0.
-                        const viewportWidth = visualViewport?.width ?? window.innerWidth;
+                        const viewportWidth = visualViewport?.width ?? viewWindow.innerWidth;
                         const minX = TOOLBAR_VIEWPORT_PADDING_PX;
                         const maxX = Math.max(
                             TOOLBAR_VIEWPORT_PADDING_PX,
@@ -454,20 +459,22 @@ class TableToolbarPlugin {
     }
 
     private attachViewportListeners() {
+        const doc = getViewDocument(this.view);
+        const viewWindow = getDocumentWindow(doc);
         const handler = () => {
             this.schedulePositionUpdate();
         };
 
-        document.addEventListener('scroll', handler, { passive: true });
-        window.addEventListener('resize', handler);
-        window.visualViewport?.addEventListener('scroll', handler);
-        window.visualViewport?.addEventListener('resize', handler);
+        doc.addEventListener('scroll', handler, { passive: true });
+        viewWindow.addEventListener('resize', handler);
+        viewWindow.visualViewport?.addEventListener('scroll', handler);
+        viewWindow.visualViewport?.addEventListener('resize', handler);
 
         return () => {
-            document.removeEventListener('scroll', handler);
-            window.removeEventListener('resize', handler);
-            window.visualViewport?.removeEventListener('scroll', handler);
-            window.visualViewport?.removeEventListener('resize', handler);
+            doc.removeEventListener('scroll', handler);
+            viewWindow.removeEventListener('resize', handler);
+            viewWindow.visualViewport?.removeEventListener('scroll', handler);
+            viewWindow.visualViewport?.removeEventListener('resize', handler);
         };
     }
 }

--- a/src/contentScript/toolbar/toolbarLayout.ts
+++ b/src/contentScript/toolbar/toolbarLayout.ts
@@ -40,7 +40,7 @@ export interface ToolbarButtonDescriptor {
     actionId: ToolbarActionId;
     title: string;
     ariaLabel: string;
-    iconFactory: () => SVGSVGElement;
+    iconFactory: (doc: Document) => SVGSVGElement;
 }
 
 const baseRowButtons: ToolbarButtonDescriptor[] = [


### PR DESCRIPTION
use the owning document/window instead of ambient globals

add a DOM-context helper in domContext.ts and route widget creation, nested-editor mounting, toolbar DOM, viewport listeners, and lifecycle RAF scheduling through the editor’s own ownerDocument/defaultView.

Also switched TableWidget’s ResizeObserver to the editor window’s realm