### PR TITLE
refactor: Table Widget Entry-Point Responsibilities

### DIFF
--- a/docs/Architecture/Overview.md
+++ b/docs/Architecture/Overview.md
@@ -6,7 +6,7 @@ A Joplin plugin that replaces Markdown table syntax with interactive `TableWidge
 
 - `tableModel/`: pure table parsing, serialization, and table math.
 - `tableState/`: CodeMirror `StateField`/`StateEffect` definitions and selectors.
-- `tableRuntime/`: editor-bound orchestration with shared runtime primitives at the root and subdomains for `activeCell/`, `lifecycle/`, `navigation/`, `operations/`, and `selection/`.
+- `tableRuntime/`: editor-bound orchestration with shared runtime primitives at the root and subdomains for `activeCell/`, `interaction/`, `lifecycle/`, `navigation/`, `operations/`, and `selection/`.
 - `tableWidget/`: widget rendering, DOM helpers, widget visuals, and widget-local event handling.
 - `tableCommands/`: Joplin command registration only.
 - `nestedEditor/`: isolated in-cell editor implementation.
@@ -33,18 +33,18 @@ A Joplin plugin that replaces Markdown table syntax with interactive `TableWidge
 
 ## Core Components
 
-| Component     | File                                                            | Purpose                                                    |
-| :------------ | :-------------------------------------------------------------- | :--------------------------------------------------------- |
-| **Wiring**    | `contentScript/tableWidget/tableWidgetExtension.ts`             | Main entry point; connects plugins, styles, commands.      |
-| **Rendering** | `contentScript/tableWidget/TableWidget.ts`                      | HTML rendering, click-to-cell coordinate mapping.          |
-| **Lifecycle** | `contentScript/tableRuntime/lifecycle/nestedEditorLifecycle.ts` | Nested editor open/close state, synchronization triggers.  |
-| **Styles**    | `contentScript/tableWidget/tableStyles.ts`                      | CSS-in-JS for theme consistency.                           |
-| **Editor**    | `contentScript/nestedEditor/nestedEditorController.ts`          | Nested editor mount/sync/close behavior.                   |
-| **Parsing**   | `contentScript/tableModel/MarkdownTable.ts`                     | Normalized table model, parsing, serialization, mutations. |
-| **Context**   | `contentScript/tableModel/tableContext.ts`                      | Shared parsed table + cell ranges + table span.            |
-| **State**     | `contentScript/tableState/activeCellState.ts`                   | Logical active-cell state and effect wiring.               |
-| **Runtime**   | `contentScript/tableRuntime/operations/structuralOperations.ts` | Table mutation orchestration and target-cell rebasing.     |
-| **Toolbar**   | `contentScript/toolbar/tableToolbarPlugin.ts`                   | Floating UI for row/column/alignment actions.              |
+| Component     | File                                                            | Purpose                                                          |
+| :------------ | :-------------------------------------------------------------- | :--------------------------------------------------------------- |
+| **Wiring**    | `contentScript/tableWidget/tableWidgetExtension.ts`             | Main entry point; initializes services and assembles extensions. |
+| **Rendering** | `contentScript/tableWidget/TableWidget.ts`                      | HTML rendering, click-to-cell coordinate mapping.                |
+| **Lifecycle** | `contentScript/tableRuntime/lifecycle/nestedEditorLifecycle.ts` | Nested editor open/close state, synchronization triggers.        |
+| **Styles**    | `contentScript/tableWidget/tableStyles.ts`                      | CSS-in-JS for theme consistency.                                 |
+| **Editor**    | `contentScript/nestedEditor/nestedEditorController.ts`          | Nested editor mount/sync/close behavior.                         |
+| **Parsing**   | `contentScript/tableModel/MarkdownTable.ts`                     | Normalized table model, parsing, serialization, mutations.       |
+| **Context**   | `contentScript/tableModel/tableContext.ts`                      | Shared parsed table + cell ranges + table span.                  |
+| **State**     | `contentScript/tableState/activeCellState.ts`                   | Logical active-cell state and effect wiring.                     |
+| **Runtime**   | `contentScript/tableRuntime/operations/structuralOperations.ts` | Table mutation orchestration and target-cell rebasing.           |
+| **Toolbar**   | `contentScript/toolbar/tableToolbarPlugin.ts`                   | Floating UI for row/column/alignment actions.                    |
 
 ## Data Flow
 

--- a/src/contentScript/nestedEditor/nestedEditorFocusGuard.ts
+++ b/src/contentScript/nestedEditor/nestedEditorFocusGuard.ts
@@ -1,0 +1,20 @@
+import { EditorView } from '@codemirror/view';
+import { getActiveCell } from '../tableState/activeCellState';
+import { isNestedEditorOpen, refocusNestedEditor } from './nestedEditorController';
+
+/**
+ * Defensive focus handler that reclaims focus for the nested editor when it's
+ * unexpectedly stolen (e.g., by Android's focus management after toolbar commands).
+ */
+export const nestedEditorFocusGuard = EditorView.domEventHandlers({
+    focus: (_event, view) => {
+        // If the nested editor is open and should have focus, reclaim it.
+        // This handles cases where Android or other focus management systems
+        // redirect focus to the main editor after toolbar button presses.
+        if (isNestedEditorOpen(view) && getActiveCell(view.state)) {
+            refocusNestedEditor(view);
+            return true;
+        }
+        return false;
+    },
+});

--- a/src/contentScript/tableRuntime/interaction/outsideTableInteraction.ts
+++ b/src/contentScript/tableRuntime/interaction/outsideTableInteraction.ts
@@ -1,0 +1,105 @@
+import { EditorView, ViewPlugin } from '@codemirror/view';
+import { focusMainEditorWithoutScroll } from '../../shared/mainEditorFocus';
+import { CLASS_CELL_EDITOR } from '../../shared/tableDomClasses';
+import { clearActiveCellEffect, getActiveCell } from '../../tableState/activeCellState';
+import { clearCellSelectionEffect, getCellSelection } from '../../tableState/cellSelectionState';
+import { CLASS_FLOATING_TOOLBAR, getWidgetSelector } from '../../tableWidget/domHelpers';
+import { isNestedEditorOpen } from '../../nestedEditor/nestedEditorController';
+
+function getEventTargetElement(event: MouseEvent | PointerEvent): Element | null {
+    const target = event.target;
+    if (!target) return null;
+    if (target instanceof Element) return target;
+    if (target instanceof Node) return target.parentElement;
+    return null;
+}
+
+function handleOutsideTableInteraction(
+    view: EditorView,
+    event: MouseEvent | PointerEvent,
+    options: { preserveContextMenu: boolean }
+): boolean {
+    const target = getEventTargetElement(event);
+    if (!target) {
+        return false;
+    }
+
+    // Keep editor open if interaction is inside the widget or nested editor.
+    if (
+        target.closest(getWidgetSelector()) ||
+        target.closest(`.${CLASS_CELL_EDITOR}`) ||
+        target.closest(`.${CLASS_FLOATING_TOOLBAR}`)
+    ) {
+        return false;
+    }
+
+    const hasActiveCell = Boolean(getActiveCell(view.state));
+    const hasNestedEditor = isNestedEditorOpen(view);
+    const hasCellSelection = Boolean(getCellSelection(view.state));
+    if (!hasActiveCell && !hasNestedEditor && !hasCellSelection) {
+        return false;
+    }
+
+    const clickPos = view.posAtCoords({ x: event.clientX, y: event.clientY });
+
+    if (clickPos !== null) {
+        // On right-click context menus, avoid forcing focus/scroll so the native/Joplin
+        // menu opens against the expected pointer target without viewport jumps.
+        view.dispatch({
+            selection: { anchor: clickPos },
+            effects: [
+                ...(hasActiveCell ? [clearActiveCellEffect.of(undefined)] : []),
+                ...(hasCellSelection ? [clearCellSelectionEffect.of(undefined)] : []),
+            ],
+            scrollIntoView: !options.preserveContextMenu,
+        });
+        if (!options.preserveContextMenu) {
+            view.focus();
+        } else if (hasNestedEditor) {
+            // The nested editor we just destroyed held focus; restore it to the
+            // main editor without scrolling so the caret is painted.
+            focusMainEditorWithoutScroll(view);
+        }
+    } else if (hasActiveCell || hasCellSelection) {
+        view.dispatch({
+            effects: [
+                ...(hasActiveCell ? [clearActiveCellEffect.of(undefined)] : []),
+                ...(hasCellSelection ? [clearCellSelectionEffect.of(undefined)] : []),
+            ],
+        });
+    }
+
+    // For mousedown, consume only if we positioned the cursor.
+    // For contextmenu, never consume so native/Joplin menus can open.
+    return !options.preserveContextMenu && clickPos !== null;
+}
+
+export const closeOnOutsideMouseDown = EditorView.domEventHandlers({
+    mousedown: (event, view) => {
+        return handleOutsideTableInteraction(view, event, { preserveContextMenu: false });
+    },
+});
+
+export const outsideInteractionCapturePlugin = ViewPlugin.fromClass(
+    class {
+        private readonly onContextMenu: (event: MouseEvent) => void;
+
+        constructor(private readonly view: EditorView) {
+            this.onContextMenu = (event) => {
+                // Return value is intentionally ignored for document-level contextmenu.
+                // We only need side effects (close/clear), not event consumption control.
+                handleOutsideTableInteraction(this.view, event, { preserveContextMenu: true });
+            };
+
+            const doc = this.view.dom.ownerDocument;
+            // Register on the document in capture phase so outside right-click interactions
+            // are seen even when Joplin/Electron context menu handlers intercept later in bubbling.
+            doc.addEventListener('contextmenu', this.onContextMenu, true);
+        }
+
+        destroy(): void {
+            const doc = this.view.dom.ownerDocument;
+            doc.removeEventListener('contextmenu', this.onContextMenu, true);
+        }
+    }
+);

--- a/src/contentScript/tableRuntime/startupCursorCorrection.ts
+++ b/src/contentScript/tableRuntime/startupCursorCorrection.ts
@@ -1,0 +1,22 @@
+import type { Extension } from '@codemirror/state';
+import { EditorView, ViewPlugin } from '@codemirror/view';
+import { logger } from '../../logger';
+import { moveCursorOutOfTable } from './navigation/cursorUtils';
+
+export function createStartupCursorCorrection(getView: () => EditorView): Extension {
+    return ViewPlugin.fromClass(
+        class {
+            constructor() {
+                // Move cursor out of table on initial load.
+                // On mobile, the content script loads fresh per note, so this handles note switching.
+                // On desktop, this handles cold launch when Joplin restores cursor position inside a table.
+                setTimeout(() => {
+                    const moved = moveCursorOutOfTable(getView());
+                    if (moved) {
+                        logger.debug('Moved cursor out of table on content script init');
+                    }
+                }, 0);
+            }
+        }
+    );
+}

--- a/src/contentScript/tableWidget/tableDecorationField.ts
+++ b/src/contentScript/tableWidget/tableDecorationField.ts
@@ -1,0 +1,74 @@
+import { EditorState, Range, StateField } from '@codemirror/state';
+import { Decoration, DecorationSet, EditorView } from '@codemirror/view';
+import { logger } from '../../logger';
+import { documentDefinitionsField } from '../services/documentDefinitions';
+import { hashTableText } from '../shared/hashUtils';
+import { buildTableContext } from '../tableModel/tableContext';
+import { findTableRanges } from '../tableRuntime/tablePositioning';
+import { TableWidget } from './TableWidget';
+import { decideTableDecorationUpdate } from './tableDecorationPolicy';
+
+/**
+ * Build decorations for all tables in the document.
+ * Tables are always rendered as widgets - editing happens via nested cell editors.
+ */
+function buildTableDecorations(state: EditorState): DecorationSet {
+    const decorations: Range<Decoration>[] = [];
+    const tables = findTableRanges(state);
+    const definitions = state.field(documentDefinitionsField);
+
+    for (const table of tables) {
+        const ctx = buildTableContext(table);
+        if (!ctx) {
+            continue;
+        }
+
+        // Content hash includes definition block so widgets rebuild when definitions change.
+        const contentHash = hashTableText(table.text + definitions.definitionBlock);
+
+        const widget = new TableWidget(
+            ctx.table,
+            ctx.cellRanges,
+            table.text,
+            table.from,
+            table.to,
+            definitions.definitionBlock,
+            contentHash
+        );
+        const decoration = Decoration.replace({
+            widget,
+            block: true,
+        });
+
+        decorations.push(decoration.range(table.from, table.to));
+    }
+
+    return Decoration.set(decorations);
+}
+
+/**
+ * StateField that manages table widget decorations.
+ * Block decorations MUST be provided via StateField, not ViewPlugin.
+ * Tables are always rendered as widgets (unless source mode is toggled).
+ */
+export const tableDecorationField = StateField.define<DecorationSet>({
+    create(state) {
+        logger.info('Table decoration field initialized');
+        return buildTableDecorations(state);
+    },
+    update(decorations, transaction) {
+        const decision = decideTableDecorationUpdate(transaction);
+
+        switch (decision.type) {
+            case 'noneDecorations':
+                return Decoration.none;
+            case 'keepDecorations':
+                return decorations;
+            case 'mapDecorations':
+                return decorations.map(transaction.changes);
+            case 'rebuildAllDecorations':
+                return buildTableDecorations(transaction.state);
+        }
+    },
+    provide: (field) => EditorView.decorations.from(field),
+});

--- a/src/contentScript/tableWidget/tableWidgetExtension.ts
+++ b/src/contentScript/tableWidget/tableWidgetExtension.ts
@@ -1,30 +1,24 @@
-import { EditorView, Decoration, DecorationSet, ViewPlugin } from '@codemirror/view';
-import { EditorState, Range, StateField } from '@codemirror/state';
+import { EditorView } from '@codemirror/view';
 import type { Facet } from '@codemirror/state';
 import type { ContentScriptContext, CodeMirrorControl } from 'api/types';
-import { TableWidget } from './TableWidget';
-import { buildTableContext } from '../tableModel/tableContext';
 import { initRenderer } from '../services/markdownRenderer';
 import { initNestedEditorFeatureSettings } from '../services/nestedEditorFeatureSettings';
 import { initToolbarSettings } from '../services/toolbarSettings';
 import { documentDefinitionsField } from '../services/documentDefinitions';
 import { logger } from '../../logger';
-import { hashTableText } from '../shared/hashUtils';
-import { CLASS_CELL_EDITOR } from '../shared/tableDomClasses';
-import { activeCellField, clearActiveCellEffect, getActiveCell } from '../tableState/activeCellState';
+import { activeCellField } from '../tableState/activeCellState';
 import { resolvedActiveCellField } from '../tableRuntime/activeCell/resolvedActiveCellField';
-import { cellSelectionField, clearCellSelectionEffect, getCellSelection } from '../tableState/cellSelectionState';
+import { cellSelectionField } from '../tableState/cellSelectionState';
 import { searchForceSourceModeField } from '../tableState/searchForceSourceMode';
 import { sourceModeField } from '../tableState/sourceMode';
 import { cellSelectionClipboardPlugin } from '../tableRuntime/selection/cellSelectionClipboard';
 import { cellSelectionKeyCapturePlugin } from '../tableRuntime/selection/cellSelectionKeymap';
 import { cellSelectionVisualsPlugin } from './cellSelectionVisuals';
-import { isNestedEditorOpen, nestedEditorPlugin, refocusNestedEditor } from '../nestedEditor/nestedEditorController';
+import { isNestedEditorOpen, nestedEditorPlugin } from '../nestedEditor/nestedEditorController';
+import { nestedEditorFocusGuard } from '../nestedEditor/nestedEditorFocusGuard';
 import { createMainEditorActiveCellGuard } from '../editorBridge/mainEditorGuard';
 import { handleTableInteraction } from './tableWidgetInteractions';
-import { findTableRanges } from '../tableRuntime/tablePositioning';
 import { tableToolbarPlugin, tableToolbarTheme } from '../toolbar/tableToolbarPlugin';
-import { CLASS_FLOATING_TOOLBAR, getWidgetSelector } from './domHelpers';
 import { tableStyles } from './tableStyles';
 import { richTableThemeVars } from './richTableThemeVars';
 import { nestedEditorLifecyclePlugin } from '../tableRuntime/lifecycle/nestedEditorLifecycle';
@@ -32,173 +26,13 @@ import { registerTableCommands } from '../tableCommands/tableCommands';
 import { searchPanelWatcherPlugin } from '../tableRuntime/searchPanelWatcher';
 import { navigationLockKeymap } from './navigationLockKeymap';
 import { createNoteIdWatcher } from '../tableRuntime/noteIdWatcher';
-import { moveCursorOutOfTable } from '../tableRuntime/navigation/cursorUtils';
-import { decideTableDecorationUpdate } from './tableDecorationPolicy';
-import { focusMainEditorWithoutScroll } from '../shared/mainEditorFocus';
 import { createUndoScrollPreservation } from '../tableRuntime/undoScrollPreservation';
-
-/**
- * Build decorations for all tables in the document.
- * Tables are always rendered as widgets - editing happens via nested cell editors.
- */
-function buildTableDecorations(state: EditorState): DecorationSet {
-    const decorations: Range<Decoration>[] = [];
-    const tables = findTableRanges(state);
-    const definitions = state.field(documentDefinitionsField);
-
-    for (const table of tables) {
-        const ctx = buildTableContext(table);
-        if (!ctx) {
-            continue;
-        }
-
-        // Content hash includes definition block so widgets rebuild when definitions change.
-        const contentHash = hashTableText(table.text + definitions.definitionBlock);
-
-        const widget = new TableWidget(
-            ctx.table,
-            ctx.cellRanges,
-            table.text,
-            table.from,
-            table.to,
-            definitions.definitionBlock,
-            contentHash
-        );
-        const decoration = Decoration.replace({
-            widget,
-            block: true,
-        });
-
-        decorations.push(decoration.range(table.from, table.to));
-    }
-
-    return Decoration.set(decorations);
-}
-
-/**
- * StateField that manages table widget decorations.
- * Block decorations MUST be provided via StateField, not ViewPlugin.
- * Tables are always rendered as widgets (unless source mode is toggled).
- */
-const tableDecorationField = StateField.define<DecorationSet>({
-    create(state) {
-        logger.info('Table decoration field initialized');
-        return buildTableDecorations(state);
-    },
-    update(decorations, transaction) {
-        const decision = decideTableDecorationUpdate(transaction);
-
-        switch (decision.type) {
-            case 'noneDecorations':
-                return Decoration.none;
-            case 'keepDecorations':
-                return decorations;
-            case 'mapDecorations':
-                return decorations.map(transaction.changes);
-            case 'rebuildAllDecorations':
-                return buildTableDecorations(transaction.state);
-        }
-    },
-    provide: (field) => EditorView.decorations.from(field),
-});
-
-function getEventTargetElement(event: MouseEvent | PointerEvent): Element | null {
-    const target = event.target;
-    if (!target) return null;
-    if (target instanceof Element) return target;
-    if (target instanceof Node) return target.parentElement;
-    return null;
-}
-
-function handleOutsideTableInteraction(
-    view: EditorView,
-    event: MouseEvent | PointerEvent,
-    options: { preserveContextMenu: boolean }
-): boolean {
-    const target = getEventTargetElement(event);
-    if (!target) {
-        return false;
-    }
-
-    // Keep editor open if interaction is inside the widget or nested editor.
-    if (
-        target.closest(getWidgetSelector()) ||
-        target.closest(`.${CLASS_CELL_EDITOR}`) ||
-        target.closest(`.${CLASS_FLOATING_TOOLBAR}`)
-    ) {
-        return false;
-    }
-
-    const hasActiveCell = Boolean(getActiveCell(view.state));
-    const hasNestedEditor = isNestedEditorOpen(view);
-    const hasCellSelection = Boolean(getCellSelection(view.state));
-    if (!hasActiveCell && !hasNestedEditor && !hasCellSelection) {
-        return false;
-    }
-
-    const clickPos = view.posAtCoords({ x: event.clientX, y: event.clientY });
-
-    if (clickPos !== null) {
-        // On right-click context menus, avoid forcing focus/scroll so the native/Joplin
-        // menu opens against the expected pointer target without viewport jumps.
-        view.dispatch({
-            selection: { anchor: clickPos },
-            effects: [
-                ...(hasActiveCell ? [clearActiveCellEffect.of(undefined)] : []),
-                ...(hasCellSelection ? [clearCellSelectionEffect.of(undefined)] : []),
-            ],
-            scrollIntoView: !options.preserveContextMenu,
-        });
-        if (!options.preserveContextMenu) {
-            view.focus();
-        } else if (hasNestedEditor) {
-            // The nested editor we just destroyed held focus; restore it to the
-            // main editor without scrolling so the caret is painted.
-            focusMainEditorWithoutScroll(view);
-        }
-    } else if (hasActiveCell || hasCellSelection) {
-        view.dispatch({
-            effects: [
-                ...(hasActiveCell ? [clearActiveCellEffect.of(undefined)] : []),
-                ...(hasCellSelection ? [clearCellSelectionEffect.of(undefined)] : []),
-            ],
-        });
-    }
-
-    // For mousedown, consume only if we positioned the cursor.
-    // For contextmenu, never consume so native/Joplin menus can open.
-    return !options.preserveContextMenu && clickPos !== null;
-}
-
-const closeOnOutsideMouseDown = EditorView.domEventHandlers({
-    mousedown: (event, view) => {
-        return handleOutsideTableInteraction(view, event, { preserveContextMenu: false });
-    },
-});
-
-const outsideInteractionCapturePlugin = ViewPlugin.fromClass(
-    class {
-        private readonly onContextMenu: (event: MouseEvent) => void;
-
-        constructor(private readonly view: EditorView) {
-            this.onContextMenu = (event) => {
-                // Return value is intentionally ignored for document-level contextmenu.
-                // We only need side effects (close/clear), not event consumption control.
-                handleOutsideTableInteraction(this.view, event, { preserveContextMenu: true });
-            };
-
-            const doc = this.view.dom.ownerDocument;
-            // Register on the document in capture phase so outside right-click interactions
-            // are seen even when Joplin/Electron context menu handlers intercept later in bubbling.
-            doc.addEventListener('contextmenu', this.onContextMenu, true);
-        }
-
-        destroy(): void {
-            const doc = this.view.dom.ownerDocument;
-            doc.removeEventListener('contextmenu', this.onContextMenu, true);
-        }
-    }
-);
+import {
+    closeOnOutsideMouseDown,
+    outsideInteractionCapturePlugin,
+} from '../tableRuntime/interaction/outsideTableInteraction';
+import { createStartupCursorCorrection } from '../tableRuntime/startupCursorCorrection';
+import { tableDecorationField } from './tableDecorationField';
 
 const tableWidgetInteractionHandlers = EditorView.domEventHandlers({
     mousedown: (event, view) => {
@@ -206,23 +40,6 @@ const tableWidgetInteractionHandlers = EditorView.domEventHandlers({
     },
     click: (event, view) => {
         return handleTableInteraction(view, event);
-    },
-});
-
-/**
- * Defensive focus handler that reclaims focus for the nested editor when it's
- * unexpectedly stolen (e.g., by Android's focus management after toolbar commands).
- */
-const nestedEditorFocusGuard = EditorView.domEventHandlers({
-    focus: (_event, view) => {
-        // If the nested editor is open and should have focus, reclaim it.
-        // This handles cases where Android or other focus management systems
-        // redirect focus to the main editor after toolbar button presses.
-        if (isNestedEditorOpen(view) && getActiveCell(view.state)) {
-            refocusNestedEditor(view);
-            return true;
-        }
-        return false;
     },
 });
 
@@ -254,6 +71,7 @@ export default function (context: ContentScriptContext) {
             editorControl.addExtension([
                 // Close nested editor on note switch (detected via noteIdFacet)
                 createNoteIdWatcher(noteIdFacet, () => cm6View),
+                createStartupCursorCorrection(() => cm6View),
                 createUndoScrollPreservation(() => cm6View),
 
                 searchPanelWatcherPlugin,
@@ -283,16 +101,6 @@ export default function (context: ContentScriptContext) {
             ]);
 
             registerTableCommands(editorControl);
-
-            // Move cursor out of table on initial load.
-            // On mobile, the content script loads fresh per note, so this handles note switching.
-            // On desktop, this handles cold launch when Joplin restores cursor position inside a table.
-            setTimeout(() => {
-                const moved = moveCursorOutOfTable(cm6View);
-                if (moved) {
-                    logger.debug('Moved cursor out of table on content script init');
-                }
-            }, 0);
 
             logger.info('Table widget extension registered');
         },


### PR DESCRIPTION
Refactor tableWidgetExtension.ts into a true wiring entry point by moving behavior-owned CodeMirror extensions into named modules