### PR TITLE
refactor: structural command flow

### DIFF
--- a/docs/Architecture/Structural-Commands-and-Serialization.md
+++ b/docs/Architecture/Structural-Commands-and-Serialization.md
@@ -10,9 +10,11 @@ Multi-cell clipboard writes use the same parse -> mutate -> serialize pattern, b
 ```
 User Action (keyboard/toolbar)
          ↓
-    tableCommands.ts           ← Command registration only
+    tableCommands.ts / tableToolbarPlugin.ts ← Resolve active cell once
          ↓
-   operations/structuralOperations.ts   ← Runtime entry points
+   operations/structuralActions.ts      ← Shared action registry
+         ↓
+   operations/structuralOperations.ts   ← Runtime intent entry points
           ↓
    operations/runStructuralMutation.ts ← Parse, mutate, serialize, dispatch
          ↓
@@ -24,8 +26,12 @@ User Action (keyboard/toolbar)
 ### 1. Entry Point (`tableCommands.ts`)
 
 - **Joplin Registration**: `richTables.insertRowBelow`, etc.
-- **Active Cell Validation**: Checks before executing.
-- **Delegation Only**: Dispatches into `tableRuntime/operations/structuralOperations.ts`.
+- **Active Cell Resolution**: Resolves the current active cell once with `getResolvedActiveCell()`.
+- **Delegation Only**: Dispatches through the shared structural action registry.
+
+The floating toolbar follows the same action path. It keeps plain `ActiveCell` state for visibility and positioning,
+but resolves fresh from the current editor state when a toolbar button is clicked so async toolbar layout work does
+not preserve stale table context.
 
 ### 1b. Selection Clipboard Entry (`tableRuntime/selection/cellSelectionClipboard.ts`)
 
@@ -56,9 +62,9 @@ define paragraph-splitting behavior.
 
 ### 2. Runtime Mutation Helpers (`tableRuntime/operations/runStructuralMutation.ts`)
 
-`runStructuralMutation.ts` has one shared preparation core that orchestrates:
+`runStructuralMutation.ts` has one shared preparation core that receives a `ResolvedActiveCell` and orchestrates:
 
-1. **Build Context**: Slice table text → `TableContext` (`MarkdownTable` + `cellRanges`).
+1. **Use Resolved Context**: Reuse the resolved table span, `TableContext`, and logical active cell.
 2. **Mutate**: Call operation function.
 3. **Short-circuit**: Exit on no-op.
 4. **Serialize**: `table.serialize()` → Markdown.
@@ -66,6 +72,9 @@ define paragraph-splitting behavior.
 6. **Dispatch**: `runStructuralMutationAndReopen()` replaces the table range when needed, sets the
    main-editor selection, registers an explicit open-cell request, dispatches its id-only open signal,
    forces a widget rebuild, and can run an immediate post-dispatch callback such as main-editor focus handoff.
+
+`structuralActions.ts` maps shared action IDs to runtime operations so keyboard commands and toolbar buttons do not
+maintain separate operation switchboards.
 
 `structuralOperations.ts` is the intent layer on top of the runner:
 

--- a/src/contentScript/__tests__/tableCommands.test.ts
+++ b/src/contentScript/__tests__/tableCommands.test.ts
@@ -1,9 +1,10 @@
 import { EditorView } from '@codemirror/view';
 import type { ActiveCell } from '../tableState/activeCellState';
-import { resolveActiveCell } from '../tableRuntime/activeCell/resolvedActiveCell';
+import { getResolvedActiveCell, type ResolvedActiveCell } from '../tableRuntime/activeCell/resolvedActiveCell';
 import { runStructuralMutationAndReopen } from '../tableRuntime/operations/runStructuralMutation';
 import type { TargetCell } from '../tableModel/activeCellForTableText';
 import { MarkdownTable } from '../tableModel/MarkdownTable';
+import { registerTableCommands } from '../tableCommands/tableCommands';
 import {
     clearColumn,
     clearRow,
@@ -29,13 +30,13 @@ jest.mock('../tableRuntime/operations/runStructuralMutation', () => ({
     runStructuralMutationAndReopen: jest.fn(),
 }));
 jest.mock('../tableRuntime/activeCell/resolvedActiveCell', () => ({
-    resolveActiveCell: jest.fn(),
+    getResolvedActiveCell: jest.fn(),
 }));
 
 describe('tableCommands (computTargetCell)', () => {
     let mockView: EditorView;
     let mockRunStructuralMutationAndReopen: jest.Mock;
-    let mockResolveActiveCell: jest.Mock;
+    let mockGetResolvedActiveCell: jest.Mock;
 
     beforeEach(() => {
         mockView = {
@@ -45,23 +46,26 @@ describe('tableCommands (computTargetCell)', () => {
         } as unknown as EditorView;
         mockRunStructuralMutationAndReopen = runStructuralMutationAndReopen as jest.Mock;
         mockRunStructuralMutationAndReopen.mockClear();
-        mockResolveActiveCell = resolveActiveCell as jest.Mock;
-        mockResolveActiveCell.mockReset();
+        mockGetResolvedActiveCell = getResolvedActiveCell as jest.Mock;
+        mockGetResolvedActiveCell.mockReset();
     });
 
     // Helper to invoke a command and check the computeTargetCell logic
     const testCommand = (
-        command: (view: EditorView, cell: ActiveCell) => void,
+        command: (view: EditorView, resolvedCell: ResolvedActiveCell) => void,
         startCell: ActiveCell,
         expectedTarget: TargetCell,
         // Optional mocks for old/new table data if logic depends on it (usually doesn't for simple moves)
         mockOldTable: MarkdownTable = {} as MarkdownTable,
         mockNewTable: MarkdownTable = {} as MarkdownTable
     ) => {
-        command(mockView, startCell);
+        const resolvedCell = createResolvedCell(startCell);
+
+        command(mockView, resolvedCell);
 
         expect(mockRunStructuralMutationAndReopen).toHaveBeenCalledTimes(1);
         const params = mockRunStructuralMutationAndReopen.mock.calls[0][0];
+        expect(params.resolvedCell).toBe(resolvedCell);
 
         // Isolate the target computation function
         const computeTargetCell = params.computeTargetCell;
@@ -76,6 +80,24 @@ describe('tableCommands (computTargetCell)', () => {
         row,
         col,
     });
+
+    const createResolvedCell = (activeCell: ActiveCell): ResolvedActiveCell =>
+        ({
+            activeCell,
+            tableFrom: activeCell.tableFrom,
+            tableTo: 100,
+            contentFrom: 0,
+            contentTo: 0,
+            editableFrom: 0,
+            editableTo: 0,
+            ctx: {
+                from: activeCell.tableFrom,
+                to: 100,
+                text: '',
+                table: {} as MarkdownTable,
+                cellRanges: { headers: [], rows: [] },
+            },
+        }) satisfies ResolvedActiveCell;
 
     describe('insertRow', () => {
         it('insertRowAbove (header) -> stay in header', () => {
@@ -120,13 +142,14 @@ describe('tableCommands (computTargetCell)', () => {
 
         it('routes row insertion through runStructuralMutationAndReopen with row defaults', () => {
             const cell = createCell('body', 1, 1);
+            const resolvedCell = createResolvedCell(cell);
 
-            insertRowBelow(mockView, cell);
+            insertRowBelow(mockView, resolvedCell);
 
             expect(mockRunStructuralMutationAndReopen).toHaveBeenCalledWith(
                 expect.objectContaining({
                     view: mockView,
-                    cell,
+                    resolvedCell,
                     initialCursorPos: 'start',
                     afterDispatch: expect.any(Function),
                 })
@@ -160,13 +183,14 @@ describe('tableCommands (computTargetCell)', () => {
 
         it('routes non-row structural operations through shared reopen defaults', () => {
             const cell = createCell('body', 2, 3);
+            const resolvedCell = createResolvedCell(cell);
 
-            insertColumnRight(mockView, cell);
+            insertColumnRight(mockView, resolvedCell);
 
             expect(mockRunStructuralMutationAndReopen).toHaveBeenCalledWith(
                 expect.objectContaining({
                     view: mockView,
-                    cell,
+                    resolvedCell,
                     afterDispatch: expect.any(Function),
                 })
             );
@@ -335,8 +359,9 @@ describe('tableCommands (computTargetCell)', () => {
 
         it('updateAlignment keeps the same target cell and uses reopen dispatch', () => {
             const cell = createCell('body', 2, 1);
+            const resolvedCell = createResolvedCell(cell);
 
-            updateAlignment(mockView, cell, 'center');
+            updateAlignment(mockView, resolvedCell, 'center');
 
             expect(mockRunStructuralMutationAndReopen).toHaveBeenCalledTimes(1);
             const params = mockRunStructuralMutationAndReopen.mock.calls[0][0];
@@ -372,17 +397,68 @@ describe('tableCommands (computTargetCell)', () => {
             } as unknown as EditorView;
             const cell = createCell('body', 1, 0);
             cell.tableFrom = 10;
-            mockResolveActiveCell.mockReturnValue({
-                tableFrom: 10,
-                tableTo: 100,
-            });
+            const resolvedCell = createResolvedCell(cell);
 
-            deleteTable(mockEditorView, cell);
+            deleteTable(mockEditorView, resolvedCell);
 
             expect(dispatchMock).toHaveBeenCalledTimes(1);
             const arg = dispatchMock.mock.calls[0][0];
             expect(arg.changes).toEqual({ from: 10, to: 100, insert: '' });
             expect(arg.effects).toHaveLength(2);
+        });
+    });
+
+    describe('registerTableCommands', () => {
+        function createEditorControl() {
+            const callbacks = new Map<string, (...args: unknown[]) => unknown>();
+            const cm6 = {
+                state: { doc: { length: 0 } },
+                contentDOM: { focus: jest.fn() },
+            } as unknown as EditorView;
+
+            return {
+                callbacks,
+                editorControl: {
+                    editor: cm6,
+                    cm6,
+                    addExtension: jest.fn(),
+                    registerCommand: jest.fn((name: string, callback: (...args: unknown[]) => unknown) => {
+                        callbacks.set(name, callback);
+                    }),
+                },
+            };
+        }
+
+        it('resolves the active cell once before running a structural command', () => {
+            const { callbacks, editorControl } = createEditorControl();
+            const cell = createCell('body', 1, 1);
+            const resolvedCell = createResolvedCell(cell);
+            mockGetResolvedActiveCell.mockReturnValue(resolvedCell);
+            registerTableCommands(editorControl);
+
+            const result = callbacks.get('richTables.addRowBelow')?.();
+
+            expect(result).toBeUndefined();
+            expect(mockGetResolvedActiveCell).toHaveBeenCalledWith(editorControl.cm6.state);
+            expect(mockRunStructuralMutationAndReopen).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    view: editorControl.cm6,
+                    resolvedCell,
+                    initialCursorPos: 'start',
+                })
+            );
+        });
+
+        it('returns false and does not run an action when no active cell resolves', () => {
+            const { callbacks, editorControl } = createEditorControl();
+            mockGetResolvedActiveCell.mockReturnValue(null);
+            registerTableCommands(editorControl);
+
+            const result = callbacks.get('richTables.deleteColumn')?.();
+
+            expect(result).toBe(false);
+            expect(mockGetResolvedActiveCell).toHaveBeenCalledWith(editorControl.cm6.state);
+            expect(mockRunStructuralMutationAndReopen).not.toHaveBeenCalled();
         });
     });
 });

--- a/src/contentScript/__tests__/tableNavigation.test.ts
+++ b/src/contentScript/__tests__/tableNavigation.test.ts
@@ -112,14 +112,18 @@ describe('navigateCell', () => {
             col,
         };
 
-        (getResolvedActiveCell as jest.Mock).mockReturnValue({
+        const resolvedCell = {
             activeCell,
             contentFrom: 10,
             contentTo: 20,
             editableFrom: 10,
             editableTo: 20,
             ctx: currentCtx,
-        });
+        };
+
+        (getResolvedActiveCell as jest.Mock).mockReturnValue(resolvedCell);
+
+        return resolvedCell;
     };
 
     it('should return false if no active cell', () => {
@@ -197,7 +201,7 @@ describe('navigateCell', () => {
 
     it('should add row at end of table with col 0 when Tab (next) with allowRowCreation', () => {
         setupTable(1, 2);
-        setupActiveCell(SECTION_BODY, 0, 1); // Last cell, col 1
+        const resolvedCell = setupActiveCell(SECTION_BODY, 0, 1); // Last cell, col 1
         (insertRowAtBottom as jest.Mock).mockReturnValue(true);
 
         const result = navigateCell(mockView, 'next', { allowRowCreation: true });
@@ -206,7 +210,7 @@ describe('navigateCell', () => {
         expect(result).toBe(true);
         expect(insertRowAtBottom).toHaveBeenCalledWith(
             mockView,
-            expect.anything(),
+            resolvedCell,
             0,
             expect.objectContaining({
                 suppressKeys: true,
@@ -217,14 +221,14 @@ describe('navigateCell', () => {
 
     it('should add row at end of table with same col when Enter (down) with allowRowCreation', () => {
         setupTable(1, 2);
-        setupActiveCell(SECTION_BODY, 0, 1); // Last row, col 1
+        const resolvedCell = setupActiveCell(SECTION_BODY, 0, 1); // Last row, col 1
         (insertRowAtBottom as jest.Mock).mockReturnValue(true);
 
         const result = navigateCell(mockView, 'down', { allowRowCreation: true });
         expect(result).toBe(true);
         expect(insertRowAtBottom).toHaveBeenCalledWith(
             mockView,
-            expect.anything(),
+            resolvedCell,
             1,
             expect.objectContaining({
                 suppressKeys: true,

--- a/src/contentScript/__tests__/tableToolbarPlugin.test.ts
+++ b/src/contentScript/__tests__/tableToolbarPlugin.test.ts
@@ -5,41 +5,19 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import type { EditorView } from '@codemirror/view';
 import type { ActiveCell } from '../tableState/activeCellState';
+import type { ResolvedActiveCell } from '../tableRuntime/activeCell/resolvedActiveCell';
 
-const mockInsertRowAbove = jest.fn();
-const mockInsertRowBelow = jest.fn();
-const mockInsertColumnLeft = jest.fn();
-const mockInsertColumnRight = jest.fn();
-const mockDeleteRow = jest.fn();
-const mockDeleteColumn = jest.fn();
-const mockUpdateAlignment = jest.fn();
-const mockClearRow = jest.fn();
-const mockClearColumn = jest.fn();
-const mockClearTable = jest.fn();
-const mockDeleteTable = jest.fn();
-const mockMoveRowUp = jest.fn();
-const mockMoveRowDown = jest.fn();
-const mockMoveColumnLeft = jest.fn();
-const mockMoveColumnRight = jest.fn();
+const mockGetResolvedActiveCell = jest.fn();
+const mockRunStructuralAction = jest.fn();
 const mockIsNestedEditorOpen = jest.fn();
 const mockRefocusNestedEditor = jest.fn();
 
-jest.mock('../tableRuntime/operations/structuralOperations', () => ({
-    insertRowAbove: mockInsertRowAbove,
-    insertRowBelow: mockInsertRowBelow,
-    insertColumnLeft: mockInsertColumnLeft,
-    insertColumnRight: mockInsertColumnRight,
-    deleteRow: mockDeleteRow,
-    deleteColumn: mockDeleteColumn,
-    updateAlignment: mockUpdateAlignment,
-    clearRow: mockClearRow,
-    clearColumn: mockClearColumn,
-    clearTable: mockClearTable,
-    deleteTable: mockDeleteTable,
-    moveRowUp: mockMoveRowUp,
-    moveRowDown: mockMoveRowDown,
-    moveColumnLeft: mockMoveColumnLeft,
-    moveColumnRight: mockMoveColumnRight,
+jest.mock('../tableRuntime/activeCell/resolvedActiveCell', () => ({
+    getResolvedActiveCell: mockGetResolvedActiveCell,
+}));
+
+jest.mock('../tableRuntime/operations/structuralActions', () => ({
+    runStructuralAction: mockRunStructuralAction,
 }));
 
 jest.mock('../nestedEditor/nestedEditorController', () => ({
@@ -61,7 +39,26 @@ function createCell(): ActiveCell {
 function createView(): EditorView {
     const dom = document.createElement('div');
     document.body.appendChild(dom);
-    return { dom } as unknown as EditorView;
+    return { dom, state: { doc: { length: 0 } } } as unknown as EditorView;
+}
+
+function createResolvedCell(activeCell: ActiveCell): ResolvedActiveCell {
+    return {
+        activeCell,
+        tableFrom: activeCell.tableFrom,
+        tableTo: 100,
+        contentFrom: 0,
+        contentTo: 0,
+        editableFrom: 0,
+        editableTo: 0,
+        ctx: {
+            from: activeCell.tableFrom,
+            to: 100,
+            text: '',
+            table: {},
+            cellRanges: { headers: [], rows: [] },
+        },
+    } as unknown as ResolvedActiveCell;
 }
 
 function getToolbarButton(plugin: TableToolbarPlugin, ariaLabel: string): HTMLButtonElement {
@@ -96,15 +93,18 @@ describe('tableToolbarPlugin', () => {
         const view = createView();
         const plugin = new TableToolbarPlugin(view);
         const cell = createCell();
+        const resolvedCell = createResolvedCell(cell);
 
         setCurrentActiveCell(plugin, cell);
         createToolbarButtons(plugin);
-        mockMoveRowUp.mockReturnValue(false);
+        mockGetResolvedActiveCell.mockReturnValue(resolvedCell);
+        mockRunStructuralAction.mockReturnValue(false);
         mockIsNestedEditorOpen.mockReturnValue(true);
 
         getToolbarButton(plugin, 'Move row up').click();
 
-        expect(mockMoveRowUp).toHaveBeenCalledWith(view, cell);
+        expect(mockGetResolvedActiveCell).toHaveBeenCalledWith(view.state);
+        expect(mockRunStructuralAction).toHaveBeenCalledWith(view, 'moveRowUp', resolvedCell);
         expect(mockRefocusNestedEditor).toHaveBeenCalledWith(view);
 
         plugin.destroy();
@@ -114,16 +114,36 @@ describe('tableToolbarPlugin', () => {
         const view = createView();
         const plugin = new TableToolbarPlugin(view);
         const cell = createCell();
+        const resolvedCell = createResolvedCell(cell);
 
         setCurrentActiveCell(plugin, cell);
         createToolbarButtons(plugin);
-        mockMoveRowUp.mockReturnValue(true);
+        mockGetResolvedActiveCell.mockReturnValue(resolvedCell);
+        mockRunStructuralAction.mockReturnValue(true);
         mockIsNestedEditorOpen.mockReturnValue(true);
 
         getToolbarButton(plugin, 'Move row up').click();
 
-        expect(mockMoveRowUp).toHaveBeenCalledWith(view, cell);
+        expect(mockRunStructuralAction).toHaveBeenCalledWith(view, 'moveRowUp', resolvedCell);
         expect(mockRefocusNestedEditor).not.toHaveBeenCalled();
+
+        plugin.destroy();
+    });
+
+    it('does not run a toolbar action when the active cell no longer resolves', () => {
+        const view = createView();
+        const plugin = new TableToolbarPlugin(view);
+
+        setCurrentActiveCell(plugin, createCell());
+        createToolbarButtons(plugin);
+        mockGetResolvedActiveCell.mockReturnValue(null);
+        mockIsNestedEditorOpen.mockReturnValue(true);
+
+        getToolbarButton(plugin, 'Move row up').click();
+
+        expect(mockGetResolvedActiveCell).toHaveBeenCalledWith(view.state);
+        expect(mockRunStructuralAction).not.toHaveBeenCalled();
+        expect(mockRefocusNestedEditor).toHaveBeenCalledWith(view);
 
         plugin.destroy();
     });

--- a/src/contentScript/__tests__/tableTransactionHelpers.test.ts
+++ b/src/contentScript/__tests__/tableTransactionHelpers.test.ts
@@ -1,5 +1,5 @@
-import { beforeEach, describe, expect, it, jest } from '@jest/globals';
-import { resolveActiveCell } from '../tableRuntime/activeCell/resolvedActiveCell';
+import { describe, expect, it, jest } from '@jest/globals';
+import type { ResolvedActiveCell } from '../tableRuntime/activeCell/resolvedActiveCell';
 import type { ActiveCell } from '../tableState/activeCellState';
 import { MarkdownTable } from '../tableModel/MarkdownTable';
 import { computeMarkdownTableCellRanges } from '../tableModel/markdownTableCellRanges';
@@ -9,10 +9,6 @@ import { rebuildTableWidgetsEffect } from '../tableState/tableWidgetEffects';
 import { requestOpenCellEffect } from '../tableRuntime/openCellRequest';
 import { createActiveCellForTableText } from '../tableRuntime/activeCell/activeCellFactory';
 import { beginOpenCellRequestEffect } from '../tableRuntime/openCellRequest';
-
-jest.mock('../tableRuntime/activeCell/resolvedActiveCell', () => ({
-    resolveActiveCell: jest.fn(),
-}));
 
 describe('tableTransactionHelpers', () => {
     let currentTableText = '';
@@ -37,28 +33,30 @@ describe('tableTransactionHelpers', () => {
         } satisfies ActiveCell;
     }
 
-    beforeEach(() => {
-        (resolveActiveCell as jest.Mock).mockImplementation((...args: unknown[]) => {
-            const cell = args[1] as ActiveCell;
+    function createResolvedCell(cell: ActiveCell): ResolvedActiveCell {
+        const table = MarkdownTable.parse(currentTableText);
+        const cellRanges = computeMarkdownTableCellRanges(currentTableText);
+        if (!table || !cellRanges) {
+            throw new Error('Expected valid table fixture');
+        }
 
-            return {
-                activeCell: cell,
-                tableFrom: 0,
-                tableTo: currentTableText.length,
-                contentFrom: 0,
-                contentTo: 0,
-                editableFrom: 0,
-                editableTo: 0,
-                ctx: {
-                    from: 0,
-                    to: currentTableText.length,
-                    text: currentTableText,
-                    table: MarkdownTable.parse(currentTableText),
-                    cellRanges: computeMarkdownTableCellRanges(currentTableText),
-                },
-            };
-        });
-    });
+        return {
+            activeCell: cell,
+            tableFrom: 0,
+            tableTo: currentTableText.length,
+            contentFrom: 0,
+            contentTo: 0,
+            editableFrom: 0,
+            editableTo: 0,
+            ctx: {
+                from: 0,
+                to: currentTableText.length,
+                text: currentTableText,
+                table,
+                cellRanges,
+            },
+        };
+    }
 
     it('dispatches an explicit reopen transaction for row insertion', () => {
         const tableText = ['| H1 | H2 |', '| --- | --- |', '| a | b |'].join('\n');
@@ -78,7 +76,7 @@ describe('tableTransactionHelpers', () => {
 
         const result = runStructuralMutationAndReopen({
             view: view as never,
-            cell,
+            resolvedCell: createResolvedCell(cell),
             operation: (table) => table.insertRowRelativeTo('body', 0, 'after'),
             computeTargetCell: () => ({ section: 'body', row: 1, col: 1 }),
             initialCursorPos: 'start',
@@ -129,7 +127,7 @@ describe('tableTransactionHelpers', () => {
 
         const result = runStructuralMutationAndReopen({
             view: view as never,
-            cell,
+            resolvedCell: createResolvedCell(cell),
             operation: (table) => table,
             computeTargetCell: () => ({ section: 'body', row: 0, col: 1 }),
             afterDispatch,
@@ -147,7 +145,7 @@ describe('tableTransactionHelpers', () => {
 
         const result = runStructuralMutationAndReopen({
             view: view as never,
-            cell,
+            resolvedCell: createResolvedCell(cell),
             operation: (table) => table.moveRow('body', 1, 'up'),
             computeTargetCell: () => ({ section: 'body', row: 0, col: 0 }),
         });
@@ -187,7 +185,7 @@ describe('tableTransactionHelpers', () => {
 
         const result = runStructuralMutationAndReopen({
             view: view as never,
-            cell,
+            resolvedCell: createResolvedCell(cell),
             operation: (table, currentCell) => table.updateColumnAlignment(currentCell.col, 'center'),
             computeTargetCell: () => ({ section: 'body', row: 0, col: 0 }),
         });

--- a/src/contentScript/tableCommands/tableCommands.ts
+++ b/src/contentScript/tableCommands/tableCommands.ts
@@ -1,24 +1,8 @@
 import { EditorView } from '@codemirror/view';
-import { getActiveCell, type ActiveCell } from '../tableState/activeCellState';
 import { toggleSourceMode } from '../tableRuntime/sourceModeController';
-import {
-    clearColumn,
-    clearRow,
-    clearTable,
-    deleteColumn,
-    deleteRow,
-    deleteTable,
-    insertColumnLeft,
-    insertColumnRight,
-    insertRowAbove,
-    insertRowBelow,
-    moveColumnLeft,
-    moveColumnRight,
-    moveRowDown,
-    moveRowUp,
-    updateAlignment,
-    insertTableAndActivate,
-} from '../tableRuntime/operations/structuralOperations';
+import { insertTableAndActivate } from '../tableRuntime/operations/structuralOperations';
+import { getResolvedActiveCell } from '../tableRuntime/activeCell/resolvedActiveCell';
+import { runStructuralAction, type StructuralActionId } from '../tableRuntime/operations/structuralActions';
 
 /**
  * Editor control interface provided by Joplin
@@ -31,36 +15,35 @@ interface EditorControl {
 }
 
 export function registerTableCommands(editorControl: EditorControl): void {
-    // Wrapper to reduce boilerplate for commands requiring an active cell
-    const registerCellCommand = (name: string, action: (view: EditorView, cell: ActiveCell) => boolean) => {
+    const registerCellCommand = (name: string, actionId: StructuralActionId) => {
         editorControl.registerCommand(name, () => {
-            const cell = getActiveCell(editorControl.cm6.state);
-            if (!cell) return false;
-            return action(editorControl.cm6, cell);
+            const resolvedCell = getResolvedActiveCell(editorControl.cm6.state);
+            if (!resolvedCell) return false;
+            return runStructuralAction(editorControl.cm6, actionId, resolvedCell);
         });
     };
 
     // Register table manipulation commands
-    registerCellCommand('richTables.addRowAbove', insertRowAbove);
-    registerCellCommand('richTables.addRowBelow', insertRowBelow);
-    registerCellCommand('richTables.addColumnLeft', insertColumnLeft);
-    registerCellCommand('richTables.addColumnRight', insertColumnRight);
-    registerCellCommand('richTables.deleteRow', deleteRow);
-    registerCellCommand('richTables.deleteColumn', deleteColumn);
+    registerCellCommand('richTables.addRowAbove', 'insertRowBefore');
+    registerCellCommand('richTables.addRowBelow', 'insertRowAfter');
+    registerCellCommand('richTables.addColumnLeft', 'insertColumnBefore');
+    registerCellCommand('richTables.addColumnRight', 'insertColumnAfter');
+    registerCellCommand('richTables.deleteRow', 'deleteRow');
+    registerCellCommand('richTables.deleteColumn', 'deleteColumn');
 
-    registerCellCommand('richTables.alignLeft', (v, c) => updateAlignment(v, c, 'left'));
-    registerCellCommand('richTables.alignRight', (v, c) => updateAlignment(v, c, 'right'));
-    registerCellCommand('richTables.alignCenter', (v, c) => updateAlignment(v, c, 'center'));
+    registerCellCommand('richTables.alignLeft', 'alignLeft');
+    registerCellCommand('richTables.alignRight', 'alignRight');
+    registerCellCommand('richTables.alignCenter', 'alignCenter');
 
-    registerCellCommand('richTables.moveRowUp', moveRowUp);
-    registerCellCommand('richTables.moveRowDown', moveRowDown);
-    registerCellCommand('richTables.moveColumnLeft', moveColumnLeft);
-    registerCellCommand('richTables.moveColumnRight', moveColumnRight);
+    registerCellCommand('richTables.moveRowUp', 'moveRowUp');
+    registerCellCommand('richTables.moveRowDown', 'moveRowDown');
+    registerCellCommand('richTables.moveColumnLeft', 'moveColumnLeft');
+    registerCellCommand('richTables.moveColumnRight', 'moveColumnRight');
 
-    registerCellCommand('richTables.clearRow', clearRow);
-    registerCellCommand('richTables.clearColumn', clearColumn);
-    registerCellCommand('richTables.clearTable', clearTable);
-    registerCellCommand('richTables.deleteTable', deleteTable);
+    registerCellCommand('richTables.clearRow', 'clearRow');
+    registerCellCommand('richTables.clearColumn', 'clearColumn');
+    registerCellCommand('richTables.clearTable', 'clearTable');
+    registerCellCommand('richTables.deleteTable', 'deleteTable');
 
     // Register insert table command that activates the first cell
     editorControl.registerCommand('richTables.insertTableAndActivate', () => {

--- a/src/contentScript/tableRuntime/navigation/tableNavigation.ts
+++ b/src/contentScript/tableRuntime/navigation/tableNavigation.ts
@@ -1,17 +1,24 @@
 import { EditorView } from '@codemirror/view';
-import type { ActiveCell } from '../../tableState/activeCellState';
-import { getResolvedActiveCell, resolveCellWithinResolvedTable } from '../activeCell/resolvedActiveCell';
+import {
+    getResolvedActiveCell,
+    resolveCellWithinResolvedTable,
+    type ResolvedActiveCell,
+} from '../activeCell/resolvedActiveCell';
 import { insertRowAtBottom } from '../operations/structuralOperations';
 import { type CellCoords } from '../../tableModel/types';
 import { SECTION_BODY, SECTION_HEADER } from '../../tableWidget/domHelpers';
 import { requestOpenCell, shouldSuppressNavigationKeys } from '../openCellRequest';
 
-function insertRowFromKeyboardNavigation(view: EditorView, activeCell: ActiveCell, targetCol: number): boolean {
+function insertRowFromKeyboardNavigation(
+    view: EditorView,
+    resolvedActiveCell: ResolvedActiveCell,
+    targetCol: number
+): boolean {
     if (shouldSuppressNavigationKeys(view.state)) {
         return true; // Already locked
     }
 
-    insertRowAtBottom(view, activeCell, targetCol, {
+    insertRowAtBottom(view, resolvedActiveCell, targetCol, {
         suppressKeys: true,
     });
 
@@ -81,7 +88,7 @@ export function navigateCell(
         if (options.allowRowCreation) {
             // Tab ('next') goes to first col, Enter/down stays in same col
             const targetCol = direction === 'next' ? 0 : activeCell.col;
-            return insertRowFromKeyboardNavigation(view, activeCell, targetCol);
+            return insertRowFromKeyboardNavigation(view, resolvedActiveCell, targetCol);
         }
         // Walked off end of table
         return true;

--- a/src/contentScript/tableRuntime/operations/runStructuralMutation.ts
+++ b/src/contentScript/tableRuntime/operations/runStructuralMutation.ts
@@ -5,7 +5,7 @@ import { MarkdownTable } from '../../tableModel/MarkdownTable';
 import type { TargetCell } from '../../tableModel/activeCellForTableText';
 import { prepareOpenCellRequestTransaction } from '../openCellRequest';
 import { createActiveCellForTableText } from '../activeCell/activeCellFactory';
-import { resolveActiveCell } from '../activeCell/resolvedActiveCell';
+import type { ResolvedActiveCell } from '../activeCell/resolvedActiveCell';
 
 function isSameCellCoords(a: ActiveCell, b: ActiveCell): boolean {
     return a.section === b.section && a.row === b.row && a.col === b.col;
@@ -13,7 +13,7 @@ function isSameCellCoords(a: ActiveCell, b: ActiveCell): boolean {
 
 interface StructuralMutationPreparationParams {
     view: EditorView;
-    cell: ActiveCell;
+    resolvedCell: ResolvedActiveCell;
     operation: (table: MarkdownTable, cell: ActiveCell) => MarkdownTable;
     computeTargetCell: (cell: ActiveCell, oldTable: MarkdownTable, newTable: MarkdownTable) => TargetCell;
 }
@@ -37,10 +37,8 @@ interface PreparedStructuralMutation {
 }
 
 function prepareStructuralMutation(params: StructuralMutationPreparationParams): PreparedStructuralMutation | null {
-    const { view, cell, operation, computeTargetCell } = params;
-    const resolvedCell = resolveActiveCell(view.state, cell);
-    if (!resolvedCell) return null;
-
+    const { resolvedCell, operation, computeTargetCell } = params;
+    const cell = resolvedCell.activeCell;
     const { tableFrom, tableTo, ctx } = resolvedCell;
     const text = ctx.text;
 

--- a/src/contentScript/tableRuntime/operations/structuralActions.ts
+++ b/src/contentScript/tableRuntime/operations/structuralActions.ts
@@ -1,0 +1,68 @@
+import type { EditorView } from '@codemirror/view';
+import type { ResolvedActiveCell } from '../activeCell/resolvedActiveCell';
+import {
+    clearColumn,
+    clearRow,
+    clearTable,
+    deleteColumn,
+    deleteRow,
+    deleteTable,
+    insertColumnLeft,
+    insertColumnRight,
+    insertRowAbove,
+    insertRowBelow,
+    moveColumnLeft,
+    moveColumnRight,
+    moveRowDown,
+    moveRowUp,
+    updateAlignment,
+} from './structuralOperations';
+
+export type StructuralActionId =
+    | 'insertRowBefore'
+    | 'insertRowAfter'
+    | 'deleteRow'
+    | 'insertColumnBefore'
+    | 'insertColumnAfter'
+    | 'deleteColumn'
+    | 'deleteTable'
+    | 'moveRowUp'
+    | 'moveRowDown'
+    | 'moveColumnLeft'
+    | 'moveColumnRight'
+    | 'clearRow'
+    | 'clearColumn'
+    | 'clearTable'
+    | 'alignLeft'
+    | 'alignCenter'
+    | 'alignRight';
+
+type StructuralActionHandler = (view: EditorView, resolvedCell: ResolvedActiveCell) => boolean;
+
+export const structuralActions: Record<StructuralActionId, StructuralActionHandler> = {
+    insertRowBefore: insertRowAbove,
+    insertRowAfter: insertRowBelow,
+    deleteRow,
+    insertColumnBefore: insertColumnLeft,
+    insertColumnAfter: insertColumnRight,
+    deleteColumn,
+    deleteTable,
+    moveRowUp,
+    moveRowDown,
+    moveColumnLeft,
+    moveColumnRight,
+    clearRow,
+    clearColumn,
+    clearTable,
+    alignLeft: (view, resolvedCell) => updateAlignment(view, resolvedCell, 'left'),
+    alignCenter: (view, resolvedCell) => updateAlignment(view, resolvedCell, 'center'),
+    alignRight: (view, resolvedCell) => updateAlignment(view, resolvedCell, 'right'),
+};
+
+export function runStructuralAction(
+    view: EditorView,
+    actionId: StructuralActionId,
+    resolvedCell: ResolvedActiveCell
+): boolean {
+    return structuralActions[actionId](view, resolvedCell);
+}

--- a/src/contentScript/tableRuntime/operations/structuralOperations.ts
+++ b/src/contentScript/tableRuntime/operations/structuralOperations.ts
@@ -3,7 +3,7 @@ import { clearActiveCellEffect, type ActiveCell } from '../../tableState/activeC
 import { rebuildTableWidgetsEffect } from '../../tableState/tableWidgetEffects';
 import { MarkdownTable, type TableAlignment } from '../../tableModel/MarkdownTable';
 import type { TargetCell } from '../../tableModel/activeCellForTableText';
-import { resolveActiveCell } from '../activeCell/resolvedActiveCell';
+import type { ResolvedActiveCell } from '../activeCell/resolvedActiveCell';
 import { activateTableCell } from '../activeCell/cellActivation';
 import { focusMainEditorWithoutScroll } from '../../shared/mainEditorFocus';
 import { buildIsolatedRootTableInsertRewrite } from './rootTableInsertRewrite';
@@ -76,10 +76,10 @@ function createReopeningStructuralOperation(
     operation: (table: MarkdownTable, cell: ActiveCell) => MarkdownTable,
     computeTargetCell: (cell: ActiveCell, oldTable: MarkdownTable, newTable: MarkdownTable) => TargetCell
 ) {
-    return (view: EditorView, cell: ActiveCell, options?: StructuralReopenOptions): boolean =>
+    return (view: EditorView, resolvedCell: ResolvedActiveCell, options?: StructuralReopenOptions): boolean =>
         runStructuralMutationAndReopen({
             view,
-            cell,
+            resolvedCell,
             operation,
             computeTargetCell,
             ...getDefaultStructuralReopenOptions(view),
@@ -91,10 +91,10 @@ function createRowInsertOperation(
     operation: (table: MarkdownTable, cell: ActiveCell) => MarkdownTable,
     computeTargetCell: (cell: ActiveCell, oldTable: MarkdownTable, newTable: MarkdownTable) => TargetCell
 ) {
-    return (view: EditorView, cell: ActiveCell, options?: RowInsertOpenOptions): boolean =>
+    return (view: EditorView, resolvedCell: ResolvedActiveCell, options?: RowInsertOpenOptions): boolean =>
         runStructuralMutationAndReopen({
             view,
-            cell,
+            resolvedCell,
             operation,
             computeTargetCell,
             ...getDefaultRowInsertOpenOptions(view),
@@ -167,12 +167,7 @@ export const clearColumn = createReopeningStructuralOperation(
     (cell) => sameCell(cell)
 );
 
-export function deleteTable(view: EditorView, cell: ActiveCell): boolean {
-    const resolvedCell = resolveActiveCell(view.state, cell);
-    if (!resolvedCell) {
-        return false;
-    }
-
+export function deleteTable(view: EditorView, resolvedCell: ResolvedActiveCell): boolean {
     view.dispatch({
         changes: { from: resolvedCell.tableFrom, to: resolvedCell.tableTo, insert: '' },
         effects: [
@@ -188,13 +183,13 @@ export function deleteTable(view: EditorView, cell: ActiveCell): boolean {
 
 export function updateAlignment(
     view: EditorView,
-    cell: ActiveCell,
+    resolvedCell: ResolvedActiveCell,
     align: CommandColumnAlignment,
     options?: StructuralReopenOptions
 ): boolean {
     return runStructuralMutationAndReopen({
         view,
-        cell,
+        resolvedCell,
         operation: (table, currentCell) => table.updateColumnAlignment(currentCell.col, align),
         computeTargetCell: (currentCell) => sameCell(currentCell),
         ...getDefaultStructuralReopenOptions(view),
@@ -204,13 +199,13 @@ export function updateAlignment(
 
 export function insertRowAtBottom(
     view: EditorView,
-    cell: ActiveCell,
+    resolvedCell: ResolvedActiveCell,
     targetCol: number,
     options?: RowInsertOpenOptions
 ): boolean {
     return runStructuralMutationAndReopen({
         view,
-        cell,
+        resolvedCell,
         operation: (table, currentCell) => table.insertRowRelativeTo(currentCell.section, currentCell.row, 'after'),
         computeTargetCell: (currentCell) => targetInsertedRowAtBottom(currentCell, targetCol),
         ...getDefaultRowInsertOpenOptions(view),

--- a/src/contentScript/toolbar/tableToolbarPlugin.ts
+++ b/src/contentScript/toolbar/tableToolbarPlugin.ts
@@ -1,22 +1,5 @@
 import { ViewPlugin, ViewUpdate, EditorView } from '@codemirror/view';
 import { activeCellField, type ActiveCell } from '../tableState/activeCellState';
-import {
-    insertRowAbove,
-    insertRowBelow,
-    insertColumnLeft,
-    insertColumnRight,
-    deleteRow,
-    deleteColumn,
-    updateAlignment,
-    clearRow,
-    clearColumn,
-    clearTable,
-    deleteTable,
-    moveRowUp,
-    moveRowDown,
-    moveColumnLeft,
-    moveColumnRight,
-} from '../tableRuntime/operations/structuralOperations';
 import { computePosition, autoUpdate, offset, shift, hide } from '@floating-ui/dom';
 import { syncAnnotation } from '../editorBridge/syncAnnotation';
 import { rebuildTableWidgetsEffect } from '../tableState/tableWidgetEffects';
@@ -27,6 +10,8 @@ import { getToolbarSettings, waitForToolbarSettings } from '../services/toolbarS
 import { getToolbarButtonGroups, renderToolbarButtonGroups, type ToolbarActionId } from './toolbarLayout';
 import { getDocumentWindow, getViewDocument } from '../shared/domContext';
 import { isNestedEditorOpen, refocusNestedEditor } from '../nestedEditor/nestedEditorController';
+import { getResolvedActiveCell } from '../tableRuntime/activeCell/resolvedActiveCell';
+import { runStructuralAction } from '../tableRuntime/operations/structuralActions';
 
 export class TableToolbarPlugin {
     dom: HTMLElement;
@@ -162,42 +147,12 @@ export class TableToolbarPlugin {
                 return false;
             }
 
-            switch (actionId) {
-                case 'insertRowBefore':
-                    return insertRowAbove(this.view, this.currentActiveCell);
-                case 'insertRowAfter':
-                    return insertRowBelow(this.view, this.currentActiveCell);
-                case 'deleteRow':
-                    return deleteRow(this.view, this.currentActiveCell);
-                case 'insertColumnBefore':
-                    return insertColumnLeft(this.view, this.currentActiveCell);
-                case 'insertColumnAfter':
-                    return insertColumnRight(this.view, this.currentActiveCell);
-                case 'deleteColumn':
-                    return deleteColumn(this.view, this.currentActiveCell);
-                case 'deleteTable':
-                    return deleteTable(this.view, this.currentActiveCell);
-                case 'moveRowUp':
-                    return moveRowUp(this.view, this.currentActiveCell);
-                case 'moveRowDown':
-                    return moveRowDown(this.view, this.currentActiveCell);
-                case 'moveColumnLeft':
-                    return moveColumnLeft(this.view, this.currentActiveCell);
-                case 'moveColumnRight':
-                    return moveColumnRight(this.view, this.currentActiveCell);
-                case 'clearRow':
-                    return clearRow(this.view, this.currentActiveCell);
-                case 'clearColumn':
-                    return clearColumn(this.view, this.currentActiveCell);
-                case 'clearTable':
-                    return clearTable(this.view, this.currentActiveCell);
-                case 'alignLeft':
-                    return updateAlignment(this.view, this.currentActiveCell, 'left');
-                case 'alignCenter':
-                    return updateAlignment(this.view, this.currentActiveCell, 'center');
-                case 'alignRight':
-                    return updateAlignment(this.view, this.currentActiveCell, 'right');
+            const resolvedCell = getResolvedActiveCell(this.view.state);
+            if (!resolvedCell) {
+                return false;
             }
+
+            return runStructuralAction(this.view, actionId, resolvedCell);
         };
     }
 

--- a/src/contentScript/toolbar/toolbarLayout.ts
+++ b/src/contentScript/toolbar/toolbarLayout.ts
@@ -16,25 +16,9 @@ import {
     rowInsertTopIcon,
     rowRemoveIcon,
 } from './icons';
+import type { StructuralActionId } from '../tableRuntime/operations/structuralActions';
 
-export type ToolbarActionId =
-    | 'insertRowBefore'
-    | 'insertRowAfter'
-    | 'deleteRow'
-    | 'insertColumnBefore'
-    | 'insertColumnAfter'
-    | 'deleteColumn'
-    | 'deleteTable'
-    | 'moveRowUp'
-    | 'moveRowDown'
-    | 'moveColumnLeft'
-    | 'moveColumnRight'
-    | 'clearRow'
-    | 'clearColumn'
-    | 'clearTable'
-    | 'alignLeft'
-    | 'alignCenter'
-    | 'alignRight';
+export type ToolbarActionId = StructuralActionId;
 
 export interface ToolbarButtonDescriptor {
     actionId: ToolbarActionId;


### PR DESCRIPTION
Refactor structural table commands so every user entry point follows one flow:

keyboard/toolbar action -> resolve active cell once -> run shared structural action -> mutate/serialize/reopen

This will align structural commands with the navigation flow, use the cached resolvedActiveCellField where available, and remove duplicated keyboard/toolbar action mapping.