### PR TITLE
Fix nested editor behavior when leaving table cells

### DIFF
--- a/src/contentScript/__tests__/nestedEditorLifecycle.test.ts
+++ b/src/contentScript/__tests__/nestedEditorLifecycle.test.ts
@@ -54,7 +54,7 @@ jest.mock('../services/nestedEditorFeatureSettings', () => ({
 }));
 
 describe('nestedEditorLifecycle', () => {
-    const originalRequestAnimationFrame = global.requestAnimationFrame;
+    const originalRequestAnimationFrame = globalThis.requestAnimationFrame;
     let animationFrameQueue: FrameRequestCallback[] = [];
 
     const flushAnimationFrames = (): void => {
@@ -74,14 +74,14 @@ describe('nestedEditorLifecycle', () => {
         nestedEditorControllerMock.openNestedEditor.mockReset();
         nestedEditorControllerMock.isNestedEditorOpen.mockReturnValue(false);
         animationFrameQueue = [];
-        global.requestAnimationFrame = ((callback: FrameRequestCallback) => {
+        globalThis.requestAnimationFrame = ((callback: FrameRequestCallback) => {
             animationFrameQueue.push(callback);
             return animationFrameQueue.length;
         }) as typeof requestAnimationFrame;
     });
 
     afterEach(() => {
-        global.requestAnimationFrame = originalRequestAnimationFrame;
+        globalThis.requestAnimationFrame = originalRequestAnimationFrame;
         document.body.innerHTML = '';
     });
 
@@ -368,6 +368,48 @@ describe('nestedEditorLifecycle', () => {
 
         expect(view.state.selection.main.anchor).toBe(selectionFrom);
         expect(view.state.selection.main.head).toBe(selectionTo);
+
+        view.destroy();
+    });
+
+    it('closes and clears the active cell when main-editor selection leaves the active table', () => {
+        nestedEditorControllerMock.isNestedEditorOpen.mockReturnValue(true);
+
+        const prefixedDoc = ['before', '', '| H1 | H2 |', '| --- | --- |', '| a1 | a2 |', '', 'after'].join('\n');
+        const tableFrom = 'before\n\n'.length;
+        const activeCell: ActiveCell = {
+            tableFrom,
+            section: 'header',
+            row: 0,
+            col: 0,
+        };
+
+        let state = EditorState.create({
+            doc: prefixedDoc,
+            extensions: [
+                markdown({ extensions: [GFM] }),
+                activeCellField,
+                searchForceSourceModeField,
+                sourceModeField,
+                nestedEditorLifecyclePlugin,
+            ],
+        });
+        state = state.update({
+            effects: setActiveCellEffect.of(activeCell),
+            selection: { anchor: tableFrom + 2 },
+        }).state;
+
+        const parent = document.createElement('div');
+        document.body.appendChild(parent);
+        const view = new EditorView({ parent, state });
+
+        view.dispatch({
+            selection: { anchor: 0 },
+        });
+        flushAnimationFrames();
+
+        expect(nestedEditorControllerMock.closeNestedEditor).toHaveBeenCalledWith(view);
+        expect(getActiveCell(view.state)).toBeNull();
 
         view.destroy();
     });

--- a/src/contentScript/__tests__/nestedEditorLifecycle.test.ts
+++ b/src/contentScript/__tests__/nestedEditorLifecycle.test.ts
@@ -17,6 +17,7 @@ import { resolveActiveCell } from '../tableRuntime/activeCell/activeCellResolver
 import { requestOpenActiveCellEffect } from '../tableRuntime/activeCell/activeCellOpen';
 import { rememberPendingCellOpen } from '../nestedEditor/pendingCellOpen';
 import type { NestedEditorFeatureSettings } from '../../contentScriptBridge/editorSettingsBridge';
+import { createActiveCellForTableText } from '../tableRuntime/activeCell/activeCellFactory';
 
 const activateTableCellMock = jest.fn();
 const findCellElementMock: jest.Mock = jest.fn(() => document.createElement('td'));
@@ -410,6 +411,72 @@ describe('nestedEditorLifecycle', () => {
 
         expect(nestedEditorControllerMock.closeNestedEditor).toHaveBeenCalledWith(view);
         expect(getActiveCell(view.state)).toBeNull();
+
+        view.destroy();
+    });
+
+    it('keeps the pending reopen when selection leaves the table after a structural close', () => {
+        nestedEditorControllerMock.isNestedEditorOpen.mockReturnValueOnce(true).mockReturnValue(false);
+
+        const originalTable = ['| H1 | H2 |', '| --- | --- |', '| a1 | a2 |'].join('\n');
+        const updatedTable = ['| H1 | H2 |', '| --- | --- |', '| a1 | a2 |', '|  |  |'].join('\n');
+        const prefixedDoc = ['before', '', originalTable, '', 'after'].join('\n');
+        const tableFrom = 'before\n\n'.length;
+        const tableTo = tableFrom + originalTable.length;
+        const currentCell: ActiveCell = {
+            tableFrom,
+            section: 'body',
+            row: 0,
+            col: 1,
+        };
+        const nextCell = createActiveCellForTableText({
+            tableFrom,
+            tableText: updatedTable,
+            target: { section: 'body', row: 1, col: 1 },
+        })?.activeCell;
+        expect(nextCell).not.toBeNull();
+        if (!nextCell) {
+            throw new Error('Expected next active cell after structural edit');
+        }
+
+        let state = EditorState.create({
+            doc: prefixedDoc,
+            extensions: [
+                markdown({ extensions: [GFM] }),
+                activeCellField,
+                searchForceSourceModeField,
+                sourceModeField,
+                nestedEditorLifecyclePlugin,
+            ],
+        });
+        state = state.update({
+            effects: setActiveCellEffect.of(currentCell),
+            selection: { anchor: tableFrom + originalTable.indexOf('a2') },
+        }).state;
+
+        const parent = document.createElement('div');
+        document.body.appendChild(parent);
+        const view = new EditorView({ parent, state });
+
+        view.dispatch({
+            changes: { from: tableFrom, to: tableTo, insert: updatedTable },
+            effects: [setActiveCellEffect.of(nextCell), rebuildTableWidgetsEffect.of({ tableFrom })],
+        });
+
+        view.dispatch({
+            selection: { anchor: 0 },
+        });
+
+        flushAnimationFrames();
+
+        expect(getActiveCell(view.state)).toEqual(nextCell);
+        expect(nestedEditorControllerMock.openNestedEditor).toHaveBeenCalledWith(
+            expect.objectContaining({
+                mainView: view,
+                activeCell: nextCell,
+                featureSettings: DEFAULT_FEATURE_SETTINGS,
+            })
+        );
 
         view.destroy();
     });

--- a/src/contentScript/__tests__/tableRuntimePolicies.test.ts
+++ b/src/contentScript/__tests__/tableRuntimePolicies.test.ts
@@ -491,6 +491,43 @@ describe('tableRuntimePolicies', () => {
         ]);
     });
 
+    it('does not clear the active cell when selection leaves the table after the nested editor already closed', () => {
+        const prefixedDoc = ['before', '', doc, '', 'after'].join('\n');
+        const tableFrom = 'before\n\n'.length;
+        const activeCell: ActiveCell = {
+            tableFrom,
+            section: 'header',
+            row: 0,
+            col: 0,
+        };
+        let startState = createMarkdownState(prefixedDoc, [
+            activeCellField,
+            cellSelectionField,
+            sourceModeField,
+            searchForceSourceModeField,
+        ]);
+        startState = startState.update({
+            effects: setActiveCellEffect.of(activeCell),
+            selection: { anchor: tableFrom + 2 },
+        }).state;
+
+        const { event } = createViewUpdate(startState, {
+            selection: { anchor: 0 },
+        });
+        const snapshot: TableRuntimeSnapshot = {
+            activeCell,
+            prevActiveCell: activeCell,
+            resolvedActiveCell: requireResolvedActiveCell(startState),
+            resolvedPrevActiveCell: requireResolvedActiveCell(startState),
+            effectiveRawMode: false,
+            nestedEditorOpen: false,
+            hadActiveCell: true,
+            pendingFullReplaceRebuild: false,
+        };
+
+        expect(planTableLifecycleActions(snapshot, event, { cursorInsideTableAfterUndoRedo: false })).toEqual([]);
+    });
+
     it('plans stale active cell cleanup when the nested editor is gone', () => {
         const activeCell = getHeaderCell();
         const startState = createState({ activeCell });

--- a/src/contentScript/__tests__/tableRuntimePolicies.test.ts
+++ b/src/contentScript/__tests__/tableRuntimePolicies.test.ts
@@ -451,6 +451,46 @@ describe('tableRuntimePolicies', () => {
         ]);
     });
 
+    it('closes and clears the active cell when selection moves outside the active table', () => {
+        const prefixedDoc = ['before', '', doc, '', 'after'].join('\n');
+        const tableFrom = 'before\n\n'.length;
+        const activeCell: ActiveCell = {
+            tableFrom,
+            section: 'header',
+            row: 0,
+            col: 0,
+        };
+        let startState = createMarkdownState(prefixedDoc, [
+            activeCellField,
+            cellSelectionField,
+            sourceModeField,
+            searchForceSourceModeField,
+        ]);
+        startState = startState.update({
+            effects: setActiveCellEffect.of(activeCell),
+            selection: { anchor: tableFrom + 2 },
+        }).state;
+
+        const { event } = createViewUpdate(startState, {
+            selection: { anchor: 0 },
+        });
+        const snapshot: TableRuntimeSnapshot = {
+            activeCell,
+            prevActiveCell: activeCell,
+            resolvedActiveCell: requireResolvedActiveCell(startState),
+            resolvedPrevActiveCell: requireResolvedActiveCell(startState),
+            effectiveRawMode: false,
+            nestedEditorOpen: true,
+            hadActiveCell: true,
+            pendingFullReplaceRebuild: false,
+        };
+
+        expect(planTableLifecycleActions(snapshot, event, { cursorInsideTableAfterUndoRedo: false })).toEqual([
+            { type: 'closeNestedEditor', useResolvedRangeFromUpdate: false },
+            { type: 'clearActiveCell' },
+        ]);
+    });
+
     it('plans stale active cell cleanup when the nested editor is gone', () => {
         const activeCell = getHeaderCell();
         const startState = createState({ activeCell });

--- a/src/contentScript/tableRuntime/lifecycle/lifecyclePolicy.ts
+++ b/src/contentScript/tableRuntime/lifecycle/lifecyclePolicy.ts
@@ -233,6 +233,14 @@ export function planTableLifecycleActions(
         return actions;
     }
 
+    if (shouldClearActiveCellWhenSelectionLeavesTable(snapshot, event)) {
+        if (snapshot.nestedEditorOpen) {
+            actions.push({ type: 'closeNestedEditor', useResolvedRangeFromUpdate: false });
+        }
+        actions.push({ type: 'clearActiveCell' });
+        return actions;
+    }
+
     if (!snapshot.activeCell && snapshot.hadActiveCell) {
         actions.push({ type: 'closeNestedEditor', useResolvedRangeFromUpdate: false });
     }
@@ -280,6 +288,31 @@ function shouldRepositionCellAfterUndoRedo(
 
     const isUndoRedo = update.transactions.some((tr) => tr.isUserEvent('undo') || tr.isUserEvent('redo'));
     return isUndoRedo && cursorInsideTableAfterUndoRedo;
+}
+
+function shouldClearActiveCellWhenSelectionLeavesTable(
+    snapshot: TableRuntimeSnapshot,
+    event: TableRuntimeEvent
+): boolean {
+    const { update, isSync, isCellSelectionTransition } = event;
+    if (!update.selectionSet || isSync || isCellSelectionTransition || snapshot.effectiveRawMode) {
+        return false;
+    }
+
+    const resolved = snapshot.resolvedActiveCell;
+    if (!resolved) {
+        return false;
+    }
+
+    const { main } = update.state.selection;
+    return (
+        !isPositionInsideRange(main.anchor, resolved.tableFrom, resolved.tableTo) ||
+        !isPositionInsideRange(main.head, resolved.tableFrom, resolved.tableTo)
+    );
+}
+
+function isPositionInsideRange(pos: number, from: number, to: number): boolean {
+    return pos >= from && pos <= to;
 }
 
 function transactionChangesOutsideCell(tr: Transaction, activeCell: ResolvedActiveCell): boolean {

--- a/src/contentScript/tableRuntime/lifecycle/lifecyclePolicy.ts
+++ b/src/contentScript/tableRuntime/lifecycle/lifecyclePolicy.ts
@@ -295,7 +295,13 @@ function shouldClearActiveCellWhenSelectionLeavesTable(
     event: TableRuntimeEvent
 ): boolean {
     const { update, isSync, isCellSelectionTransition } = event;
-    if (!update.selectionSet || isSync || isCellSelectionTransition || snapshot.effectiveRawMode) {
+    if (
+        !update.selectionSet ||
+        isSync ||
+        isCellSelectionTransition ||
+        snapshot.effectiveRawMode ||
+        !snapshot.nestedEditorOpen
+    ) {
         return false;
     }
 

--- a/src/contentScript/tableRuntime/lifecycle/nestedEditorLifecycle.ts
+++ b/src/contentScript/tableRuntime/lifecycle/nestedEditorLifecycle.ts
@@ -281,7 +281,10 @@ export const nestedEditorLifecyclePlugin = ViewPlugin.fromClass(
                         break;
                     case 'clearActiveCell':
                         clearPendingCellOpen(this.view);
-                        this.view.dispatch({ effects: clearActiveCellEffect.of(undefined) });
+                        requestViewAnimationFrame(this.view, () => {
+                            if (!this.view.dom.isConnected) return;
+                            this.view.dispatch({ effects: clearActiveCellEffect.of(undefined) });
+                        });
                         break;
                 }
             }


### PR DESCRIPTION
Ensure the nested editor closes and clears the active cell when the main editor cursor leaves the table.