### PR TITLE
fix: ensure table has empty line above/below when normalizing

### DIFF
--- a/docs/Architecture/Overview.md
+++ b/docs/Architecture/Overview.md
@@ -62,9 +62,10 @@ the main-editor selection anchor is transient request data, not part of persiste
 such as `tableTo` plus semantic/editable cell spans are derived on demand through the shared active-cell resolver.
 
 Before lifecycle opens the nested editor for user-driven entry, `tableRuntime/lifecycle/nestedEditorLifecycle.ts` checks whether the table markdown
-is already in the plugin's canonical serialized form. If not, it rewrites the whole table once, preserves the logical
-target cell, dispatches a reopen intent, rebuilds the widget, and only then opens the nested editor. Lifecycle reopens
-used for undo/redo or UI restoration skip that normalization step. Passive parsing/rendering never mutates document text.
+is already in the plugin's canonical serialized form with blank-line document boundaries. If not, it rewrites the table
+once, preserves the logical target cell, dispatches a reopen intent, rebuilds the widget, and only then opens the nested
+editor. Lifecycle reopens used for undo/redo or UI restoration skip that normalization step. Passive parsing/rendering
+never mutates document text.
 
 ### 3. Synchronization
 

--- a/src/contentScript/__tests__/nestedEditorLifecycle.test.ts
+++ b/src/contentScript/__tests__/nestedEditorLifecycle.test.ts
@@ -521,7 +521,7 @@ describe('nestedEditorLifecycle', () => {
         });
         flushAnimationFrames();
 
-        expect(view.state.doc.toString()).toBe(CANONICAL_DOC);
+        expect(view.state.doc.toString()).toBe(`\n${CANONICAL_DOC}\n`);
 
         const normalizedOpenDispatch = dispatchSpy.mock.calls
             .map((call) => call[0])
@@ -550,6 +550,64 @@ describe('nestedEditorLifecycle', () => {
             })
         );
         expect(getPendingOpenCellRequest(view.state)).toBeNull();
+
+        view.destroy();
+    });
+
+    it('adds missing blank lines around a normalized table and remaps the active cell', () => {
+        const doc = `before\n${NON_CANONICAL_DOC}\nafter`;
+        const initialTableFrom = 'before\n'.length;
+        const normalizedTableFrom = 'before\n\n'.length;
+        const activeCell: ActiveCell = {
+            tableFrom: initialTableFrom,
+            section: 'body',
+            row: 0,
+            col: 1,
+        };
+
+        const parent = document.createElement('div');
+        document.body.appendChild(parent);
+        const view = new EditorView({
+            parent,
+            state: EditorState.create({
+                doc,
+                extensions: [
+                    markdown({ extensions: [GFM] }),
+                    activeCellField,
+                    openCellRequestField,
+                    searchForceSourceModeField,
+                    sourceModeField,
+                    nestedEditorLifecyclePlugin,
+                ],
+            }),
+        });
+
+        view.dispatch({
+            effects: [
+                setActiveCellEffect.of(activeCell),
+                ...openRequestEffects({
+                    requestId: 'request-normalize-boundaries',
+                    activeCell,
+                    normalizeIfNeeded: true,
+                    initialCursorPos: 'end',
+                }),
+            ],
+        });
+        flushAnimationFrames();
+
+        expect(view.state.doc.toString()).toBe(`before\n\n${CANONICAL_DOC}\n\nafter`);
+        expect(getActiveCell(view.state)).toMatchObject({
+            tableFrom: normalizedTableFrom,
+            section: 'body',
+            row: 0,
+            col: 1,
+        });
+        expect(nestedEditorControllerMock.openNestedEditor).toHaveBeenCalledWith(
+            expect.objectContaining({
+                mainView: view,
+                initialCursorPos: 'end',
+            })
+        );
 
         view.destroy();
     });

--- a/src/contentScript/tableRuntime/lifecycle/nestedEditorLifecycle.ts
+++ b/src/contentScript/tableRuntime/lifecycle/nestedEditorLifecycle.ts
@@ -28,7 +28,7 @@ import {
     getOpenCellRequestById,
     requestOpenCellEffect,
 } from '../openCellRequest';
-import { getCanonicalTableTextIfChanged, normalizeBeforeEditAnnotation } from './tableNormalization';
+import { getNormalizedTableReplacementIfChanged, normalizeBeforeEditAnnotation } from './tableNormalization';
 import { getNestedEditorFeatureSettings } from '../../services/nestedEditorFeatureSettings';
 import {
     buildTableRuntimeEvent,
@@ -112,14 +112,14 @@ function normalizeTableBeforeOpen(params: {
         return 'not-needed';
     }
 
-    const canonicalText = getCanonicalTableTextIfChanged(resolved.ctx);
-    if (!canonicalText) {
+    const replacement = getNormalizedTableReplacementIfChanged(params.view.state, resolved.ctx);
+    if (!replacement) {
         return 'not-needed';
     }
 
     const nextActiveCell = createActiveCellForTableText({
-        tableFrom: resolved.tableFrom,
-        tableText: canonicalText,
+        tableFrom: replacement.tableFrom,
+        tableText: replacement.tableText,
         target: params.activeCell,
     });
     if (!nextActiveCell) {
@@ -135,7 +135,7 @@ function normalizeTableBeforeOpen(params: {
         changes: {
             from: resolved.tableFrom,
             to: resolved.tableTo,
-            insert: canonicalText,
+            insert: replacement.insert,
         },
         selection: { anchor: nextActiveCell.selectionAnchor },
         effects: [
@@ -146,7 +146,7 @@ function normalizeTableBeforeOpen(params: {
                 normalizeIfNeeded: false,
             }),
             requestOpenCellEffect.of({ requestId: currentRequest.requestId }),
-            rebuildTableWidgetsEffect.of({ tableFrom: resolved.tableFrom }),
+            rebuildTableWidgetsEffect.of({ tableFrom: replacement.tableFrom }),
         ],
         annotations: normalizeBeforeEditAnnotation.of(true),
         scrollIntoView: false,

--- a/src/contentScript/tableRuntime/lifecycle/tableNormalization.ts
+++ b/src/contentScript/tableRuntime/lifecycle/tableNormalization.ts
@@ -1,13 +1,45 @@
 import { Annotation } from '@codemirror/state';
+import type { EditorState } from '@codemirror/state';
 import type { TableContext } from '../../tableModel/tableContext';
+import {
+    countLeadingBlankLinesAfterBoundary,
+    countTrailingBlankLinesBeforeBoundary,
+    REQUIRED_TABLE_BOUNDARY_BLANK_LINES,
+} from '../tableBoundarySpacing';
 
 export const normalizeBeforeEditAnnotation = Annotation.define<boolean>();
 
+export interface NormalizedTableReplacement {
+    insert: string;
+    tableText: string;
+    tableFrom: number;
+}
+
 /**
- * Returns canonical serialized markdown when the current table text is non-canonical.
- * Passive callers can use this to detect divergence without mutating editor state.
+ * Returns canonical table markdown plus missing blank-line boundaries when needed.
+ * The table serializer stays table-only; boundary spacing depends on document context.
  */
-export function getCanonicalTableTextIfChanged(ctx: Pick<TableContext, 'table' | 'text'>): string | null {
-    const canonicalText = ctx.table.serialize();
-    return canonicalText === ctx.text ? null : canonicalText;
+export function getNormalizedTableReplacementIfChanged(
+    state: EditorState,
+    ctx: Pick<TableContext, 'from' | 'to' | 'table' | 'text'>
+): NormalizedTableReplacement | null {
+    const tableText = ctx.table.serialize();
+    const beforeText = state.doc.sliceString(0, ctx.from);
+    const afterText = state.doc.sliceString(ctx.to);
+    const needsLeadingSeparator =
+        countTrailingBlankLinesBeforeBoundary(beforeText) < REQUIRED_TABLE_BOUNDARY_BLANK_LINES;
+    const needsTrailingSeparator = countLeadingBlankLinesAfterBoundary(afterText) < REQUIRED_TABLE_BOUNDARY_BLANK_LINES;
+    const prefix = needsLeadingSeparator ? '\n' : '';
+    const suffix = needsTrailingSeparator ? '\n' : '';
+    const insert = prefix + tableText + suffix;
+
+    if (insert === ctx.text) {
+        return null;
+    }
+
+    return {
+        insert,
+        tableText,
+        tableFrom: ctx.from + prefix.length,
+    };
 }

--- a/src/contentScript/tableRuntime/operations/rootTableInsertRewrite.ts
+++ b/src/contentScript/tableRuntime/operations/rootTableInsertRewrite.ts
@@ -1,4 +1,9 @@
 import type { EditorState } from '@codemirror/state';
+import {
+    countLeadingBlankLinesAfterBoundary,
+    countTrailingBlankLinesBeforeBoundary,
+    REQUIRED_TABLE_BOUNDARY_BLANK_LINES,
+} from '../tableBoundarySpacing';
 
 export interface RootTableInsertRewrite {
     changes: {
@@ -10,40 +15,6 @@ export interface RootTableInsertRewrite {
      * Absolute table start in the post-change document.
      */
     tableFrom: number;
-}
-
-function countTrailingBlankLinesBeforeBoundary(text: string): number {
-    if (text.length === 0 || !text.endsWith('\n')) {
-        return 0;
-    }
-
-    const lines = text.split('\n');
-    let index = lines.length - 2;
-    let blankLineCount = 0;
-
-    while (index >= 0 && lines[index].trim().length === 0) {
-        blankLineCount++;
-        index--;
-    }
-
-    return blankLineCount;
-}
-
-function countLeadingBlankLinesAfterBoundary(text: string): number {
-    if (text.length === 0 || !text.startsWith('\n')) {
-        return 0;
-    }
-
-    const lines = text.split('\n');
-    let index = 1;
-    let blankLineCount = 0;
-
-    while (index < lines.length && lines[index].trim().length === 0) {
-        blankLineCount++;
-        index++;
-    }
-
-    return blankLineCount;
 }
 
 function hasNonWhitespace(text: string): boolean {
@@ -61,12 +32,14 @@ function buildRootTableInsertRewrite(
     const insertsIntoEmptyDocument = state.doc.length === 0;
     const needsLeadingSeparator =
         insertsIntoEmptyDocument ||
-        (hasNonWhitespace(beforeText) && countTrailingBlankLinesBeforeBoundary(beforeText) < 1);
+        (hasNonWhitespace(beforeText) &&
+            countTrailingBlankLinesBeforeBoundary(beforeText) < REQUIRED_TABLE_BOUNDARY_BLANK_LINES);
     const insertsAtDocumentEnd = replaceTo === state.doc.length && state.doc.length > 0;
     const needsTrailingSeparator =
         insertsIntoEmptyDocument ||
         insertsAtDocumentEnd ||
-        (hasNonWhitespace(afterText) && countLeadingBlankLinesAfterBoundary(afterText) < 1);
+        (hasNonWhitespace(afterText) &&
+            countLeadingBlankLinesAfterBoundary(afterText) < REQUIRED_TABLE_BOUNDARY_BLANK_LINES);
     const prefix = needsLeadingSeparator ? '\n' : '';
     const suffix = needsTrailingSeparator ? '\n' : '';
     const insert = prefix + tableText + suffix;

--- a/src/contentScript/tableRuntime/tableBoundarySpacing.ts
+++ b/src/contentScript/tableRuntime/tableBoundarySpacing.ts
@@ -1,0 +1,35 @@
+export const REQUIRED_TABLE_BOUNDARY_BLANK_LINES = 1;
+
+export function countTrailingBlankLinesBeforeBoundary(text: string): number {
+    if (text.length === 0 || !text.endsWith('\n')) {
+        return 0;
+    }
+
+    const lines = text.split('\n');
+    let index = lines.length - 2;
+    let blankLineCount = 0;
+
+    while (index >= 0 && lines[index].trim().length === 0) {
+        blankLineCount++;
+        index--;
+    }
+
+    return blankLineCount;
+}
+
+export function countLeadingBlankLinesAfterBoundary(text: string): number {
+    if (text.length === 0 || !text.startsWith('\n')) {
+        return 0;
+    }
+
+    const lines = text.split('\n');
+    let index = 1;
+    let blankLineCount = 0;
+
+    while (index < lines.length && lines[index].trim().length === 0) {
+        blankLineCount++;
+        index++;
+    }
+
+    return blankLineCount;
+}


### PR DESCRIPTION
The plugin already normalized whitespace above/below pasting tables, but not during the normalization that occurs when activating the cell editor. This refactor moves the blank line helpers into a shared module and refactors both tableNormalization and rootTableInsertRewrite to use the shared helpers