### PR TITLE
Refactor table positioning and active cell resolution

### DIFF
--- a/docs/Architecture/Overview.md
+++ b/docs/Architecture/Overview.md
@@ -99,6 +99,10 @@ This is the shared derived object used across widget rendering, table interactio
 navigation, and command helpers so the plugin does not repeatedly run separate
 resolve -> parse -> compute-ranges chains for the same table content.
 
+`tableRuntime/tableResolution.ts` owns generic syntax-tree table lookup and cell-range
+resolution. `tableRuntime/tablePositioning.ts` is limited to DOM/event target fallback
+resolution for widget interactions.
+
 The active-cell resolver builds on `TableContext` and is the only supported way to
 derive current table/cell offsets for the persisted logical active-cell state.
 Once current-state code has a concrete active cell, it should pass `ResolvedActiveCell`

--- a/src/contentScript/__tests__/cellSelectionClipboard.test.ts
+++ b/src/contentScript/__tests__/cellSelectionClipboard.test.ts
@@ -168,6 +168,20 @@ describe('cellSelectionClipboard', () => {
         });
     });
 
+    it('returns no active-cell paste anchor when the nested editor cell no longer resolves', () => {
+        let state = createMarkdownState(doc, [activeCellField]);
+        state = state.update({
+            effects: setActiveCellEffect.of({
+                tableFrom: 0,
+                section: 'body',
+                row: 0,
+                col: 99,
+            }),
+        }).state;
+
+        expect(resolveTableClipboardTarget(state, { nestedEditorOpen: true })).toBeNull();
+    });
+
     it('returns no anchor when neither a selection nor open nested editor is available', () => {
         const state = createMarkdownState(doc, [activeCellField]);
 

--- a/src/contentScript/__tests__/cellSelectionKeymap.test.ts
+++ b/src/contentScript/__tests__/cellSelectionKeymap.test.ts
@@ -10,8 +10,9 @@ import { history } from '@codemirror/commands';
 import { markdown } from '@codemirror/lang-markdown';
 import { EditorView } from '@codemirror/view';
 import { GFM } from '@lezer/markdown';
-import { activeCellField, getActiveCell } from '../tableState/activeCellState';
+import { activeCellField, getActiveCell, setActiveCellEffect } from '../tableState/activeCellState';
 import { setCellSelectionEffect, getCellSelection, cellSelectionField } from '../tableState/cellSelectionState';
+import { startCellSelectionFromActiveCell } from '../tableRuntime/selection/cellSelectionController';
 import { cellSelectionKeyCapturePlugin } from '../tableRuntime/selection/cellSelectionKeymap';
 import { requestOpenCellEffect } from '../tableRuntime/openCellRequest';
 
@@ -275,6 +276,61 @@ describe('cellSelectionKeymap', () => {
         const lastSpec = dispatchSpy.mock.calls[dispatchSpy.mock.calls.length - 1]?.[0];
         const effects = Array.isArray(lastSpec?.effects) ? lastSpec.effects : [lastSpec?.effects];
         expect(effects.some((effect) => effect?.is?.(requestOpenCellEffect))).toBe(true);
+
+        view.destroy();
+    });
+
+    it('starts cell selection from a resolved active cell', () => {
+        const parent = document.createElement('div');
+        document.body.appendChild(parent);
+
+        const view = new EditorView({
+            parent,
+            extensions: [markdownExtension, activeCellField, cellSelectionField],
+            doc: ['| H1 | H2 |', '| --- | --- |', '| a1 | a2 |'].join('\n'),
+        });
+        view.dispatch({
+            effects: setActiveCellEffect.of({
+                tableFrom: 0,
+                section: 'body',
+                row: 0,
+                col: 0,
+            }),
+        });
+
+        expect(startCellSelectionFromActiveCell(view, 'right')).toBe(true);
+        expect(getActiveCell(view.state)).toBeNull();
+        expect(getCellSelection(view.state)).toEqual({
+            tableFrom: 0,
+            anchor: { section: 'body', row: 0, col: 0 },
+            focus: { section: 'body', row: 0, col: 1 },
+        });
+
+        view.destroy();
+    });
+
+    it('does not start cell selection from a stale active cell', () => {
+        const parent = document.createElement('div');
+        document.body.appendChild(parent);
+
+        const view = new EditorView({
+            parent,
+            extensions: [markdownExtension, activeCellField, cellSelectionField],
+            doc: ['| H1 | H2 |', '| --- | --- |', '| a1 | a2 |'].join('\n'),
+        });
+        view.dispatch({
+            effects: setActiveCellEffect.of({
+                tableFrom: 0,
+                section: 'body',
+                row: 0,
+                col: 99,
+            }),
+        });
+        const dispatchSpy = jest.spyOn(view, 'dispatch');
+
+        expect(startCellSelectionFromActiveCell(view, 'right')).toBe(false);
+        expect(dispatchSpy).not.toHaveBeenCalled();
+        expect(getCellSelection(view.state)).toBeNull();
 
         view.destroy();
     });

--- a/src/contentScript/__tests__/mainEditorGuard.test.ts
+++ b/src/contentScript/__tests__/mainEditorGuard.test.ts
@@ -202,6 +202,33 @@ describe('createMainEditorActiveCellGuard', () => {
         });
     });
 
+    it('does not rewrite nested-editor table paste when the active cell no longer resolves', () => {
+        const doc = ['| H1 | H2 | H3 |', '| --- | --- | --- |', '| a | b | c |', '| d | e | f |'].join('\n');
+        let state = createState({ doc, nestedOpen: true });
+        state = state.update({
+            effects: setActiveCellEffect.of({
+                tableFrom: 0,
+                section: 'body',
+                row: 0,
+                col: 99,
+            }),
+        }).state;
+
+        const pasteText = ['| P1 | P2 |', '| --- | --- |', '| Q1 | Q2 |'].join('\n');
+        const tr = state.update({
+            changes: {
+                from: 0,
+                to: 0,
+                insert: pasteText,
+            },
+            userEvent: 'input.paste',
+        });
+
+        expect(tr.state.doc.toString()).toBe(`${pasteText}${doc}`);
+        expect(getActiveCell(tr.state)).toBeNull();
+        expect(getCellSelection(tr.state)).toBeNull();
+    });
+
     it('rewrites plain root markdown-table paste into canonical table text and activation effect', () => {
         const state = createState({
             doc: ['before', '', 'after'].join('\n'),

--- a/src/contentScript/__tests__/tablePositioning.test.ts
+++ b/src/contentScript/__tests__/tablePositioning.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, it } from '@jest/globals';
 import { EditorView } from '@codemirror/view';
 import { activeCellField, setActiveCellEffect } from '../tableState/activeCellState';
 import { createMarkdownState } from './testMarkdownState';
-import { resolveTableContextFromEventTarget, trimTrailingNonTableLines } from '../tableRuntime/tablePositioning';
+import { resolveTableContextFromEventTarget } from '../tableRuntime/tablePositioning';
+import { trimTrailingNonTableLines } from '../tableRuntime/tableResolution';
 
 describe('trimTrailingNonTableLines', () => {
     it('returns unchanged text for valid table without trailing content', () => {

--- a/src/contentScript/__tests__/undoScrollPreservation.test.ts
+++ b/src/contentScript/__tests__/undoScrollPreservation.test.ts
@@ -1,0 +1,95 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { markdown } from '@codemirror/lang-markdown';
+import { EditorView } from '@codemirror/view';
+import { GFM } from '@lezer/markdown';
+import { activeCellField, setActiveCellEffect } from '../tableState/activeCellState';
+import { createUndoScrollPreservation } from '../tableRuntime/undoScrollPreservation';
+import { isNestedEditorOpen } from '../nestedEditor/nestedEditorController';
+
+jest.mock('../nestedEditor/nestedEditorController', () => ({
+    isNestedEditorOpen: jest.fn(),
+}));
+
+const markdownExtension = markdown({
+    extensions: [GFM],
+});
+
+const mockIsNestedEditorOpen = isNestedEditorOpen as jest.Mock;
+
+describe('createUndoScrollPreservation', () => {
+    beforeEach(() => {
+        mockIsNestedEditorOpen.mockReset();
+        mockIsNestedEditorOpen.mockReturnValue(true);
+    });
+
+    it('preserves scroll for undo in a resolved active cell', () => {
+        const parent = document.createElement('div');
+        document.body.appendChild(parent);
+
+        let view: EditorView;
+        view = new EditorView({
+            parent,
+            extensions: [markdownExtension, activeCellField, createUndoScrollPreservation(() => view)],
+            doc: ['| H1 | H2 |', '| --- | --- |', '| a1 | a2 |'].join('\n'),
+        });
+        view.dispatch({
+            effects: setActiveCellEffect.of({
+                tableFrom: 0,
+                section: 'body',
+                row: 0,
+                col: 0,
+            }),
+        });
+        const scrollSnapshotSpy = jest.spyOn(view, 'scrollSnapshot');
+
+        view.dispatch({
+            changes: {
+                from: view.state.doc.toString().indexOf('a1'),
+                to: view.state.doc.toString().indexOf('a1') + 2,
+                insert: 'a',
+            },
+            userEvent: 'undo',
+        });
+
+        expect(scrollSnapshotSpy).toHaveBeenCalledTimes(1);
+
+        view.destroy();
+    });
+
+    it('does not preserve scroll for undo when the active cell no longer resolves', () => {
+        const parent = document.createElement('div');
+        document.body.appendChild(parent);
+
+        let view: EditorView;
+        view = new EditorView({
+            parent,
+            extensions: [markdownExtension, activeCellField, createUndoScrollPreservation(() => view)],
+            doc: ['| H1 | H2 |', '| --- | --- |', '| a1 | a2 |'].join('\n'),
+        });
+        view.dispatch({
+            effects: setActiveCellEffect.of({
+                tableFrom: 0,
+                section: 'body',
+                row: 0,
+                col: 99,
+            }),
+        });
+        const scrollSnapshotSpy = jest.spyOn(view, 'scrollSnapshot');
+
+        view.dispatch({
+            changes: {
+                from: view.state.doc.toString().indexOf('a1'),
+                to: view.state.doc.toString().indexOf('a1') + 2,
+                insert: 'a',
+            },
+            userEvent: 'undo',
+        });
+
+        expect(scrollSnapshotSpy).not.toHaveBeenCalled();
+
+        view.destroy();
+    });
+});

--- a/src/contentScript/editorBridge/mainEditorGuardPolicy.ts
+++ b/src/contentScript/editorBridge/mainEditorGuardPolicy.ts
@@ -91,25 +91,28 @@ export function decideMainEditorGuardTransaction(
         const pastedText = extractSingleInsertedText(tr);
 
         if (pastedText) {
-            const activeCell = getActiveCell(tr.startState);
+            if (params.nestedEditorOpen) {
+                const resolvedActiveCell = getResolvedActiveCell(tr.startState);
 
-            if (params.nestedEditorOpen && activeCell) {
-                const rewrite = buildMultiCellPasteRewrite(
-                    tr.startState,
-                    {
-                        tableFrom: activeCell.tableFrom,
-                        anchor: {
-                            section: activeCell.section,
-                            row: activeCell.row,
-                            col: activeCell.col,
+                if (resolvedActiveCell) {
+                    const activeCell = resolvedActiveCell.activeCell;
+                    const rewrite = buildMultiCellPasteRewrite(
+                        tr.startState,
+                        {
+                            tableFrom: resolvedActiveCell.tableFrom,
+                            anchor: {
+                                section: activeCell.section,
+                                row: activeCell.row,
+                                col: activeCell.col,
+                            },
+                            source: 'activeCell',
                         },
-                        source: 'activeCell',
-                    },
-                    pastedText
-                );
+                        pastedText
+                    );
 
-                if (rewrite) {
-                    return { type: 'rewriteTableClipboard', rewrite };
+                    if (rewrite) {
+                        return { type: 'rewriteTableClipboard', rewrite };
+                    }
                 }
             }
 

--- a/src/contentScript/tableModel/types.ts
+++ b/src/contentScript/tableModel/types.ts
@@ -6,7 +6,7 @@ export type TableSection = 'header' | 'body';
 
 /**
  * A table's document-level position and raw text.
- * Produced by Lezer syntax-tree resolution in tablePositioning.
+ * Produced by Lezer syntax-tree resolution in tableResolution.
  */
 export interface ResolvedTable {
     from: number;

--- a/src/contentScript/tableRuntime/activeCell/cellActivation.ts
+++ b/src/contentScript/tableRuntime/activeCell/cellActivation.ts
@@ -5,7 +5,7 @@
 import { EditorView } from '@codemirror/view';
 import { clearActiveCellEffect, getActiveCell, type ActiveCell } from '../../tableState/activeCellState';
 import { isSourceModeEnabled } from '../../tableState/sourceMode';
-import { findTableRanges } from '../tablePositioning';
+import { findTableRanges } from '../tableResolution';
 import { findCellForPos } from '../../tableModel/markdownTableCellRanges';
 import { buildTableContext } from '../../tableModel/tableContext';
 import { createActiveCellFromRanges } from './activeCellFactory';

--- a/src/contentScript/tableRuntime/activeCell/resolvedActiveCell.ts
+++ b/src/contentScript/tableRuntime/activeCell/resolvedActiveCell.ts
@@ -58,41 +58,16 @@ function clampDocPos(state: EditorState, pos: number): number {
     return Math.min(Math.max(pos, 0), state.doc.length);
 }
 
-export function resolveTableForActiveCell(
-    state: EditorState,
-    activeCell: ActiveCell
-): {
-    ctx: TableContext;
-    tableFrom: number;
-    tableTo: number;
-    contentFrom: number;
-    contentTo: number;
-    editableFrom: number;
-    editableTo: number;
-} | null {
+export function resolveTableForActiveCell(state: EditorState, activeCell: ActiveCell): ResolvedActiveCell | null {
     const ctx = resolveTableContextAtPos(state, clampDocPos(state, activeCell.tableFrom));
     if (!ctx) {
         return null;
     }
 
-    const range = resolveCellDocRange({
-        tableFrom: ctx.from,
-        ranges: ctx.cellRanges,
+    return createResolvedActiveCell({
+        ctx,
         coords: activeCell,
     });
-    if (!range) {
-        return null;
-    }
-
-    return {
-        ctx,
-        tableFrom: ctx.from,
-        tableTo: ctx.to,
-        contentFrom: range.contentFrom,
-        contentTo: range.contentTo,
-        editableFrom: range.editableFrom,
-        editableTo: range.editableTo,
-    };
 }
 
 export function resolveActiveCell(state: EditorState, activeCell: ActiveCell | null): ResolvedActiveCell | null {
@@ -100,19 +75,7 @@ export function resolveActiveCell(state: EditorState, activeCell: ActiveCell | n
         return null;
     }
 
-    const resolved = resolveTableForActiveCell(state, activeCell);
-    if (!resolved) {
-        return null;
-    }
-
-    return createResolvedActiveCell({
-        ctx: resolved.ctx,
-        coords: {
-            section: activeCell.section,
-            row: activeCell.row,
-            col: activeCell.col,
-        },
-    });
+    return resolveTableForActiveCell(state, activeCell);
 }
 
 /**

--- a/src/contentScript/tableRuntime/activeCell/resolvedActiveCell.ts
+++ b/src/contentScript/tableRuntime/activeCell/resolvedActiveCell.ts
@@ -58,7 +58,7 @@ function clampDocPos(state: EditorState, pos: number): number {
     return Math.min(Math.max(pos, 0), state.doc.length);
 }
 
-export function resolveTableForActiveCell(state: EditorState, activeCell: ActiveCell): ResolvedActiveCell | null {
+function resolveAnchoredActiveCell(state: EditorState, activeCell: ActiveCell): ResolvedActiveCell | null {
     const ctx = resolveTableContextAtPos(state, clampDocPos(state, activeCell.tableFrom));
     if (!ctx) {
         return null;
@@ -75,7 +75,7 @@ export function resolveActiveCell(state: EditorState, activeCell: ActiveCell | n
         return null;
     }
 
-    return resolveTableForActiveCell(state, activeCell);
+    return resolveAnchoredActiveCell(state, activeCell);
 }
 
 /**

--- a/src/contentScript/tableRuntime/activeCell/resolvedActiveCell.ts
+++ b/src/contentScript/tableRuntime/activeCell/resolvedActiveCell.ts
@@ -3,7 +3,7 @@ import { StateField } from '@codemirror/state';
 import { activeCellField, getActiveCell, type ActiveCell } from '../../tableState/activeCellState';
 import type { TableContext } from '../../tableModel/tableContext';
 import type { CellCoords } from '../../tableModel/types';
-import { resolveCellDocRange, resolveTableForActiveCell } from '../tablePositioning';
+import { resolveCellDocRange, resolveTableContextAtPos } from '../tableResolution';
 
 export interface ResolvedActiveCell {
     activeCell: ActiveCell;
@@ -52,6 +52,47 @@ export function resolveCellWithinResolvedTable(
         ctx: resolved.ctx,
         coords,
     });
+}
+
+function clampDocPos(state: EditorState, pos: number): number {
+    return Math.min(Math.max(pos, 0), state.doc.length);
+}
+
+export function resolveTableForActiveCell(
+    state: EditorState,
+    activeCell: ActiveCell
+): {
+    ctx: TableContext;
+    tableFrom: number;
+    tableTo: number;
+    contentFrom: number;
+    contentTo: number;
+    editableFrom: number;
+    editableTo: number;
+} | null {
+    const ctx = resolveTableContextAtPos(state, clampDocPos(state, activeCell.tableFrom));
+    if (!ctx) {
+        return null;
+    }
+
+    const range = resolveCellDocRange({
+        tableFrom: ctx.from,
+        ranges: ctx.cellRanges,
+        coords: activeCell,
+    });
+    if (!range) {
+        return null;
+    }
+
+    return {
+        ctx,
+        tableFrom: ctx.from,
+        tableTo: ctx.to,
+        contentFrom: range.contentFrom,
+        contentTo: range.contentTo,
+        editableFrom: range.editableFrom,
+        editableTo: range.editableTo,
+    };
 }
 
 export function resolveActiveCell(state: EditorState, activeCell: ActiveCell | null): ResolvedActiveCell | null {

--- a/src/contentScript/tableRuntime/lifecycle/nestedEditorLifecycle.ts
+++ b/src/contentScript/tableRuntime/lifecycle/nestedEditorLifecycle.ts
@@ -18,7 +18,7 @@ import {
 } from '../../nestedEditor/nestedEditorController';
 import { findCellElement } from '../../tableWidget/domHelpers';
 import { makeTableId } from '../../tableModel/types';
-import { findTableRanges } from '../tablePositioning';
+import { findTableRanges } from '../tableResolution';
 import { createActiveCellForTableText } from '../activeCell/activeCellFactory';
 import { activateCellAtPosition, activateTableCell } from '../activeCell/cellActivation';
 import {

--- a/src/contentScript/tableRuntime/navigation/cursorUtils.ts
+++ b/src/contentScript/tableRuntime/navigation/cursorUtils.ts
@@ -1,5 +1,5 @@
 import { EditorView } from '@codemirror/view';
-import { findTableRanges } from '../tablePositioning';
+import { findTableRanges } from '../tableResolution';
 
 export function moveCursorOutOfTable(view: EditorView, offset: number = 1): boolean {
     const tables = findTableRanges(view.state);

--- a/src/contentScript/tableRuntime/selection/cellSelectionClipboard.ts
+++ b/src/contentScript/tableRuntime/selection/cellSelectionClipboard.ts
@@ -1,7 +1,7 @@
 import { EditorSelection } from '@codemirror/state';
 import { EditorView, ViewPlugin } from '@codemirror/view';
 import { ClipboardTableFragment, MarkdownTable, type TableAlignment } from '../../tableModel/MarkdownTable';
-import { clearActiveCellEffect, getActiveCell } from '../../tableState/activeCellState';
+import { clearActiveCellEffect } from '../../tableState/activeCellState';
 import {
     cellSelectionTransitionAnnotation,
     clearCellSelectionEffect,
@@ -13,6 +13,7 @@ import {
     type CellSelection,
 } from '../../tableState/cellSelectionState';
 import { createActiveCellForTableText } from '../activeCell/activeCellFactory';
+import { getResolvedActiveCell } from '../activeCell/resolvedActiveCell';
 import { resolveTableContextAtPos } from '../tableResolution';
 import { getCellRange } from '../../tableModel/markdownTableCellRanges';
 import type { CellCoords } from '../../tableModel/types';
@@ -120,13 +121,14 @@ export function resolveTableClipboardTarget(
         return null;
     }
 
-    const activeCell = getActiveCell(state);
-    if (!activeCell) {
+    const resolvedActiveCell = getResolvedActiveCell(state);
+    if (!resolvedActiveCell) {
         return null;
     }
 
+    const activeCell = resolvedActiveCell.activeCell;
     return {
-        tableFrom: activeCell.tableFrom,
+        tableFrom: resolvedActiveCell.tableFrom,
         anchor: {
             section: activeCell.section,
             row: activeCell.row,

--- a/src/contentScript/tableRuntime/selection/cellSelectionClipboard.ts
+++ b/src/contentScript/tableRuntime/selection/cellSelectionClipboard.ts
@@ -13,7 +13,7 @@ import {
     type CellSelection,
 } from '../../tableState/cellSelectionState';
 import { createActiveCellForTableText } from '../activeCell/activeCellFactory';
-import { resolveTableContextAtPos } from '../tablePositioning';
+import { resolveTableContextAtPos } from '../tableResolution';
 import { getCellRange } from '../../tableModel/markdownTableCellRanges';
 import type { CellCoords } from '../../tableModel/types';
 import { canHandleTableClipboardShortcut, canHandleTableSelectionKeydown } from './cellSelectionShortcutScope';

--- a/src/contentScript/tableRuntime/selection/cellSelectionController.ts
+++ b/src/contentScript/tableRuntime/selection/cellSelectionController.ts
@@ -114,7 +114,10 @@ export function startCellSelectionFromActiveCell(view: EditorView, direction: Ce
     }
 
     const activeCell = resolvedActiveCell.activeCell;
-    const clampedFocus = clampSelectionFocusWithinContext(resolvedActiveCell.ctx, moveCellCoords(activeCell, direction));
+    const clampedFocus = clampSelectionFocusWithinContext(
+        resolvedActiveCell.ctx,
+        moveCellCoords(activeCell, direction)
+    );
     if (!clampedFocus) {
         return false;
     }

--- a/src/contentScript/tableRuntime/selection/cellSelectionController.ts
+++ b/src/contentScript/tableRuntime/selection/cellSelectionController.ts
@@ -12,7 +12,7 @@ import {
     type CellSelection,
     type CellSelectionDirection,
 } from '../../tableState/cellSelectionState';
-import { resolveCellDocRange, resolveTableContextAtPos } from '../tablePositioning';
+import { resolveCellDocRange, resolveTableContextAtPos } from '../tableResolution';
 import { makeTableId, type CellCoords } from '../../tableModel/types';
 import { findCellElement } from '../../tableWidget/domHelpers';
 

--- a/src/contentScript/tableRuntime/selection/cellSelectionController.ts
+++ b/src/contentScript/tableRuntime/selection/cellSelectionController.ts
@@ -1,6 +1,6 @@
 import { EditorSelection } from '@codemirror/state';
 import type { EditorView } from '@codemirror/view';
-import { clearActiveCellEffect, getActiveCell } from '../../tableState/activeCellState';
+import { clearActiveCellEffect } from '../../tableState/activeCellState';
 import {
     cellSelectionTransitionAnnotation,
     fromUnifiedRow,
@@ -12,20 +12,34 @@ import {
     type CellSelection,
     type CellSelectionDirection,
 } from '../../tableState/cellSelectionState';
+import type { TableContext } from '../../tableModel/tableContext';
 import { resolveCellDocRange, resolveTableContextAtPos } from '../tableResolution';
 import { makeTableId, type CellCoords } from '../../tableModel/types';
 import { findCellElement } from '../../tableWidget/domHelpers';
+import { getResolvedActiveCell } from '../activeCell/resolvedActiveCell';
 
-function getTableBounds(view: EditorView, tableFrom: number): { totalRows: number; totalCols: number } | null {
-    const ctx = resolveTableContextAtPos(view.state, tableFrom);
-    if (!ctx) {
-        return null;
-    }
-
+function getTableBoundsFromContext(ctx: TableContext): { totalRows: number; totalCols: number } {
     return {
         totalRows: 1 + ctx.cellRanges.rows.length,
         totalCols: ctx.cellRanges.headers.length,
     };
+}
+
+function getTableBounds(view: EditorView, tableFrom: number): { totalRows: number; totalCols: number } | null {
+    const ctx = resolveTableContextAtPos(view.state, tableFrom);
+    return ctx ? getTableBoundsFromContext(ctx) : null;
+}
+
+function clampSelectionFocusWithinContext(ctx: TableContext, focus: CellCoords): CellCoords | null {
+    const bounds = getTableBoundsFromContext(ctx);
+    if (bounds.totalCols <= 0) {
+        return null;
+    }
+
+    const unifiedRow = Math.max(0, Math.min(bounds.totalRows - 1, toUnifiedRow(focus)));
+    const col = Math.max(0, Math.min(bounds.totalCols - 1, focus.col));
+
+    return fromUnifiedRow(unifiedRow, col);
 }
 
 function clampSelectionFocus(view: EditorView, tableFrom: number, focus: CellCoords): CellCoords | null {
@@ -40,12 +54,12 @@ function clampSelectionFocus(view: EditorView, tableFrom: number, focus: CellCoo
     return fromUnifiedRow(unifiedRow, col);
 }
 
-function dispatchSelection(view: EditorView, selection: CellSelection, options: { clearActiveCell: boolean }): boolean {
-    const ctx = resolveTableContextAtPos(view.state, selection.tableFrom);
-    if (!ctx) {
-        return false;
-    }
-
+function dispatchSelectionWithContext(
+    view: EditorView,
+    ctx: TableContext,
+    selection: CellSelection,
+    options: { clearActiveCell: boolean }
+): boolean {
     const focusRange = resolveCellDocRange({
         tableFrom: ctx.from,
         ranges: ctx.cellRanges,
@@ -84,21 +98,32 @@ function dispatchSelection(view: EditorView, selection: CellSelection, options: 
     return true;
 }
 
-export function startCellSelectionFromActiveCell(view: EditorView, direction: CellSelectionDirection): boolean {
-    const activeCell = getActiveCell(view.state);
-    if (!activeCell) {
+function dispatchSelection(view: EditorView, selection: CellSelection, options: { clearActiveCell: boolean }): boolean {
+    const ctx = resolveTableContextAtPos(view.state, selection.tableFrom);
+    if (!ctx) {
         return false;
     }
 
-    const clampedFocus = clampSelectionFocus(view, activeCell.tableFrom, moveCellCoords(activeCell, direction));
+    return dispatchSelectionWithContext(view, ctx, selection, options);
+}
+
+export function startCellSelectionFromActiveCell(view: EditorView, direction: CellSelectionDirection): boolean {
+    const resolvedActiveCell = getResolvedActiveCell(view.state);
+    if (!resolvedActiveCell) {
+        return false;
+    }
+
+    const activeCell = resolvedActiveCell.activeCell;
+    const clampedFocus = clampSelectionFocusWithinContext(resolvedActiveCell.ctx, moveCellCoords(activeCell, direction));
     if (!clampedFocus) {
         return false;
     }
 
-    return dispatchSelection(
+    return dispatchSelectionWithContext(
         view,
+        resolvedActiveCell.ctx,
         {
-            tableFrom: activeCell.tableFrom,
+            tableFrom: resolvedActiveCell.tableFrom,
             anchor: activeCell,
             focus: clampedFocus,
         },
@@ -147,17 +172,19 @@ export function setOrExtendCellSelectionToCoords(view: EditorView, focus: CellCo
         );
     }
 
-    const activeCell = getActiveCell(view.state);
-    if (activeCell && activeCell.tableFrom === tableFrom) {
-        const clampedFocus = clampSelectionFocus(view, activeCell.tableFrom, focus);
+    const resolvedActiveCell = getResolvedActiveCell(view.state);
+    if (resolvedActiveCell && resolvedActiveCell.tableFrom === tableFrom) {
+        const activeCell = resolvedActiveCell.activeCell;
+        const clampedFocus = clampSelectionFocusWithinContext(resolvedActiveCell.ctx, focus);
         if (!clampedFocus) {
             return false;
         }
 
-        return dispatchSelection(
+        return dispatchSelectionWithContext(
             view,
+            resolvedActiveCell.ctx,
             {
-                tableFrom: activeCell.tableFrom,
+                tableFrom: resolvedActiveCell.tableFrom,
                 anchor: activeCell,
                 focus: clampedFocus,
             },

--- a/src/contentScript/tableRuntime/selection/cellSelectionKeymap.ts
+++ b/src/contentScript/tableRuntime/selection/cellSelectionKeymap.ts
@@ -4,7 +4,7 @@ import { clearCellSelectionEffect, getCellSelection } from '../../tableState/cel
 import { getActiveCell } from '../../tableState/activeCellState';
 import { createActiveCellFromRanges } from '../activeCell/activeCellFactory';
 import { extendExistingCellSelection, startCellSelectionFromActiveCell } from './cellSelectionController';
-import { resolveTableAtPos } from '../tablePositioning';
+import { resolveTableAtPos } from '../tableResolution';
 import { buildTableContext } from '../../tableModel/tableContext';
 import { canHandleTableSelectionKeydown } from './cellSelectionShortcutScope';
 import { handleSelectionDelete } from './cellSelectionClipboard';

--- a/src/contentScript/tableRuntime/tablePositioning.ts
+++ b/src/contentScript/tableRuntime/tablePositioning.ts
@@ -1,157 +1,8 @@
-import { ensureSyntaxTree } from '@codemirror/language';
-import type { EditorState } from '@codemirror/state';
-import type { SyntaxNode } from '@lezer/common';
 import type { EditorView } from '@codemirror/view';
-import { getCellRange, type TableCellRanges, type CellRange } from '../tableModel/markdownTableCellRanges';
-import { buildTableContext, type TableContext } from '../tableModel/tableContext';
-import { getActiveCell, type ActiveCell } from '../tableState/activeCellState';
+import type { TableContext } from '../tableModel/tableContext';
 import { getWidgetSelector } from '../tableWidget/domHelpers';
-import type { CellCoords, ResolvedTable } from '../tableModel/types';
-
-const TABLE_SYNTAX_TREE_RESOLVE_TIMEOUT_MS = 1500;
-const TABLE_SYNTAX_TREE_SCAN_TIMEOUT_MS = 500;
-
-/**
- * Trims trailing non-table lines from a Lezer-reported table range.
- *
- * Lezer's Markdown parser treats any non-blank line after a table as part of
- * the table until a blank line separator. This function scans backward and
- * excludes lines that don't contain '|' (i.e., not valid table rows).
- *
- * @param text - The raw table text from Lezer's range
- * @returns The trimmed text containing only valid table rows
- */
-export function trimTrailingNonTableLines(text: string): string {
-    const lines = text.split('\n');
-
-    // Need at least header + separator (2 lines) for a valid table
-    while (lines.length > 2) {
-        const lastLine = lines[lines.length - 1];
-        // A valid table row must contain '|'
-        if (lastLine.includes('|')) {
-            break;
-        }
-        lines.pop();
-    }
-
-    return lines.join('\n');
-}
-
-/**
- * Resolve the Lezer `Table` node that contains `pos`.
- */
-export function resolveTableAtPos(
-    state: EditorState,
-    pos: number,
-    timeoutMs: number = TABLE_SYNTAX_TREE_RESOLVE_TIMEOUT_MS
-): ResolvedTable | null {
-    const tree = ensureSyntaxTree(state, pos, timeoutMs);
-    if (!tree) {
-        return null;
-    }
-
-    let node: SyntaxNode | null = tree.resolve(pos, 1);
-    while (node && node.name !== 'Table') {
-        node = node.parent;
-    }
-
-    if (!node || node.name !== 'Table') {
-        return null;
-    }
-
-    const rawText = state.doc.sliceString(node.from, node.to);
-    const text = trimTrailingNonTableLines(rawText);
-    const to = node.from + text.length;
-
-    return { from: node.from, to, text };
-}
-
-/**
- * Find all markdown table ranges in the document using the syntax tree.
- */
-export function findTableRanges(
-    state: EditorState,
-    timeoutMs: number = TABLE_SYNTAX_TREE_SCAN_TIMEOUT_MS
-): ResolvedTable[] {
-    const tables: ResolvedTable[] = [];
-    const doc = state.doc;
-
-    const tree = ensureSyntaxTree(state, state.doc.length, timeoutMs);
-    if (!tree) {
-        return tables;
-    }
-
-    tree.iterate({
-        enter: (node) => {
-            if (node.name === 'Table') {
-                const rawText = doc.sliceString(node.from, node.to);
-                const text = trimTrailingNonTableLines(rawText);
-                const to = node.from + text.length;
-                tables.push({ from: node.from, to, text });
-            }
-        },
-    });
-
-    return tables;
-}
-
-function resolveTableContextFromResolved(resolved: ResolvedTable | null): TableContext | null {
-    if (!resolved) {
-        return null;
-    }
-
-    return buildTableContext(resolved);
-}
-
-function clampDocPos(state: EditorState, pos: number): number {
-    return Math.min(Math.max(pos, 0), state.doc.length);
-}
-
-export function resolveTableForActiveCell(
-    state: EditorState,
-    activeCell: ActiveCell
-): {
-    ctx: TableContext;
-    tableFrom: number;
-    tableTo: number;
-    contentFrom: number;
-    contentTo: number;
-    editableFrom: number;
-    editableTo: number;
-} | null {
-    const ctx = resolveTableContextAtPos(state, clampDocPos(state, activeCell.tableFrom));
-    if (!ctx) {
-        return null;
-    }
-
-    const range = resolveCellDocRange({
-        tableFrom: ctx.from,
-        ranges: ctx.cellRanges,
-        coords: activeCell,
-    });
-    if (!range) {
-        return null;
-    }
-
-    return {
-        ctx,
-        tableFrom: ctx.from,
-        tableTo: ctx.to,
-        contentFrom: range.contentFrom,
-        contentTo: range.contentTo,
-        editableFrom: range.editableFrom,
-        editableTo: range.editableTo,
-    };
-}
-
-function resolveActiveCellTableContext(state: EditorState): TableContext | null {
-    const activeCell = getActiveCell(state);
-    if (!activeCell) {
-        return null;
-    }
-
-    return resolveTableForActiveCell(state, activeCell)?.ctx ?? null;
-}
+import { getResolvedActiveCell } from './activeCell/resolvedActiveCell';
+import { resolveTableContextAtPos } from './tableResolution';
 
 /**
  * Resolve a table context from an event target, using a best-effort set of fallbacks.
@@ -165,7 +16,7 @@ export function resolveTableContextFromEventTarget(view: EditorView, target: HTM
     // Best case: map DOM->doc position.
     try {
         const pos = view.posAtDOM(target, 0);
-        const context = resolveTableContextFromResolved(resolveTableAtPos(view.state, pos));
+        const context = resolveTableContextAtPos(view.state, pos);
         if (context) {
             return context;
         }
@@ -180,7 +31,7 @@ export function resolveTableContextFromEventTarget(view: EditorView, target: HTM
     if (container) {
         try {
             const pos = view.posAtDOM(container, 0);
-            const context = resolveTableContextFromResolved(resolveTableAtPos(view.state, pos));
+            const context = resolveTableContextAtPos(view.state, pos);
             if (context) {
                 return context;
             }
@@ -191,41 +42,10 @@ export function resolveTableContextFromEventTarget(view: EditorView, target: HTM
 
     // Fallback: use the persisted active cell identity when nested editing has
     // detached the event target from a reliable document position.
-    const activeCellContext = resolveActiveCellTableContext(view.state);
+    const activeCellContext = getResolvedActiveCell(view.state)?.ctx ?? null;
     if (activeCellContext) {
         return activeCellContext;
     }
 
     return null;
-}
-
-export function resolveCellDocRange(params: { tableFrom: number; ranges: TableCellRanges; coords: CellCoords }): {
-    contentFrom: number;
-    contentTo: number;
-    editableFrom: number;
-    editableTo: number;
-    relRange: CellRange;
-} | null {
-    const { tableFrom, ranges, coords } = params;
-
-    const relRange = getCellRange(ranges, coords);
-    if (!relRange) {
-        return null;
-    }
-
-    return {
-        contentFrom: tableFrom + relRange.from,
-        contentTo: tableFrom + relRange.to,
-        editableFrom: tableFrom + relRange.editableFrom,
-        editableTo: tableFrom + relRange.editableTo,
-        relRange,
-    };
-}
-
-/**
- * Resolve a table at `pos` and build a full TableContext (parsed table + cell ranges).
- * Convenience wrapper combining resolveTableAtPos + buildTableContext.
- */
-export function resolveTableContextAtPos(state: EditorState, pos: number, timeoutMs?: number): TableContext | null {
-    return resolveTableContextFromResolved(resolveTableAtPos(state, pos, timeoutMs));
 }

--- a/src/contentScript/tableRuntime/tableResolution.ts
+++ b/src/contentScript/tableRuntime/tableResolution.ts
@@ -1,0 +1,132 @@
+import { ensureSyntaxTree } from '@codemirror/language';
+import type { EditorState } from '@codemirror/state';
+import type { SyntaxNode } from '@lezer/common';
+import { getCellRange, type CellRange, type TableCellRanges } from '../tableModel/markdownTableCellRanges';
+import { buildTableContext, type TableContext } from '../tableModel/tableContext';
+import type { CellCoords, ResolvedTable } from '../tableModel/types';
+
+const TABLE_SYNTAX_TREE_RESOLVE_TIMEOUT_MS = 1500;
+const TABLE_SYNTAX_TREE_SCAN_TIMEOUT_MS = 500;
+
+/**
+ * Trims trailing non-table lines from a Lezer-reported table range.
+ *
+ * Lezer's Markdown parser treats any non-blank line after a table as part of
+ * the table until a blank line separator. This function scans backward and
+ * excludes lines that don't contain '|' (i.e., not valid table rows).
+ *
+ * @param text - The raw table text from Lezer's range
+ * @returns The trimmed text containing only valid table rows
+ */
+export function trimTrailingNonTableLines(text: string): string {
+    const lines = text.split('\n');
+
+    // Need at least header + separator (2 lines) for a valid table
+    while (lines.length > 2) {
+        const lastLine = lines[lines.length - 1];
+        // A valid table row must contain '|'
+        if (lastLine.includes('|')) {
+            break;
+        }
+        lines.pop();
+    }
+
+    return lines.join('\n');
+}
+
+/**
+ * Resolve the Lezer `Table` node that contains `pos`.
+ */
+export function resolveTableAtPos(
+    state: EditorState,
+    pos: number,
+    timeoutMs: number = TABLE_SYNTAX_TREE_RESOLVE_TIMEOUT_MS
+): ResolvedTable | null {
+    const tree = ensureSyntaxTree(state, pos, timeoutMs);
+    if (!tree) {
+        return null;
+    }
+
+    let node: SyntaxNode | null = tree.resolve(pos, 1);
+    while (node && node.name !== 'Table') {
+        node = node.parent;
+    }
+
+    if (!node || node.name !== 'Table') {
+        return null;
+    }
+
+    const rawText = state.doc.sliceString(node.from, node.to);
+    const text = trimTrailingNonTableLines(rawText);
+    const to = node.from + text.length;
+
+    return { from: node.from, to, text };
+}
+
+/**
+ * Find all markdown table ranges in the document using the syntax tree.
+ */
+export function findTableRanges(
+    state: EditorState,
+    timeoutMs: number = TABLE_SYNTAX_TREE_SCAN_TIMEOUT_MS
+): ResolvedTable[] {
+    const tables: ResolvedTable[] = [];
+    const doc = state.doc;
+
+    const tree = ensureSyntaxTree(state, state.doc.length, timeoutMs);
+    if (!tree) {
+        return tables;
+    }
+
+    tree.iterate({
+        enter: (node) => {
+            if (node.name === 'Table') {
+                const rawText = doc.sliceString(node.from, node.to);
+                const text = trimTrailingNonTableLines(rawText);
+                const to = node.from + text.length;
+                tables.push({ from: node.from, to, text });
+            }
+        },
+    });
+
+    return tables;
+}
+
+function resolveTableContextFromResolved(resolved: ResolvedTable | null): TableContext | null {
+    if (!resolved) {
+        return null;
+    }
+
+    return buildTableContext(resolved);
+}
+
+export function resolveCellDocRange(params: { tableFrom: number; ranges: TableCellRanges; coords: CellCoords }): {
+    contentFrom: number;
+    contentTo: number;
+    editableFrom: number;
+    editableTo: number;
+    relRange: CellRange;
+} | null {
+    const { tableFrom, ranges, coords } = params;
+
+    const relRange = getCellRange(ranges, coords);
+    if (!relRange) {
+        return null;
+    }
+
+    return {
+        contentFrom: tableFrom + relRange.from,
+        contentTo: tableFrom + relRange.to,
+        editableFrom: tableFrom + relRange.editableFrom,
+        editableTo: tableFrom + relRange.editableTo,
+        relRange,
+    };
+}
+
+/**
+ * Resolve a table at `pos` and build a full TableContext (parsed table + cell ranges).
+ * Convenience wrapper combining resolveTableAtPos + buildTableContext.
+ */
+export function resolveTableContextAtPos(state: EditorState, pos: number, timeoutMs?: number): TableContext | null {
+    return resolveTableContextFromResolved(resolveTableAtPos(state, pos, timeoutMs));
+}

--- a/src/contentScript/tableRuntime/undoScrollPreservation.ts
+++ b/src/contentScript/tableRuntime/undoScrollPreservation.ts
@@ -1,6 +1,5 @@
 import { EditorState, Extension } from '@codemirror/state';
 import { EditorView } from '@codemirror/view';
-import { getActiveCell } from '../tableState/activeCellState';
 import { getResolvedActiveCell } from './activeCell/resolvedActiveCell';
 import { isNestedEditorOpen } from '../nestedEditor/nestedEditorController';
 import { transactionRequiresTableRebuild } from './tableTransactionHelpers';
@@ -24,10 +23,9 @@ export function createUndoScrollPreservation(getView: () => EditorView): Extensi
         const view = getView();
         if (!isNestedEditorOpen(view)) return null;
 
-        const activeCell = getActiveCell(tr.startState);
-        if (!activeCell) return null;
-
         const resolvedActiveCell = getResolvedActiveCell(tr.startState);
+        if (!resolvedActiveCell) return null;
+
         if (transactionRequiresTableRebuild(tr, resolvedActiveCell)) return null;
 
         return { effects: view.scrollSnapshot() };

--- a/src/contentScript/tableWidget/tableDecorationField.ts
+++ b/src/contentScript/tableWidget/tableDecorationField.ts
@@ -4,7 +4,7 @@ import { logger } from '../../logger';
 import { documentDefinitionsField } from '../services/documentDefinitions';
 import { hashTableText } from '../shared/hashUtils';
 import { buildTableContext } from '../tableModel/tableContext';
-import { findTableRanges } from '../tableRuntime/tablePositioning';
+import { findTableRanges } from '../tableRuntime/tableResolution';
 import { TableWidget } from './TableWidget';
 import { decideTableDecorationUpdate } from './tableDecorationPolicy';
 


### PR DESCRIPTION
- Split tableRuntime/tablePositioning.ts into clear layers so DOM/event positioning can depend on getResolvedActiveCell() without creating a circular dependency

- Refactor active-cell paths that need a valid table/cell range to use getResolvedActiveCell() instead of raw getActiveCell(). Keep raw getActiveCell() for boolean presence checks and stale-state cleanup decisions. This is an internal refactor; no public plugin API or persisted state shape changes.