### PR TITLE
refactor: consolidation around ResolvedActiveCell

### DIFF
--- a/docs/Architecture/Nested-Editor-Architecture.md
+++ b/docs/Architecture/Nested-Editor-Architecture.md
@@ -13,8 +13,8 @@ Overlay a real editor rather than using contenteditable (for full syntax highlig
 
 Managed by `contentScript/tableRuntime/lifecycle/nestedEditorLifecycle.ts`.
 
-**Activation**: Cell click/keyboard activation resolves the target cell from widget DOM + `TableContext`/cell ranges →
-`setActiveCellEffect` plus an open-intent effect dispatched → lifecycle plugin mounts the nested editor.
+**Activation**: Cell click/keyboard activation resolves the target cell from widget DOM + `TableContext`/cell ranges into
+`ResolvedActiveCell` → `setActiveCellEffect` plus an open-intent effect dispatched → lifecycle plugin mounts the nested editor.
 
 `setActiveCellEffect` stores stable logical cell identity: `tableFrom` plus `section/row/col`. Any cursor placement for
 opening is passed separately as transient selection-anchor data. The lifecycle plugin resolves raw table/cell offsets from
@@ -41,7 +41,7 @@ The lifecycle plugin remains responsible only for executing nested-editor side e
 2. `NestedEditorSession` uses `editorBridge/cellTextCodec.ts` to sanitize local display text (`\n` -> `<br>`, `|` -> `\|`) and map the local selection into root cell coordinates.
 3. The main editor applies the cell-only replacement transaction tagged with `editorBridge/syncAnnotation.ts`.
 4. If normalization rewrites the whole table first, it also dispatches a reopen intent so lifecycle can reopen after rebuild.
-5. After root dispatch, the session refreshes its derived semantic/editable ranges from the current active-cell identity.
+5. After root dispatch, the session refreshes its `ResolvedActiveCell` from the current active-cell identity.
 6. External non-sync root changes re-resolve the logical cell and rebase the isolated editor from authoritative root text.
 
 ### Selection Sync

--- a/docs/Architecture/Overview.md
+++ b/docs/Architecture/Overview.md
@@ -101,6 +101,8 @@ resolve -> parse -> compute-ranges chains for the same table content.
 
 The active-cell resolver builds on `TableContext` and is the only supported way to
 derive current table/cell offsets for the persisted logical active-cell state.
+Once current-state code has a concrete active cell, it should pass `ResolvedActiveCell`
+through the runtime instead of re-threading table context and raw offsets separately.
 
 ### 6. Shared Transition Policy
 

--- a/docs/Architecture/Table-Parsing.md
+++ b/docs/Architecture/Table-Parsing.md
@@ -79,6 +79,10 @@ the current editor state through the shared active-cell resolver. That resolver:
 - Rebuilds `TableContext`.
 - Derives `tableTo`, trimmed content bounds, and editable bounds from current `cellRanges`.
 
+The resulting `ResolvedActiveCell` is the standard transient runtime object for active-cell-aware code. Once a concrete
+current-state cell has been chosen, runtime paths should pass `ResolvedActiveCell` rather than re-threading separate
+`ActiveCell`, `TableContext`, and raw offset fields.
+
 If resolution fails, the active cell is treated as stale and cleared rather than clamped to a nearby cell.
 
 ## Structural Operations (Rows/Columns/Alignment)

--- a/src/contentScript/__tests__/activeCellResolver.test.ts
+++ b/src/contentScript/__tests__/activeCellResolver.test.ts
@@ -1,8 +1,13 @@
 import { describe, expect, it } from '@jest/globals';
 import { activeCellField, getActiveCell, setActiveCellEffect, type ActiveCell } from '../tableState/activeCellState';
-import { resolveActiveCell } from '../tableRuntime/activeCell/activeCellResolver';
+import {
+    createResolvedActiveCell,
+    resolveActiveCell,
+    retargetResolvedActiveCell,
+} from '../tableRuntime/activeCell/activeCellResolver';
 import { getResolvedActiveCell, resolvedActiveCellField } from '../tableRuntime/activeCell/resolvedActiveCellField';
 import { createMarkdownState } from './testMarkdownState';
+import { buildTableContext } from '../tableModel/tableContext';
 
 function createState(doc: string, activeCell?: ActiveCell) {
     let state = createMarkdownState(doc, [activeCellField]);
@@ -104,6 +109,85 @@ describe('activeCellResolver', () => {
         expect(resolved?.editableTo).toBe(doc.indexOf('foo') + 'foo '.length);
         expect(state.doc.sliceString(resolved!.contentFrom, resolved!.contentTo)).toBe('foo');
         expect(state.doc.sliceString(resolved!.editableFrom, resolved!.editableTo)).toBe(' foo ');
+    });
+
+    it('creates a resolved active cell directly from table context and coords', () => {
+        const doc = ['| H1 | H2 |', '| --- | --- |', '| a1 | a2 |'].join('\n');
+        const ctx = buildTableContext({ from: 0, to: doc.length, text: doc });
+
+        expect(ctx).not.toBeNull();
+        if (!ctx) {
+            throw new Error('Expected table context');
+        }
+
+        const resolved = createResolvedActiveCell({
+            ctx,
+            coords: { section: 'body', row: 0, col: 1 },
+        });
+
+        expect(resolved).not.toBeNull();
+        expect(resolved?.activeCell).toEqual({
+            tableFrom: 0,
+            section: 'body',
+            row: 0,
+            col: 1,
+        });
+        expect(resolved?.tableFrom).toBe(0);
+        expect(resolved?.tableTo).toBe(doc.length);
+        expect(resolved?.contentFrom).toBe(doc.indexOf('a2'));
+        expect(resolved?.contentTo).toBe(doc.indexOf('a2') + 2);
+        expect(resolved?.editableFrom).toBe(doc.indexOf('a2'));
+        expect(resolved?.editableTo).toBe(doc.indexOf('a2') + 2);
+    });
+
+    it('retargets within the same resolved table context without reparsing', () => {
+        const doc = ['| H1 | H2 |', '| --- | --- |', '| a1 | a2 |'].join('\n');
+        const state = createState(doc, {
+            tableFrom: 0,
+            section: 'header',
+            row: 0,
+            col: 0,
+        });
+
+        const resolved = resolveActiveCell(state, getActiveCell(state));
+        expect(resolved).not.toBeNull();
+        if (!resolved) {
+            throw new Error('Expected resolved cell');
+        }
+
+        const retargeted = retargetResolvedActiveCell(resolved, {
+            section: 'body',
+            row: 0,
+            col: 1,
+        });
+
+        expect(retargeted).not.toBeNull();
+        expect(retargeted?.ctx).toBe(resolved.ctx);
+        expect(retargeted?.activeCell).toEqual({
+            tableFrom: 0,
+            section: 'body',
+            row: 0,
+            col: 1,
+        });
+        expect(retargeted?.editableFrom).toBe(doc.indexOf('a2'));
+        expect(retargeted?.editableTo).toBe(doc.indexOf('a2') + 2);
+    });
+
+    it('returns null when creating a resolved active cell for invalid coordinates', () => {
+        const doc = ['| H1 | H2 |', '| --- | --- |', '| a1 | a2 |'].join('\n');
+        const ctx = buildTableContext({ from: 0, to: doc.length, text: doc });
+
+        expect(ctx).not.toBeNull();
+        if (!ctx) {
+            throw new Error('Expected table context');
+        }
+
+        expect(
+            createResolvedActiveCell({
+                ctx,
+                coords: { section: 'body', row: 9, col: 9 },
+            })
+        ).toBeNull();
     });
 
     it('is selection-independent even when the cursor moves into editable edge whitespace', () => {

--- a/src/contentScript/__tests__/interactiveCellNormalization.test.ts
+++ b/src/contentScript/__tests__/interactiveCellNormalization.test.ts
@@ -232,6 +232,29 @@ describe('interactive cell normalization', () => {
         expect(openRequest?.value).toMatchObject({ normalizeIfNeeded: false });
     });
 
+    it('clamps a preferred fallback cell instead of reopening the first cell on structural punctuation', () => {
+        const doc = ['| H1 | H2 |', '| --- | --- |', '| a1 | a2 |'].join('\n');
+        const { view } = createViewHarness({ doc });
+
+        expect(
+            activateCellAtPosition(view, doc.indexOf('| a2'), {
+                normalizeIfNeeded: false,
+                preferredActiveCell: {
+                    tableFrom: 0,
+                    section: 'body',
+                    row: 1,
+                    col: 1,
+                },
+            })
+        ).toBe(true);
+
+        expect(getActiveCell(view.state)).toMatchObject({
+            section: 'body',
+            row: 0,
+            col: 1,
+        });
+    });
+
     it('normalizes on keyboard navigation before reopening the target cell', () => {
         const { view } = createViewHarness({
             activeCell: {

--- a/src/contentScript/__tests__/nestedEditorLifecycle.test.ts
+++ b/src/contentScript/__tests__/nestedEditorLifecycle.test.ts
@@ -225,6 +225,57 @@ describe('nestedEditorLifecycle', () => {
         view.destroy();
     });
 
+    it('maps the fallback hint when undo or redo shifts the table start before reactivation', () => {
+        const doc = ['| H1 | H2 |', '| --- | --- |', '| a1 | a2 |', '| b1 | b2 |'].join('\n');
+        const insertedPrefix = 'abc\n';
+        const activeCell: ActiveCell = {
+            tableFrom: 0,
+            section: 'body',
+            row: 1,
+            col: 1,
+        };
+
+        let state = EditorState.create({
+            doc,
+            extensions: [
+                markdown({ extensions: [GFM] }),
+                activeCellField,
+                searchForceSourceModeField,
+                sourceModeField,
+                nestedEditorLifecyclePlugin,
+            ],
+        });
+        state = state.update({ effects: setActiveCellEffect.of(activeCell) }).state;
+
+        const parent = document.createElement('div');
+        document.body.appendChild(parent);
+        const view = new EditorView({ parent, state });
+
+        view.dispatch({
+            changes: { from: 0, to: 0, insert: insertedPrefix },
+            effects: clearActiveCellEffect.of(undefined),
+            annotations: Transaction.userEvent.of('redo'),
+            selection: { anchor: insertedPrefix.length + doc.indexOf('| a2') },
+        });
+        flushAnimationFrames();
+
+        expect(activateCellAtPositionMock).toHaveBeenCalledWith(
+            view,
+            insertedPrefix.length + doc.indexOf('| a2'),
+            expect.objectContaining({
+                clearIfOutside: true,
+                normalizeIfNeeded: false,
+                preserveMainSelection: false,
+                preferredActiveCell: {
+                    ...activeCell,
+                    tableFrom: insertedPrefix.length,
+                },
+            })
+        );
+
+        view.destroy();
+    });
+
     it('does not pass a resolved range when force rebuild closes the nested editor', () => {
         nestedEditorControllerMock.isNestedEditorOpen.mockReturnValue(true);
 

--- a/src/contentScript/__tests__/nestedEditorLifecycle.test.ts
+++ b/src/contentScript/__tests__/nestedEditorLifecycle.test.ts
@@ -7,7 +7,13 @@ import { EditorView } from '@codemirror/view';
 import { describe, expect, it, beforeEach, afterEach, jest } from '@jest/globals';
 import { nestedEditorLifecyclePlugin } from '../tableRuntime/lifecycle/nestedEditorLifecycle';
 import { activateInsertedTableEffect } from '../tableState/insertedTableActivation';
-import { activeCellField, getActiveCell, setActiveCellEffect, type ActiveCell } from '../tableState/activeCellState';
+import {
+    activeCellField,
+    clearActiveCellEffect,
+    getActiveCell,
+    setActiveCellEffect,
+    type ActiveCell,
+} from '../tableState/activeCellState';
 import { searchForceSourceModeField } from '../tableState/searchForceSourceMode';
 import { exitSourceModeEffect, sourceModeField, toggleSourceModeEffect } from '../tableState/sourceMode';
 import { rebuildTableWidgetsEffect } from '../tableState/tableWidgetEffects';
@@ -19,6 +25,7 @@ import { rememberPendingCellOpen } from '../nestedEditor/pendingCellOpen';
 import type { NestedEditorFeatureSettings } from '../../contentScriptBridge/editorSettingsBridge';
 import { createActiveCellForTableText } from '../tableRuntime/activeCell/activeCellFactory';
 
+const activateCellAtPositionMock = jest.fn();
 const activateTableCellMock = jest.fn();
 const findCellElementMock: jest.Mock = jest.fn(() => document.createElement('td'));
 const DEFAULT_FEATURE_SETTINGS = {
@@ -34,7 +41,7 @@ const NON_CANONICAL_DOC = ['|H1|H2|', '|---|---|', '|a|b|'].join('\n');
 const CANONICAL_DOC = ['| H1 | H2 |', '| --- | --- |', '| a | b |'].join('\n');
 
 jest.mock('../tableRuntime/activeCell/cellActivation', () => ({
-    activateCellAtPosition: jest.fn(),
+    activateCellAtPosition: (...args: unknown[]) => activateCellAtPositionMock(...args),
     activateTableCell: (...args: unknown[]) => activateTableCellMock(...args),
 }));
 
@@ -66,6 +73,7 @@ describe('nestedEditorLifecycle', () => {
     };
 
     beforeEach(() => {
+        activateCellAtPositionMock.mockReset();
         activateTableCellMock.mockReset();
         findCellElementMock.mockClear();
         getNestedEditorFeatureSettingsMock.mockReset();
@@ -162,6 +170,57 @@ describe('nestedEditorLifecycle', () => {
             contentFrom: resolved.contentFrom,
             contentTo: resolved.contentTo,
         });
+
+        view.destroy();
+    });
+
+    it('passes the pre-undo active cell as a fallback hint during undo or redo reactivation', () => {
+        const doc = ['| H1 | H2 |', '| --- | --- |', '| a1 | a2 |', '| b1 | b2 |'].join('\n');
+        const activeCell: ActiveCell = {
+            tableFrom: 0,
+            section: 'body',
+            row: 1,
+            col: 1,
+        };
+
+        let state = EditorState.create({
+            doc,
+            extensions: [
+                markdown({ extensions: [GFM] }),
+                activeCellField,
+                searchForceSourceModeField,
+                sourceModeField,
+                nestedEditorLifecyclePlugin,
+            ],
+        });
+        state = state.update({ effects: setActiveCellEffect.of(activeCell) }).state;
+
+        const parent = document.createElement('div');
+        document.body.appendChild(parent);
+        const view = new EditorView({ parent, state });
+
+        view.dispatch({
+            changes: {
+                from: doc.indexOf('| b1 | b2 |'),
+                to: doc.length,
+                insert: '',
+            },
+            effects: clearActiveCellEffect.of(undefined),
+            annotations: Transaction.userEvent.of('undo'),
+            selection: { anchor: doc.indexOf('| a2') },
+        });
+        flushAnimationFrames();
+
+        expect(activateCellAtPositionMock).toHaveBeenCalledWith(
+            view,
+            doc.indexOf('| a2'),
+            expect.objectContaining({
+                clearIfOutside: true,
+                normalizeIfNeeded: false,
+                preserveMainSelection: false,
+                preferredActiveCell: activeCell,
+            })
+        );
 
         view.destroy();
     });

--- a/src/contentScript/__tests__/tableNavigation.test.ts
+++ b/src/contentScript/__tests__/tableNavigation.test.ts
@@ -2,8 +2,7 @@ import { EditorView } from '@codemirror/view';
 import { EditorState } from '@codemirror/state';
 import { navigateCell } from '../tableRuntime/navigation/tableNavigation';
 import { getActiveCell } from '../tableState/activeCellState';
-import { resolveActiveCell } from '../tableRuntime/activeCell/activeCellResolver';
-import { resolveCellDocRange } from '../tableRuntime/tablePositioning';
+import { resolveActiveCell, retargetResolvedActiveCell } from '../tableRuntime/activeCell/activeCellResolver';
 import { SECTION_BODY, SECTION_HEADER } from '../tableWidget/domHelpers';
 import { isNavigationLocked, resetNavigationLock } from '../tableRuntime/navigationLock';
 
@@ -13,9 +12,9 @@ import { requestOpenActiveCellEffect } from '../tableRuntime/activeCell/activeCe
 import { execInsertRowAtBottom } from '../tableRuntime/operations/tableOperations';
 
 // Mock dependencies (not activeCellState - we need the real StateEffect identity)
-jest.mock('../tableRuntime/tablePositioning');
 jest.mock('../tableRuntime/activeCell/activeCellResolver', () => ({
     resolveActiveCell: jest.fn(),
+    retargetResolvedActiveCell: jest.fn(),
 }));
 jest.mock('../tableRuntime/operations/tableOperations', () => ({
     __esModule: true,
@@ -56,7 +55,7 @@ describe('navigateCell', () => {
         getActiveCellSpy = jest.spyOn(activeCellState, 'getActiveCell');
         getActiveCellSpy.mockReset();
         (resolveActiveCell as jest.Mock).mockReset();
-        (resolveCellDocRange as jest.Mock).mockReset();
+        (retargetResolvedActiveCell as jest.Mock).mockReset();
         (execInsertRowAtBottom as jest.Mock).mockReset();
     });
 
@@ -87,13 +86,21 @@ describe('navigateCell', () => {
             },
         };
 
-        (resolveCellDocRange as jest.Mock).mockReturnValue({
+        (retargetResolvedActiveCell as jest.Mock).mockImplementation((_resolved, target) => ({
+            activeCell: {
+                tableFrom: 0,
+                section: target.section,
+                row: target.row,
+                col: target.col,
+            },
+            editableFrom: 10,
+            editableTo: 20,
+        }));
+        (resolveActiveCell as jest.Mock).mockReturnValue({
             contentFrom: 10,
             contentTo: 20,
             editableFrom: 10,
             editableTo: 20,
-        });
-        (resolveActiveCell as jest.Mock).mockReturnValue({
             ctx,
         });
     };
@@ -132,6 +139,11 @@ describe('navigateCell', () => {
         expect(getOpenRequestValue()).toMatchObject({
             normalizeIfNeeded: true,
         });
+        expect(mockDispatch).toHaveBeenCalledWith(
+            expect.objectContaining({
+                selection: { anchor: 10 },
+            })
+        );
     });
 
     it('should navigate next from header end to body start', () => {

--- a/src/contentScript/nestedEditor/nestedEditorController.ts
+++ b/src/contentScript/nestedEditor/nestedEditorController.ts
@@ -17,7 +17,7 @@ import {
 import { syncAnnotation } from '../editorBridge/syncAnnotation';
 import { consumePendingNavigationCallback } from '../tableRuntime/navigationLock';
 import { ensureCellWrapper } from './mounting';
-import { resolveActiveCell } from '../tableRuntime/activeCell/activeCellResolver';
+import { resolveActiveCell, type ResolvedActiveCell } from '../tableRuntime/activeCell/activeCellResolver';
 import { clearActiveCellEffect, getActiveCell, type ActiveCell } from '../tableState/activeCellState';
 import { buildRenderableContent, containsMarkdown, escapeHtmlPreservingBr } from '../shared/cellContentUtils';
 import { CLASS_CELL_ACTIVE } from '../shared/tableDomClasses';
@@ -28,15 +28,6 @@ import { createNestedEditorFeatureExtensions } from './nestedEditorFeatureConfig
 import { requestViewAnimationFrame } from '../shared/domContext';
 
 const SYNTAX_TREE_PARSE_TIMEOUT = 500;
-
-export interface NestedEditorCellRange {
-    tableFrom: number;
-    tableTo: number;
-    contentFrom: number;
-    contentTo: number;
-    editableFrom: number;
-    editableTo: number;
-}
 
 export interface NestedEditorLocalState {
     text: string;
@@ -49,8 +40,7 @@ export interface NestedEditorRootState {
 }
 
 export interface NestedEditorSession {
-    activeCell: ActiveCell;
-    range: NestedEditorCellRange;
+    resolvedCell: ResolvedActiveCell;
     local: NestedEditorLocalState;
     root: NestedEditorRootState;
     editor: EditorView | null;
@@ -133,15 +123,7 @@ class NestedEditorController {
         }
 
         const session: NestedEditorSession = {
-            activeCell: resolved.activeCell,
-            range: {
-                tableFrom: resolved.tableFrom,
-                tableTo: resolved.tableTo,
-                contentFrom: resolved.contentFrom,
-                contentTo: resolved.contentTo,
-                editableFrom: resolved.editableFrom,
-                editableTo: resolved.editableTo,
-            },
+            resolvedCell: resolved,
             local: { text: localText, selection: localSelection },
             root: { text: rootText, selection: rootSelection },
             editor: null,
@@ -216,11 +198,7 @@ class NestedEditorController {
         }
 
         const stateActiveCell = getActiveCell(update.state);
-        if (stateActiveCell) {
-            this.session.activeCell = stateActiveCell;
-        }
-
-        const resolved = resolveActiveCell(update.state, this.session.activeCell);
+        const resolved = resolveActiveCell(update.state, stateActiveCell ?? this.session.resolvedCell.activeCell);
         if (!resolved) {
             const mainView = this.mainView;
             this.close();
@@ -230,15 +208,7 @@ class NestedEditorController {
             return;
         }
 
-        this.session.activeCell = resolved.activeCell;
-        this.session.range = {
-            tableFrom: resolved.tableFrom,
-            tableTo: resolved.tableTo,
-            contentFrom: resolved.contentFrom,
-            contentTo: resolved.contentTo,
-            editableFrom: resolved.editableFrom,
-            editableTo: resolved.editableTo,
-        };
+        this.session.resolvedCell = resolved;
 
         const rootText = update.state.doc.sliceString(resolved.editableFrom, resolved.editableTo);
         const rootSelection = toRelativeSelection(update.state.selection, resolved.editableFrom, resolved.editableTo);
@@ -299,9 +269,9 @@ class NestedEditorController {
 
     /**
      * Resolve cell range for close(), preferring freshly-resolved positions over
-     * cached session positions. After undo/redo, the cached session.range may
-     * point to stale document positions (the document shifted but session.range
-     * was not remapped), causing close() to read the wrong cell text.
+     * cached session positions. After undo/redo, the cached resolved cell may
+     * point to stale document positions until it is refreshed, causing close()
+     * to read the wrong cell text.
      *
      * Re-resolves the cell using the session's own identity and cached table
      * position against the current editor state. This stays anchored to the
@@ -319,15 +289,15 @@ class NestedEditorController {
         }
 
         if (session && mainView) {
-            const resolved = resolveActiveCell(mainView.state, session.activeCell);
+            const resolved = resolveActiveCell(mainView.state, session.resolvedCell.activeCell);
             if (resolved) {
                 return { contentFrom: resolved.contentFrom, contentTo: resolved.contentTo };
             }
         }
 
         return {
-            contentFrom: session?.range.contentFrom ?? 0,
-            contentTo: session?.range.contentTo ?? 0,
+            contentFrom: session?.resolvedCell.contentFrom ?? 0,
+            contentTo: session?.resolvedCell.contentTo ?? 0,
         };
     }
 
@@ -386,7 +356,7 @@ class NestedEditorController {
 
         const rootText = sanitizeLocalText(this.session.local.text);
         const rootSelection = toRootSelection(this.session.local.selection, this.session.local.text);
-        const absoluteSelection = toAbsoluteSelection(rootSelection, this.session.range.editableFrom);
+        const absoluteSelection = toAbsoluteSelection(rootSelection, this.session.resolvedCell.editableFrom);
         const currentMainSelection = this.mainView.state.selection.main;
 
         const textChanged = rootText !== this.session.root.text;
@@ -402,8 +372,8 @@ class NestedEditorController {
             changes:
                 includeChanges && textChanged
                     ? {
-                          from: this.session.range.editableFrom,
-                          to: this.session.range.editableTo,
+                          from: this.session.resolvedCell.editableFrom,
+                          to: this.session.resolvedCell.editableTo,
                           insert: rootText,
                       }
                     : undefined,
@@ -450,7 +420,7 @@ class NestedEditorController {
         mirrorLocalSelectionToMain({
             nestedView,
             mainView: this.mainView,
-            selection: toAbsoluteSelection(rootSelection, this.session.range.editableFrom),
+            selection: toAbsoluteSelection(rootSelection, this.session.resolvedCell.editableFrom),
         });
     }
 
@@ -460,24 +430,15 @@ class NestedEditorController {
         }
 
         const stateActiveCell = getActiveCell(this.mainView.state);
-        if (stateActiveCell) {
-            this.session.activeCell = stateActiveCell;
-        }
-
-        const resolved = resolveActiveCell(this.mainView.state, this.session.activeCell);
+        const resolved = resolveActiveCell(
+            this.mainView.state,
+            stateActiveCell ?? this.session.resolvedCell.activeCell
+        );
         if (!resolved) {
             return;
         }
 
-        this.session.activeCell = resolved.activeCell;
-        this.session.range = {
-            tableFrom: resolved.tableFrom,
-            tableTo: resolved.tableTo,
-            contentFrom: resolved.contentFrom,
-            contentTo: resolved.contentTo,
-            editableFrom: resolved.editableFrom,
-            editableTo: resolved.editableTo,
-        };
+        this.session.resolvedCell = resolved;
         this.session.root = {
             text: this.mainView.state.doc.sliceString(resolved.editableFrom, resolved.editableTo),
             selection: toRelativeSelection(this.mainView.state.selection, resolved.editableFrom, resolved.editableTo),

--- a/src/contentScript/tableRuntime/activeCell/activeCellOpen.ts
+++ b/src/contentScript/tableRuntime/activeCell/activeCellOpen.ts
@@ -4,6 +4,7 @@ import { setActiveCellEffect, type ActiveCell } from '../../tableState/activeCel
 import { clearCellSelectionEffect } from '../../tableState/cellSelectionState';
 import { setPendingNavigationCallback } from '../navigationLock';
 import { rememberPendingCellOpen } from '../../nestedEditor/pendingCellOpen';
+import type { ResolvedActiveCell } from './activeCellResolver';
 
 export interface OpenActiveCellRequest {
     activeCell: ActiveCell;
@@ -44,5 +45,18 @@ export function selectAndRequestOpenActiveCell(view: EditorView, params: SelectA
             }),
         ],
         scrollIntoView: params.scrollIntoView ?? false,
+    });
+}
+
+export function selectAndRequestOpenResolvedActiveCell(
+    view: EditorView,
+    params: Omit<SelectAndRequestOpenActiveCellParams, 'activeCell' | 'selectionAnchor'> & {
+        resolvedCell: ResolvedActiveCell;
+    }
+): void {
+    selectAndRequestOpenActiveCell(view, {
+        ...params,
+        activeCell: params.resolvedCell.activeCell,
+        selectionAnchor: params.resolvedCell.editableFrom,
     });
 }

--- a/src/contentScript/tableRuntime/activeCell/activeCellResolver.ts
+++ b/src/contentScript/tableRuntime/activeCell/activeCellResolver.ts
@@ -2,6 +2,8 @@ import type { EditorState } from '@codemirror/state';
 import { resolveTableForActiveCell } from '../tablePositioning';
 import type { ActiveCell } from '../../tableState/activeCellState';
 import type { TableContext } from '../../tableModel/tableContext';
+import { resolveCellDocRange } from '../tablePositioning';
+import type { CellCoords } from '../../tableModel/types';
 
 export interface ResolvedActiveCell {
     activeCell: ActiveCell;
@@ -14,6 +16,44 @@ export interface ResolvedActiveCell {
     editableTo: number;
 }
 
+export function createResolvedActiveCell(params: { ctx: TableContext; coords: CellCoords }): ResolvedActiveCell | null {
+    const { ctx, coords } = params;
+    const range = resolveCellDocRange({
+        tableFrom: ctx.from,
+        ranges: ctx.cellRanges,
+        coords,
+    });
+    if (!range) {
+        return null;
+    }
+
+    return {
+        activeCell: {
+            tableFrom: ctx.from,
+            section: coords.section,
+            row: coords.section === 'header' ? 0 : coords.row,
+            col: coords.col,
+        },
+        ctx,
+        tableFrom: ctx.from,
+        tableTo: ctx.to,
+        contentFrom: range.contentFrom,
+        contentTo: range.contentTo,
+        editableFrom: range.editableFrom,
+        editableTo: range.editableTo,
+    };
+}
+
+export function retargetResolvedActiveCell(
+    resolved: ResolvedActiveCell,
+    coords: CellCoords
+): ResolvedActiveCell | null {
+    return createResolvedActiveCell({
+        ctx: resolved.ctx,
+        coords,
+    });
+}
+
 export function resolveActiveCell(state: EditorState, activeCell: ActiveCell | null): ResolvedActiveCell | null {
     if (!activeCell) {
         return null;
@@ -24,17 +64,12 @@ export function resolveActiveCell(state: EditorState, activeCell: ActiveCell | n
         return null;
     }
 
-    return {
-        activeCell: {
-            ...activeCell,
-            tableFrom: resolved.tableFrom,
-        },
+    return createResolvedActiveCell({
         ctx: resolved.ctx,
-        tableFrom: resolved.tableFrom,
-        tableTo: resolved.tableTo,
-        contentFrom: resolved.contentFrom,
-        contentTo: resolved.contentTo,
-        editableFrom: resolved.editableFrom,
-        editableTo: resolved.editableTo,
-    };
+        coords: {
+            section: activeCell.section,
+            row: activeCell.row,
+            col: activeCell.col,
+        },
+    });
 }

--- a/src/contentScript/tableRuntime/activeCell/cellActivation.ts
+++ b/src/contentScript/tableRuntime/activeCell/cellActivation.ts
@@ -8,8 +8,8 @@ import { isSourceModeEnabled } from '../../tableState/sourceMode';
 import { findTableRanges } from '../tablePositioning';
 import { findCellForPos } from '../../tableModel/markdownTableCellRanges';
 import { buildTableContext } from '../../tableModel/tableContext';
-import { createActiveCellFromRanges } from './activeCellFactory';
-import { selectAndRequestOpenActiveCell } from './activeCellOpen';
+import { createResolvedActiveCell } from './activeCellResolver';
+import { selectAndRequestOpenResolvedActiveCell } from './activeCellOpen';
 import { requestViewAnimationFrame } from '../../shared/domContext';
 
 export interface ActivateCellOptions {
@@ -90,24 +90,22 @@ export function activateCellAtPosition(view: EditorView, pos: number, options?: 
         activeCell: getActiveCell(view.state),
     });
 
-    const newActiveCell = createActiveCellFromRanges({
-        tableFrom: ctx.from,
-        ranges: ctx.cellRanges,
-        target: targetCell,
+    const resolvedCell = createResolvedActiveCell({
+        ctx,
+        coords: targetCell,
     });
 
-    if (!newActiveCell) {
+    if (!resolvedCell) {
         if (options?.clearIfOutside) {
             view.dispatch({ effects: clearActiveCellEffect.of(undefined) });
         }
         return false;
     }
 
-    selectAndRequestOpenActiveCell(view, {
-        activeCell: newActiveCell.activeCell,
+    selectAndRequestOpenResolvedActiveCell(view, {
+        resolvedCell,
         normalizeIfNeeded: options?.normalizeIfNeeded ?? true,
         preserveMainSelection: options?.preserveMainSelection ?? false,
-        selectionAnchor: newActiveCell.selectionAnchor,
     });
 
     return true;
@@ -137,18 +135,16 @@ export function activateTableCell(
         const ctx = buildTableContext(table);
         if (!ctx) return;
 
-        const newActiveCell = createActiveCellFromRanges({
-            tableFrom: ctx.from,
-            ranges: ctx.cellRanges,
-            target: coords,
+        const resolvedCell = createResolvedActiveCell({
+            ctx,
+            coords,
         });
 
-        if (!newActiveCell) return;
+        if (!resolvedCell) return;
 
-        selectAndRequestOpenActiveCell(view, {
-            activeCell: newActiveCell.activeCell,
+        selectAndRequestOpenResolvedActiveCell(view, {
+            resolvedCell,
             normalizeIfNeeded: true,
-            selectionAnchor: newActiveCell.selectionAnchor,
         });
     });
 }

--- a/src/contentScript/tableRuntime/activeCell/cellActivation.ts
+++ b/src/contentScript/tableRuntime/activeCell/cellActivation.ts
@@ -3,11 +3,12 @@
  * Consolidated from nestedEditorLifecycle.ts and searchPanelWatcher.ts.
  */
 import { EditorView } from '@codemirror/view';
-import { clearActiveCellEffect, getActiveCell } from '../../tableState/activeCellState';
+import { clearActiveCellEffect, getActiveCell, type ActiveCell } from '../../tableState/activeCellState';
 import { isSourceModeEnabled } from '../../tableState/sourceMode';
 import { findTableRanges } from '../tablePositioning';
 import { findCellForPos } from '../../tableModel/markdownTableCellRanges';
 import { buildTableContext } from '../../tableModel/tableContext';
+import { createActiveCellFromRanges } from './activeCellFactory';
 import { createResolvedActiveCell } from './activeCellResolver';
 import { selectAndRequestOpenResolvedActiveCell } from './activeCellOpen';
 import { requestViewAnimationFrame } from '../../shared/domContext';
@@ -19,6 +20,8 @@ export interface ActivateCellOptions {
     normalizeIfNeeded?: boolean;
     /** If true, preserve the current main-editor selection when requesting the nested editor open */
     preserveMainSelection?: boolean;
+    /** Optional fallback identity used when the cursor lands on table structure during lifecycle-driven reactivation */
+    preferredActiveCell?: ActiveCell | null;
 }
 
 export function resolveActivationTargetCell(params: {
@@ -87,12 +90,24 @@ export function activateCellAtPosition(view: EditorView, pos: number, options?: 
         tableFrom: ctx.from,
         relativePos,
         cellRanges: ctx.cellRanges,
-        activeCell: getActiveCell(view.state),
+        activeCell: options?.preferredActiveCell ?? getActiveCell(view.state),
     });
+
+    const nextActiveCell = createActiveCellFromRanges({
+        tableFrom: ctx.from,
+        ranges: ctx.cellRanges,
+        target: targetCell,
+    });
+    if (!nextActiveCell) {
+        if (options?.clearIfOutside) {
+            view.dispatch({ effects: clearActiveCellEffect.of(undefined) });
+        }
+        return false;
+    }
 
     const resolvedCell = createResolvedActiveCell({
         ctx,
-        coords: targetCell,
+        coords: nextActiveCell.activeCell,
     });
 
     if (!resolvedCell) {

--- a/src/contentScript/tableRuntime/lifecycle/nestedEditorLifecycle.ts
+++ b/src/contentScript/tableRuntime/lifecycle/nestedEditorLifecycle.ts
@@ -210,6 +210,7 @@ export const nestedEditorLifecyclePlugin = ViewPlugin.fromClass(
                                 clearIfOutside: action.clearIfOutside,
                                 normalizeIfNeeded: action.normalizeIfNeeded,
                                 preserveMainSelection: action.preserveMainSelection,
+                                preferredActiveCell: getActiveCell(update.startState),
                             });
                             if (action.ensureCursorVisibleIfNotActivated && !getActiveCell(this.view.state)) {
                                 ensureCursorVisible(this.view);

--- a/src/contentScript/tableRuntime/lifecycle/nestedEditorLifecycle.ts
+++ b/src/contentScript/tableRuntime/lifecycle/nestedEditorLifecycle.ts
@@ -9,6 +9,7 @@ import { activateInsertedTableEffect } from '../../tableState/insertedTableActiv
 import { isEffectiveRawMode } from '../../tableState/sourceMode';
 import { rebuildAllTableWidgetsEffect, rebuildTableWidgetsEffect } from '../../tableState/tableWidgetEffects';
 import { resolveActiveCell } from '../activeCell/activeCellResolver';
+import { getResolvedActiveCell } from '../activeCell/resolvedActiveCellField';
 import {
     closeNestedEditor,
     handleMainEditorUpdate,
@@ -66,6 +67,18 @@ function getInsertedTableActivationRequest(update: ViewUpdate) {
     return null;
 }
 
+function getResolvedActiveCellFromStateOrExplicit(
+    state: EditorView['state'],
+    activeCell: NonNullable<ReturnType<typeof getActiveCell>>
+) {
+    const resolvedFromState = getResolvedActiveCell(state);
+    if (resolvedFromState && isSameActiveCell(resolvedFromState.activeCell, activeCell)) {
+        return resolvedFromState;
+    }
+
+    return resolveActiveCell(state, activeCell);
+}
+
 function normalizeTableBeforeOpen(params: {
     view: EditorView;
     activeCell: NonNullable<ReturnType<typeof getActiveCell>>;
@@ -76,7 +89,7 @@ function normalizeTableBeforeOpen(params: {
         return false;
     }
 
-    const resolved = resolveActiveCell(params.view.state, params.activeCell);
+    const resolved = getResolvedActiveCellFromStateOrExplicit(params.view.state, params.activeCell);
     if (!resolved) {
         return false;
     }
@@ -234,7 +247,10 @@ export const nestedEditorLifecyclePlugin = ViewPlugin.fromClass(
                                 abortPendingOpen();
                                 return;
                             }
-                            const resolvedActiveCell = resolveActiveCell(this.view.state, action.activeCell);
+                            const resolvedActiveCell = getResolvedActiveCellFromStateOrExplicit(
+                                this.view.state,
+                                action.activeCell
+                            );
                             if (!resolvedActiveCell) {
                                 abortPendingOpen();
                                 this.view.dispatch({ effects: clearActiveCellEffect.of(undefined) });
@@ -298,8 +314,7 @@ export const nestedEditorLifecyclePlugin = ViewPlugin.fromClass(
 );
 
 function snapshotResolvedCellRange(state: EditorView['state']): { contentFrom: number; contentTo: number } | null {
-    const activeCell = getActiveCell(state);
-    const resolved = resolveActiveCell(state, activeCell);
+    const resolved = getResolvedActiveCell(state);
     if (!resolved) {
         return null;
     }

--- a/src/contentScript/tableRuntime/lifecycle/nestedEditorLifecycle.ts
+++ b/src/contentScript/tableRuntime/lifecycle/nestedEditorLifecycle.ts
@@ -4,6 +4,7 @@ import {
     getActiveCell,
     isSameActiveCell,
     setActiveCellEffect,
+    type ActiveCell,
 } from '../../tableState/activeCellState';
 import { activateInsertedTableEffect } from '../../tableState/insertedTableActivation';
 import { isEffectiveRawMode } from '../../tableState/sourceMode';
@@ -77,6 +78,22 @@ function getResolvedActiveCellFromStateOrExplicit(
     }
 
     return resolveActiveCell(state, activeCell);
+}
+
+function mapActiveCellThroughUpdate(update: ViewUpdate, activeCell: ActiveCell | null): ActiveCell | null {
+    if (!activeCell) {
+        return null;
+    }
+
+    const mappedTableFrom = update.changes.mapPos(activeCell.tableFrom, 1);
+    if (!Number.isFinite(mappedTableFrom) || mappedTableFrom < 0) {
+        return null;
+    }
+
+    return {
+        ...activeCell,
+        tableFrom: mappedTableFrom,
+    };
 }
 
 function normalizeTableBeforeOpen(params: {
@@ -203,6 +220,10 @@ export const nestedEditorLifecyclePlugin = ViewPlugin.fromClass(
                         break;
                     case 'scheduleActivateCellAtCursor': {
                         const cursorPos = update.state.selection.main.head;
+                        const preferredActiveCell = mapActiveCellThroughUpdate(
+                            update,
+                            getActiveCell(update.startState)
+                        );
                         requestViewAnimationFrame(this.view, () => {
                             if (!this.view.dom.isConnected) return;
                             if (!action.clearIfOutside && isEffectiveRawMode(this.view.state)) return;
@@ -210,7 +231,7 @@ export const nestedEditorLifecyclePlugin = ViewPlugin.fromClass(
                                 clearIfOutside: action.clearIfOutside,
                                 normalizeIfNeeded: action.normalizeIfNeeded,
                                 preserveMainSelection: action.preserveMainSelection,
-                                preferredActiveCell: getActiveCell(update.startState),
+                                preferredActiveCell,
                             });
                             if (action.ensureCursorVisibleIfNotActivated && !getActiveCell(this.view.state)) {
                                 ensureCursorVisible(this.view);

--- a/src/contentScript/tableRuntime/navigation/tableNavigation.ts
+++ b/src/contentScript/tableRuntime/navigation/tableNavigation.ts
@@ -1,7 +1,6 @@
 import { EditorView } from '@codemirror/view';
 import { getActiveCell } from '../../tableState/activeCellState';
-import { resolveActiveCell } from '../activeCell/activeCellResolver';
-import { resolveCellDocRange } from '../tablePositioning';
+import { resolveActiveCell, retargetResolvedActiveCell } from '../activeCell/activeCellResolver';
 import { execInsertRowAtBottom } from '../operations/tableOperations';
 import { type CellCoords } from '../../tableModel/types';
 import { SECTION_BODY, SECTION_HEADER } from '../../tableWidget/domHelpers';
@@ -11,7 +10,7 @@ import {
     releaseNavigationLock,
     setPendingNavigationCallback,
 } from '../navigationLock';
-import { selectAndRequestOpenActiveCell } from '../activeCell/activeCellOpen';
+import { selectAndRequestOpenResolvedActiveCell } from '../activeCell/activeCellOpen';
 
 function insertRowFromKeyboardNavigation(
     view: EditorView,
@@ -134,13 +133,8 @@ export function navigateCell(
     };
 
     // Activate target cell
-    const resolvedRange = resolveCellDocRange({
-        tableFrom: ctx.from,
-        ranges: ctx.cellRanges,
-        coords: target,
-    });
-
-    if (!resolvedRange) {
+    const nextResolvedCell = retargetResolvedActiveCell(resolvedActiveCell, target);
+    if (!nextResolvedCell) {
         return false;
     }
 
@@ -149,17 +143,11 @@ export function navigateCell(
         return true; // Already locked
     }
 
-    selectAndRequestOpenActiveCell(view, {
-        activeCell: {
-            tableFrom: ctx.from,
-            section: target.section,
-            row: target.row,
-            col: target.col,
-        },
+    selectAndRequestOpenResolvedActiveCell(view, {
+        resolvedCell: nextResolvedCell,
         normalizeIfNeeded: true,
         initialCursorPos: options.cursorPos,
         onFocused: releaseNavigationLock,
-        selectionAnchor: resolvedRange.editableFrom,
     });
 
     return true;

--- a/src/contentScript/tableWidget/tableWidgetInteractions.ts
+++ b/src/contentScript/tableWidget/tableWidgetInteractions.ts
@@ -3,10 +3,11 @@ import { CLASS_CELL_EDITOR } from '../shared/tableDomClasses';
 import { clearActiveCellEffect, getActiveCell, type ActiveCellSection } from '../tableState/activeCellState';
 import { clearCellSelectionEffect, getCellSelection } from '../tableState/cellSelectionState';
 import { setOrExtendCellSelectionToCoords } from '../tableRuntime/selection/cellSelectionController';
-import { resolveCellDocRange, resolveTableContextFromEventTarget } from '../tableRuntime/tablePositioning';
+import { resolveTableContextFromEventTarget } from '../tableRuntime/tablePositioning';
 import { openLink } from '../services/markdownRenderer';
 import { DATA_COL, DATA_ROW, DATA_SECTION, SECTION_HEADER, getWidgetSelector } from './domHelpers';
-import { selectAndRequestOpenActiveCell } from '../tableRuntime/activeCell/activeCellOpen';
+import { selectAndRequestOpenResolvedActiveCell } from '../tableRuntime/activeCell/activeCellOpen';
+import { createResolvedActiveCell } from '../tableRuntime/activeCell/activeCellResolver';
 
 function getLinkHrefFromTarget(target: HTMLElement): string | null {
     const link = target.closest('a');
@@ -208,16 +209,17 @@ export function handleTableInteraction(view: EditorView, event: Event): boolean 
             return false;
         }
 
-        const resolvedRange = resolveCellDocRange({
-            tableFrom: ctx.from,
-            ranges: ctx.cellRanges,
-            coords: { section, row, col },
+        const resolvedCell = createResolvedActiveCell({
+            ctx,
+            coords: {
+                section,
+                row: section === SECTION_HEADER ? 0 : row,
+                col,
+            },
         });
-        if (!resolvedRange) {
+        if (!resolvedCell) {
             return false;
         }
-
-        const { editableFrom } = resolvedRange;
 
         event.preventDefault();
         event.stopPropagation();
@@ -236,16 +238,10 @@ export function handleTableInteraction(view: EditorView, event: Event): boolean 
             }
         }
 
-        selectAndRequestOpenActiveCell(view, {
-            activeCell: {
-                tableFrom: ctx.from,
-                section,
-                row: section === SECTION_HEADER ? 0 : row,
-                col,
-            },
+        selectAndRequestOpenResolvedActiveCell(view, {
+            resolvedCell,
             clearCellSelection: hasSelection,
             normalizeIfNeeded: true,
-            selectionAnchor: editableFrom,
         });
 
         return true;


### PR DESCRIPTION
- Added resolver helpers in activeCellResolver.ts so current-state code can build a ResolvedActiveCell from TableContext + coords and retarget within the same resolved table without rebuilding partial state manually.
- Added a resolved-cell open wrapper in activeCellOpen.ts and migrated activation, widget interaction, and navigation paths to use it, so editableFrom is now the standard selection anchor for these flows.
- Reworked the nested editor session in nestedEditorController.ts to store resolvedCell: ResolvedActiveCell instead of a duplicate range DTO, and updated lifecycle reads in nestedEditorLifecycle.ts to prefer cached getResolvedActiveCell(state) when the active cell is already in state.
- Updated the architecture docs to make ResolvedActiveCell the documented transient runtime object once a concrete current-state cell has been chosen.
- Fixed regressions with undo/redo cell activation