### PR TITLE
refactor: structural command handling in table model

### DIFF
--- a/docs/Architecture/Overview.md
+++ b/docs/Architecture/Overview.md
@@ -47,7 +47,7 @@ than calling back into Joplin or keeping module-level settings caches.
 | **Parsing**   | `contentScript/tableModel/MarkdownTable.ts`                     | Normalized table model, parsing, serialization, mutations.       |
 | **Context**   | `contentScript/tableModel/tableContext.ts`                      | Shared parsed table + cell ranges + table span.                  |
 | **State**     | `contentScript/tableState/activeCellState.ts`                   | Logical active-cell state and effect wiring.                     |
-| **Runtime**   | `contentScript/tableRuntime/operations/structuralOperations.ts` | Table mutation orchestration and target-cell rebasing.           |
+| **Runtime**   | `contentScript/tableRuntime/operations/structuralOperations.ts` | Editor transaction orchestration for structural table commands.  |
 | **Toolbar**   | `contentScript/toolbar/tableToolbarPlugin.ts`                   | Floating UI for row/column/alignment actions.                    |
 
 ## Data Flow
@@ -89,6 +89,7 @@ Typing in the isolated cell editor goes through the `NestedEditorSession` bridge
 
 - Parses Markdown into normalized header/alignment/body state.
 - Owns serialization and structural row/column/alignment operations.
+- Owns editor-independent structural command semantics, including target-cell intent after table-local mutations.
 - Feeds command execution and widget rendering through `TableContext`.
 - Leaves source-coordinate computation to `markdownTableCellRanges.ts`.
 

--- a/docs/Architecture/Structural-Commands-and-Serialization.md
+++ b/docs/Architecture/Structural-Commands-and-Serialization.md
@@ -16,9 +16,9 @@ User Action (keyboard/toolbar)
           ↓
    operations/structuralOperations.ts   ← Choose StructuralTableCommand + reopen defaults
             ↓
-   operations/runStructuralMutation.ts ← Invoke model semantics, serialize, dispatch
+   operations/runStructuralMutation.ts ← Requires command object (no mutation callbacks)
            ↓
-      tableModel/structuralCommandSemantics.ts ← Return { table, targetCell }
+      tableModel/structuralCommandSemantics.ts ← Apply command, return { table, targetCell }
            ↓
       MarkdownTable.ts          ← Runtime model + structural operations
 ```

--- a/docs/Architecture/Structural-Commands-and-Serialization.md
+++ b/docs/Architecture/Structural-Commands-and-Serialization.md
@@ -14,10 +14,12 @@ User Action (keyboard/toolbar)
          ↓
    operations/structuralActions.ts      ← Shared action registry
          ↓
-   operations/structuralOperations.ts   ← Runtime intent entry points
-          ↓
+   operations/structuralOperations.ts   ← Runtime command adapters
+           ↓
    operations/runStructuralMutation.ts ← Parse, mutate, serialize, dispatch
-         ↓
+          ↓
+     tableModel/structuralCommandSemantics.ts ← Pure command semantics
+          ↓
      MarkdownTable.ts          ← Runtime model + structural operations
 ```
 
@@ -65,7 +67,7 @@ define paragraph-splitting behavior.
 `runStructuralMutation.ts` has one shared preparation core that receives a `ResolvedActiveCell` and orchestrates:
 
 1. **Use Resolved Context**: Reuse the resolved table span, `TableContext`, and logical active cell.
-2. **Mutate**: Call operation function.
+2. **Mutate**: Call a pure model command semantic function.
 3. **Short-circuit**: Exit on no-op.
 4. **Serialize**: `table.serialize()` → Markdown.
 5. **Compute Active Cell**: `tableRuntime/activeCell/activeCellFactory.ts`.
@@ -76,7 +78,12 @@ define paragraph-splitting behavior.
 `structuralActions.ts` maps shared action IDs to runtime operations so keyboard commands and toolbar buttons do not
 maintain separate operation switchboards.
 
-`structuralOperations.ts` is the intent layer on top of the runner:
+`structuralCommandSemantics.ts` owns editor-independent command semantics:
+
+- It maps table-local command IDs plus active cell coordinates to a new `MarkdownTable` and target-cell intent.
+- It does not import CodeMirror or runtime state.
+
+`structuralOperations.ts` is the runtime adapter on top of the runner:
 
 - It groups entry points into reopening structural-operation families rather than ad hoc wrappers.
 - It owns shared reopen defaults such as main-editor focus handoff.

--- a/docs/Architecture/Structural-Commands-and-Serialization.md
+++ b/docs/Architecture/Structural-Commands-and-Serialization.md
@@ -13,14 +13,14 @@ User Action (keyboard/toolbar)
     tableCommands.ts / tableToolbarPlugin.ts ← Resolve active cell once
          ↓
    operations/structuralActions.ts      ← Shared action registry
-         ↓
-   operations/structuralOperations.ts   ← Runtime command adapters
+          ↓
+   operations/structuralOperations.ts   ← Choose StructuralTableCommand + reopen defaults
+            ↓
+   operations/runStructuralMutation.ts ← Invoke model semantics, serialize, dispatch
            ↓
-   operations/runStructuralMutation.ts ← Parse, mutate, serialize, dispatch
-          ↓
-     tableModel/structuralCommandSemantics.ts ← Pure command semantics
-          ↓
-     MarkdownTable.ts          ← Runtime model + structural operations
+      tableModel/structuralCommandSemantics.ts ← Return { table, targetCell }
+           ↓
+      MarkdownTable.ts          ← Runtime model + structural operations
 ```
 
 ## Layers
@@ -64,10 +64,11 @@ define paragraph-splitting behavior.
 
 ### 2. Runtime Mutation Helpers (`tableRuntime/operations/runStructuralMutation.ts`)
 
-`runStructuralMutation.ts` has one shared preparation core that receives a `ResolvedActiveCell` and orchestrates:
+`runStructuralMutation.ts` has one shared preparation core that receives a `ResolvedActiveCell` plus a
+`StructuralTableCommand` and orchestrates:
 
 1. **Use Resolved Context**: Reuse the resolved table span, `TableContext`, and logical active cell.
-2. **Mutate**: Call a pure model command semantic function.
+2. **Apply Command Semantics**: Call `structuralCommandSemantics.ts` to obtain `{ table, targetCell }`.
 3. **Short-circuit**: Exit on no-op.
 4. **Serialize**: `table.serialize()` → Markdown.
 5. **Compute Active Cell**: `tableRuntime/activeCell/activeCellFactory.ts`.
@@ -88,6 +89,7 @@ maintain separate operation switchboards.
 - It groups entry points into reopening structural-operation families rather than ad hoc wrappers.
 - It owns shared reopen defaults such as main-editor focus handoff.
 - Row-insert helpers extend those defaults with `initialCursorPos: 'start'`.
+- It passes command objects to `runStructuralMutationAndReopen()`; callers cannot provide arbitrary mutation callbacks.
 
 All active-cell-preserving structural mutations use `runStructuralMutationAndReopen()`: row/column insert,
 delete, move, clear, and alignment updates. That means command-driven structural edits don't rely on lifecycle

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,6 +11,10 @@ function siblingGroups(folderNames) {
     return folderNames.flatMap((name) => [`../${name}`, `../${name}/*`, `../${name}/**`]);
 }
 
+function anyDepthFolderGroups(folderNames) {
+    return folderNames.flatMap((name) => [`**/${name}`, `**/${name}/*`, `**/${name}/**`]);
+}
+
 export default [
     {
         ignores: ['api/**', 'dist/**'],
@@ -114,6 +118,33 @@ export default [
                                 'toolbar',
                             ]),
                             message: 'tableModel must not depend on higher-level editor layers.',
+                        },
+                        {
+                            group: anyDepthFolderGroups([
+                                'tableState',
+                                'tableRuntime',
+                                'tableWidget',
+                                'tableCommands',
+                                'nestedEditor',
+                                'services',
+                                'toolbar',
+                            ]),
+                            message:
+                                'tableModel must not depend on higher-level editor layers, even via deep relative paths.',
+                        },
+                    ],
+                    paths: [
+                        {
+                            name: '@codemirror/view',
+                            message: 'tableModel must not depend on editor/runtime packages.',
+                        },
+                        {
+                            name: '@codemirror/state',
+                            message: 'tableModel must not depend on editor/runtime packages.',
+                        },
+                        {
+                            name: '@codemirror/language',
+                            message: 'tableModel must not depend on editor/runtime packages.',
                         },
                     ],
                 },

--- a/src/contentScript/__tests__/structuralCommandSemantics.test.ts
+++ b/src/contentScript/__tests__/structuralCommandSemantics.test.ts
@@ -1,0 +1,146 @@
+import { MarkdownTable, type TableAlignment } from '../tableModel/MarkdownTable';
+import {
+    applyStructuralTableCommand,
+    type StructuralTableCommand,
+    type StructuralTableCommandId,
+} from '../tableModel/structuralCommandSemantics';
+import type { CellCoords } from '../tableModel/types';
+
+function parseTable(markdown: string): MarkdownTable {
+    const table = MarkdownTable.parse(markdown);
+    if (!table) {
+        throw new Error('Expected valid markdown table fixture');
+    }
+    return table;
+}
+
+function apply(markdown: string, activeCell: CellCoords, command: StructuralTableCommand) {
+    return applyStructuralTableCommand(parseTable(markdown), activeCell, command);
+}
+
+describe('structuralCommandSemantics', () => {
+    const tableMarkdown = ['| H1 | H2 |', '| --- | --- |', '| a1 | a2 |', '| b1 | b2 |'].join('\n');
+
+    it.each([
+        [
+            { section: 'header', row: 0, col: 1 },
+            { section: 'header', row: 0, col: 1 },
+        ],
+        [
+            { section: 'body', row: 1, col: 1 },
+            { section: 'body', row: 1, col: 1 },
+        ],
+    ] satisfies Array<[CellCoords, CellCoords]>)('targets inserted row before %#', (activeCell, targetCell) => {
+        const result = apply(tableMarkdown, activeCell, { type: 'insertRowBefore' });
+
+        expect(result.table.serialize()).toContain('|  |  |');
+        expect(result.targetCell).toEqual(targetCell);
+    });
+
+    it.each([
+        [
+            { section: 'header', row: 0, col: 1 },
+            { section: 'body', row: 0, col: 1 },
+        ],
+        [
+            { section: 'body', row: 1, col: 1 },
+            { section: 'body', row: 2, col: 1 },
+        ],
+    ] satisfies Array<[CellCoords, CellCoords]>)('targets inserted row after %#', (activeCell, targetCell) => {
+        const result = apply(tableMarkdown, activeCell, { type: 'insertRowAfter' });
+
+        expect(result.table.serialize()).toContain('|  |  |');
+        expect(result.targetCell).toEqual(targetCell);
+    });
+
+    it('supports a caller-provided target column for inserted rows', () => {
+        const result = apply(
+            tableMarkdown,
+            { section: 'body', row: 1, col: 1 },
+            { type: 'insertRowAfter', targetCol: 0 }
+        );
+
+        expect(result.targetCell).toEqual({ section: 'body', row: 2, col: 0 });
+    });
+
+    it.each([
+        [
+            { section: 'header', row: 0, col: 1 },
+            { section: 'header', row: 0, col: 1 },
+        ],
+        [
+            { section: 'body', row: 0, col: 1 },
+            { section: 'body', row: 0, col: 1 },
+        ],
+        [
+            { section: 'body', row: 1, col: 1 },
+            { section: 'body', row: 0, col: 1 },
+        ],
+    ] satisfies Array<[CellCoords, CellCoords]>)('targets deleted row %#', (activeCell, targetCell) => {
+        const result = apply(tableMarkdown, activeCell, { type: 'deleteRow' });
+
+        expect(result.targetCell).toEqual(targetCell);
+    });
+
+    it.each([
+        ['insertColumnBefore', { section: 'body', row: 0, col: 1 }, { section: 'body', row: 0, col: 1 }],
+        ['insertColumnAfter', { section: 'body', row: 0, col: 1 }, { section: 'body', row: 0, col: 2 }],
+        ['deleteColumn', { section: 'body', row: 0, col: 0 }, { section: 'body', row: 0, col: 0 }],
+        ['deleteColumn', { section: 'body', row: 0, col: 1 }, { section: 'body', row: 0, col: 0 }],
+        ['moveColumnLeft', { section: 'body', row: 0, col: 1 }, { section: 'body', row: 0, col: 0 }],
+        ['moveColumnRight', { section: 'body', row: 0, col: 0 }, { section: 'body', row: 0, col: 1 }],
+    ] satisfies Array<[StructuralTableCommandId, CellCoords, CellCoords]>)(
+        'targets column command %s',
+        (type, activeCell, targetCell) => {
+            const result = apply(tableMarkdown, activeCell, { type });
+
+            expect(result.targetCell).toEqual(targetCell);
+        }
+    );
+
+    it.each([
+        ['moveColumnLeft', { section: 'body', row: 0, col: 0 }],
+        ['moveColumnRight', { section: 'body', row: 0, col: 1 }],
+    ] satisfies Array<[StructuralTableCommandId, CellCoords]>)(
+        'preserves the active target for no-op column moves %s',
+        (type, activeCell) => {
+            const result = apply(tableMarkdown, activeCell, { type });
+
+            expect(result.targetCell).toEqual(activeCell);
+        }
+    );
+
+    it.each([
+        ['moveRowUp', { section: 'body', row: 0, col: 1 }, { section: 'header', row: 0, col: 1 }],
+        ['moveRowUp', { section: 'body', row: 1, col: 1 }, { section: 'body', row: 0, col: 1 }],
+        ['moveRowDown', { section: 'header', row: 0, col: 1 }, { section: 'body', row: 0, col: 1 }],
+        ['moveRowDown', { section: 'body', row: 0, col: 1 }, { section: 'body', row: 1, col: 1 }],
+    ] satisfies Array<[StructuralTableCommandId, CellCoords, CellCoords]>)(
+        'targets row command %s',
+        (type, activeCell, targetCell) => {
+            const result = apply(tableMarkdown, activeCell, { type });
+
+            expect(result.targetCell).toEqual(targetCell);
+        }
+    );
+
+    it.each([
+        ['clearTable', { section: 'header', row: 0, col: 0 }],
+        ['clearRow', { section: 'body', row: 1, col: 1 }],
+        ['clearColumn', { section: 'body', row: 0, col: 1 }],
+    ] satisfies Array<[StructuralTableCommandId, CellCoords]>)('preserves target cell for %s', (type, activeCell) => {
+        const result = apply(tableMarkdown, activeCell, { type });
+
+        expect(result.targetCell).toEqual(activeCell);
+    });
+
+    it.each(['left', 'center', 'right', null] satisfies TableAlignment[])(
+        'preserves target cell for alignment %s',
+        (alignment) => {
+            const activeCell = { section: 'body', row: 0, col: 1 } satisfies CellCoords;
+            const result = apply(tableMarkdown, activeCell, { type: 'alignColumn', alignment });
+
+            expect(result.targetCell).toEqual(activeCell);
+        }
+    );
+});

--- a/src/contentScript/__tests__/structuralCommandSemantics.test.ts
+++ b/src/contentScript/__tests__/structuralCommandSemantics.test.ts
@@ -111,6 +111,19 @@ describe('structuralCommandSemantics', () => {
     );
 
     it.each([
+        ['moveRowUp', { section: 'header', row: 0, col: 1 }],
+        ['moveRowDown', { section: 'body', row: 1, col: 1 }],
+    ] satisfies Array<[StructuralTableCommandId, CellCoords]>)(
+        'preserves target and table for no-op row boundaries %s',
+        (type, activeCell) => {
+            const result = apply(tableMarkdown, activeCell, { type });
+
+            expect(result.targetCell).toEqual(activeCell);
+            expect(result.table.serialize()).toEqual(tableMarkdown);
+        }
+    );
+
+    it.each([
         ['moveRowUp', { section: 'body', row: 0, col: 1 }, { section: 'header', row: 0, col: 1 }],
         ['moveRowUp', { section: 'body', row: 1, col: 1 }, { section: 'body', row: 0, col: 1 }],
         ['moveRowDown', { section: 'header', row: 0, col: 1 }, { section: 'body', row: 0, col: 1 }],
@@ -132,6 +145,16 @@ describe('structuralCommandSemantics', () => {
         const result = apply(tableMarkdown, activeCell, { type });
 
         expect(result.targetCell).toEqual(activeCell);
+    });
+
+    it('preserves target and table when header delete is blocked by table invariants', () => {
+        const headerOnlyTableMarkdown = ['| H1 | H2 |', '| --- | --- |'].join('\n');
+        const activeCell = { section: 'header', row: 0, col: 1 } satisfies CellCoords;
+
+        const result = apply(headerOnlyTableMarkdown, activeCell, { type: 'deleteRow' });
+
+        expect(result.targetCell).toEqual(activeCell);
+        expect(result.table.serialize()).toEqual(headerOnlyTableMarkdown);
     });
 
     it.each(['left', 'center', 'right', null] satisfies TableAlignment[])(

--- a/src/contentScript/__tests__/tableCommands.test.ts
+++ b/src/contentScript/__tests__/tableCommands.test.ts
@@ -74,7 +74,7 @@ describe('tableCommands', () => {
                 expect.objectContaining({
                     view: mockView,
                     resolvedCell,
-                    prepareMutation: expect.any(Function),
+                    command: { type: 'insertRowAfter' },
                     initialCursorPos: 'start',
                     afterDispatch: expect.any(Function),
                 })
@@ -94,13 +94,13 @@ describe('tableCommands', () => {
                 expect.objectContaining({
                     view: mockView,
                     resolvedCell,
-                    prepareMutation: expect.any(Function),
+                    command: { type: 'insertColumnAfter' },
                     afterDispatch: expect.any(Function),
                 })
             );
             expect(mockRunStructuralMutationAndReopen.mock.calls[0][0].initialCursorPos).toBeUndefined();
         });
-        it('routes alignment updates through the prepared mutation path', () => {
+        it('routes alignment updates through the command path', () => {
             const cell = createCell('body', 2, 1);
             const resolvedCell = createResolvedCell(cell);
 
@@ -108,7 +108,7 @@ describe('tableCommands', () => {
 
             expect(mockRunStructuralMutationAndReopen).toHaveBeenCalledTimes(1);
             const params = mockRunStructuralMutationAndReopen.mock.calls[0][0];
-            expect(params.prepareMutation).toEqual(expect.any(Function));
+            expect(params.command).toEqual({ type: 'alignColumn', alignment: 'center' });
         });
     });
 

--- a/src/contentScript/__tests__/tableCommands.test.ts
+++ b/src/contentScript/__tests__/tableCommands.test.ts
@@ -2,26 +2,14 @@ import { EditorView } from '@codemirror/view';
 import type { ActiveCell } from '../tableState/activeCellState';
 import { getResolvedActiveCell, type ResolvedActiveCell } from '../tableRuntime/activeCell/resolvedActiveCell';
 import { runStructuralMutationAndReopen } from '../tableRuntime/operations/runStructuralMutation';
-import type { TargetCell } from '../tableModel/activeCellForTableText';
 import { MarkdownTable } from '../tableModel/MarkdownTable';
 import { registerTableCommands } from '../tableCommands/tableCommands';
 import {
-    clearColumn,
-    clearRow,
-    clearTable,
-    deleteColumn,
-    deleteRow,
     deleteTable,
     getDefaultRowInsertOpenOptions,
     getDefaultStructuralReopenOptions,
-    insertColumnLeft,
     insertColumnRight,
-    insertRowAbove,
     insertRowBelow,
-    moveColumnLeft,
-    moveColumnRight,
-    moveRowDown,
-    moveRowUp,
     updateAlignment,
 } from '../tableRuntime/operations/structuralOperations';
 
@@ -33,7 +21,7 @@ jest.mock('../tableRuntime/activeCell/resolvedActiveCell', () => ({
     getResolvedActiveCell: jest.fn(),
 }));
 
-describe('tableCommands (computTargetCell)', () => {
+describe('tableCommands', () => {
     let mockView: EditorView;
     let mockRunStructuralMutationAndReopen: jest.Mock;
     let mockGetResolvedActiveCell: jest.Mock;
@@ -49,30 +37,6 @@ describe('tableCommands (computTargetCell)', () => {
         mockGetResolvedActiveCell = getResolvedActiveCell as jest.Mock;
         mockGetResolvedActiveCell.mockReset();
     });
-
-    // Helper to invoke a command and check the computeTargetCell logic
-    const testCommand = (
-        command: (view: EditorView, resolvedCell: ResolvedActiveCell) => void,
-        startCell: ActiveCell,
-        expectedTarget: TargetCell,
-        // Optional mocks for old/new table data if logic depends on it (usually doesn't for simple moves)
-        mockOldTable: MarkdownTable = {} as MarkdownTable,
-        mockNewTable: MarkdownTable = {} as MarkdownTable
-    ) => {
-        const resolvedCell = createResolvedCell(startCell);
-
-        command(mockView, resolvedCell);
-
-        expect(mockRunStructuralMutationAndReopen).toHaveBeenCalledTimes(1);
-        const params = mockRunStructuralMutationAndReopen.mock.calls[0][0];
-        expect(params.resolvedCell).toBe(resolvedCell);
-
-        // Isolate the target computation function
-        const computeTargetCell = params.computeTargetCell;
-        const actualTarget = computeTargetCell(startCell, mockOldTable, mockNewTable);
-
-        expect(actualTarget).toMatchObject(expectedTarget);
-    };
 
     const createCell = (section: 'header' | 'body', row: number, col: number): ActiveCell => ({
         tableFrom: 0,
@@ -99,47 +63,7 @@ describe('tableCommands (computTargetCell)', () => {
             },
         }) satisfies ResolvedActiveCell;
 
-    describe('insertRow', () => {
-        it('insertRowAbove (header) -> stay in header', () => {
-            testCommand(
-                insertRowAbove,
-                createCell('header', 0, 1),
-                { section: 'header', row: 0, col: 1 },
-                {} as MarkdownTable,
-                {} as MarkdownTable
-            );
-        });
-
-        it('insertRowAbove (body) -> stay in current row index (push down)', () => {
-            testCommand(
-                insertRowAbove,
-                createCell('body', 5, 1),
-                { section: 'body', row: 5, col: 1 },
-                {} as MarkdownTable,
-                {} as MarkdownTable
-            );
-        });
-
-        it('insertRowBelow (header) -> move to first body row', () => {
-            testCommand(
-                insertRowBelow,
-                createCell('header', 0, 1),
-                { section: 'body', row: 0, col: 1 },
-                {} as MarkdownTable,
-                {} as MarkdownTable
-            );
-        });
-
-        it('insertRowBelow (body) -> move to next row', () => {
-            testCommand(
-                insertRowBelow,
-                createCell('body', 5, 1),
-                { section: 'body', row: 6, col: 1 },
-                {} as MarkdownTable,
-                {} as MarkdownTable
-            );
-        });
-
+    describe('runtime structural operations', () => {
         it('routes row insertion through runStructuralMutationAndReopen with row defaults', () => {
             const cell = createCell('body', 1, 1);
             const resolvedCell = createResolvedCell(cell);
@@ -150,6 +74,7 @@ describe('tableCommands (computTargetCell)', () => {
                 expect.objectContaining({
                     view: mockView,
                     resolvedCell,
+                    prepareMutation: expect.any(Function),
                     initialCursorPos: 'start',
                     afterDispatch: expect.any(Function),
                 })
@@ -157,28 +82,6 @@ describe('tableCommands (computTargetCell)', () => {
             const afterDispatch = mockRunStructuralMutationAndReopen.mock.calls[0][0].afterDispatch as () => void;
             afterDispatch();
             expect(mockView.contentDOM.focus).toHaveBeenCalledWith({ preventScroll: true });
-        });
-    });
-
-    describe('insertColumn', () => {
-        it('insertColumnLeft -> stay in current col index', () => {
-            testCommand(
-                insertColumnLeft,
-                createCell('body', 2, 3),
-                { section: 'body', row: 2, col: 3 },
-                {} as MarkdownTable,
-                {} as MarkdownTable
-            );
-        });
-
-        it('insertColumnRight -> move to next col index', () => {
-            testCommand(
-                insertColumnRight,
-                createCell('body', 2, 3),
-                { section: 'body', row: 2, col: 4 },
-                {} as MarkdownTable,
-                {} as MarkdownTable
-            );
         });
 
         it('routes non-row structural operations through shared reopen defaults', () => {
@@ -191,173 +94,13 @@ describe('tableCommands (computTargetCell)', () => {
                 expect.objectContaining({
                     view: mockView,
                     resolvedCell,
+                    prepareMutation: expect.any(Function),
                     afterDispatch: expect.any(Function),
                 })
             );
             expect(mockRunStructuralMutationAndReopen.mock.calls[0][0].initialCursorPos).toBeUndefined();
         });
-    });
-
-    describe('deleteRow', () => {
-        it('deleteRow (header) -> promote first body row (header)', () => {
-            testCommand(
-                deleteRow,
-                createCell('header', 0, 2),
-                { section: 'header', row: 0, col: 2 },
-                {} as MarkdownTable,
-                {} as MarkdownTable
-            );
-        });
-
-        it('deleteRow (body row 0) -> move to 0', () => {
-            testCommand(
-                deleteRow,
-                createCell('body', 0, 2),
-                { section: 'body', row: 0, col: 2 },
-                {} as MarkdownTable,
-                {} as MarkdownTable
-            );
-        });
-
-        it('deleteRow (body row > 0) -> move up', () => {
-            testCommand(
-                deleteRow,
-                createCell('body', 5, 2),
-                { section: 'body', row: 4, col: 2 },
-                {} as MarkdownTable,
-                {} as MarkdownTable
-            );
-        });
-    });
-
-    describe('deleteColumn', () => {
-        it('deleteColumn (col 0) -> stay 0', () => {
-            testCommand(
-                deleteColumn,
-                createCell('body', 1, 0),
-                { section: 'body', row: 1, col: 0 },
-                {} as MarkdownTable,
-                {} as MarkdownTable
-            );
-        });
-
-        it('deleteColumn (col > 0) -> move left', () => {
-            testCommand(
-                deleteColumn,
-                createCell('body', 1, 5),
-                { section: 'body', row: 1, col: 4 },
-                {} as MarkdownTable,
-                {} as MarkdownTable
-            );
-        });
-    });
-
-    describe('moveRow', () => {
-        it('moveRowUp (row 0) -> move to header', () => {
-            testCommand(
-                moveRowUp,
-                createCell('body', 0, 1),
-                { section: 'header', row: 0, col: 1 },
-                {} as MarkdownTable,
-                {} as MarkdownTable
-            );
-        });
-
-        it('moveRowUp (row > 0) -> move up', () => {
-            testCommand(
-                moveRowUp,
-                createCell('body', 5, 1),
-                { section: 'body', row: 4, col: 1 },
-                {} as MarkdownTable,
-                {} as MarkdownTable
-            );
-        });
-
-        it('moveRowDown (header) -> move to body 0', () => {
-            testCommand(
-                moveRowDown,
-                createCell('header', 0, 1),
-                { section: 'body', row: 0, col: 1 },
-                {} as MarkdownTable,
-                {} as MarkdownTable
-            );
-        });
-
-        it('moveRowDown (body) -> move down', () => {
-            testCommand(
-                moveRowDown,
-                createCell('body', 5, 1),
-                { section: 'body', row: 6, col: 1 },
-                {} as MarkdownTable,
-                {} as MarkdownTable
-            );
-        });
-    });
-
-    describe('moveColumn', () => {
-        it('moveColumnLeft -> move left', () => {
-            testCommand(
-                moveColumnLeft,
-                createCell('body', 2, 3),
-                { section: 'body', row: 2, col: 2 },
-                {} as MarkdownTable,
-                {} as MarkdownTable
-            );
-        });
-
-        it('moveColumnRight -> move right', () => {
-            testCommand(
-                moveColumnRight,
-                createCell('body', 2, 3),
-                { section: 'body', row: 2, col: 4 },
-                {} as MarkdownTable,
-                {} as MarkdownTable
-            );
-        });
-    });
-
-    describe('clearTable', () => {
-        it('clearRow -> stay in same cell', () => {
-            testCommand(
-                clearRow,
-                createCell('body', 2, 1),
-                { section: 'body', row: 2, col: 1 },
-                {} as MarkdownTable,
-                {} as MarkdownTable
-            );
-        });
-
-        it('clearColumn -> stay in same cell', () => {
-            testCommand(
-                clearColumn,
-                createCell('body', 2, 1),
-                { section: 'body', row: 2, col: 1 },
-                {} as MarkdownTable,
-                {} as MarkdownTable
-            );
-        });
-
-        it('clearTable -> stay in same cell', () => {
-            testCommand(
-                clearTable,
-                createCell('body', 2, 1),
-                { section: 'body', row: 2, col: 1 },
-                {} as MarkdownTable,
-                {} as MarkdownTable
-            );
-        });
-
-        it('clearTable (header) -> stay in header', () => {
-            testCommand(
-                clearTable,
-                createCell('header', 0, 0),
-                { section: 'header', row: 0, col: 0 },
-                {} as MarkdownTable,
-                {} as MarkdownTable
-            );
-        });
-
-        it('updateAlignment keeps the same target cell and uses reopen dispatch', () => {
+        it('routes alignment updates through the prepared mutation path', () => {
             const cell = createCell('body', 2, 1);
             const resolvedCell = createResolvedCell(cell);
 
@@ -365,7 +108,7 @@ describe('tableCommands (computTargetCell)', () => {
 
             expect(mockRunStructuralMutationAndReopen).toHaveBeenCalledTimes(1);
             const params = mockRunStructuralMutationAndReopen.mock.calls[0][0];
-            expect(params.computeTargetCell(cell, {} as MarkdownTable, {} as MarkdownTable)).toMatchObject(cell);
+            expect(params.prepareMutation).toEqual(expect.any(Function));
         });
     });
 

--- a/src/contentScript/__tests__/tableTransactionHelpers.test.ts
+++ b/src/contentScript/__tests__/tableTransactionHelpers.test.ts
@@ -77,8 +77,7 @@ describe('tableTransactionHelpers', () => {
         const result = runStructuralMutationAndReopen({
             view: view as never,
             resolvedCell: createResolvedCell(cell),
-            operation: (table) => table.insertRowRelativeTo('body', 0, 'after'),
-            computeTargetCell: () => ({ section: 'body', row: 1, col: 1 }),
+            command: { type: 'insertRowAfter' },
             initialCursorPos: 'start',
             afterDispatch,
         });
@@ -119,17 +118,16 @@ describe('tableTransactionHelpers', () => {
         expect(openRequest?.value).toEqual({ requestId: (beginRequest?.value as { requestId?: string })?.requestId });
     });
 
-    it('does not run the post-dispatch callback when row insertion is a no-op', () => {
+    it('does not run the post-dispatch callback when the structural command is a no-op', () => {
         const tableText = ['| H1 | H2 |', '| --- | --- |', '| a | b |'].join('\n');
         const view = createView(tableText);
-        const cell = createCell(tableText, 0, 1);
+        const cell = createCell(tableText, 0, 0);
         const afterDispatch = jest.fn();
 
         const result = runStructuralMutationAndReopen({
             view: view as never,
             resolvedCell: createResolvedCell(cell),
-            operation: (table) => table,
-            computeTargetCell: () => ({ section: 'body', row: 0, col: 1 }),
+            command: { type: 'moveColumnLeft' },
             afterDispatch,
         });
 
@@ -146,8 +144,7 @@ describe('tableTransactionHelpers', () => {
         const result = runStructuralMutationAndReopen({
             view: view as never,
             resolvedCell: createResolvedCell(cell),
-            operation: (table) => table.moveRow('body', 1, 'up'),
-            computeTargetCell: () => ({ section: 'body', row: 0, col: 0 }),
+            command: { type: 'moveRowUp' },
         });
 
         expect(result).toBe(true);
@@ -186,8 +183,7 @@ describe('tableTransactionHelpers', () => {
         const result = runStructuralMutationAndReopen({
             view: view as never,
             resolvedCell: createResolvedCell(cell),
-            operation: (table, currentCell) => table.updateColumnAlignment(currentCell.col, 'center'),
-            computeTargetCell: () => ({ section: 'body', row: 0, col: 0 }),
+            command: { type: 'alignColumn', alignment: 'center' },
         });
 
         expect(result).toBe(true);

--- a/src/contentScript/tableModel/structuralCommandSemantics.ts
+++ b/src/contentScript/tableModel/structuralCommandSemantics.ts
@@ -1,0 +1,173 @@
+import { MarkdownTable, type TableAlignment } from './MarkdownTable';
+import type { TargetCell } from './activeCellForTableText';
+import type { CellCoords } from './types';
+
+export type StructuralTableCommandId =
+    | 'insertRowBefore'
+    | 'insertRowAfter'
+    | 'insertColumnBefore'
+    | 'insertColumnAfter'
+    | 'deleteRow'
+    | 'deleteColumn'
+    | 'moveRowUp'
+    | 'moveRowDown'
+    | 'moveColumnLeft'
+    | 'moveColumnRight'
+    | 'clearRow'
+    | 'clearColumn'
+    | 'clearTable';
+
+export type StructuralTableCommand =
+    | {
+          type: Exclude<StructuralTableCommandId, 'insertRowAfter'>;
+      }
+    | {
+          type: 'insertRowAfter';
+          targetCol?: number;
+      }
+    | {
+          type: 'alignColumn';
+          alignment: TableAlignment;
+      };
+
+export interface StructuralTableCommandResult {
+    table: MarkdownTable;
+    targetCell: TargetCell;
+}
+
+function sameCell(cell: CellCoords): TargetCell {
+    return cell;
+}
+
+function commandResult(
+    originalTable: MarkdownTable,
+    activeCell: CellCoords,
+    table: MarkdownTable,
+    targetCell: TargetCell
+): StructuralTableCommandResult {
+    return {
+        table,
+        targetCell: table === originalTable ? sameCell(activeCell) : targetCell,
+    };
+}
+
+function targetInsertedRowBefore(cell: CellCoords): TargetCell {
+    return cell.section === 'header'
+        ? { section: 'header', row: 0, col: cell.col }
+        : { section: 'body', row: cell.row, col: cell.col };
+}
+
+function targetInsertedRowAfter(cell: CellCoords, targetCol: number = cell.col): TargetCell {
+    return cell.section === 'header'
+        ? { section: 'body', row: 0, col: targetCol }
+        : { section: 'body', row: cell.row + 1, col: targetCol };
+}
+
+function targetDeletedRow(cell: CellCoords): TargetCell {
+    return cell.section === 'header'
+        ? { section: 'header', row: 0, col: cell.col }
+        : { section: 'body', row: Math.max(0, cell.row - 1), col: cell.col };
+}
+
+function targetDeletedColumn(cell: CellCoords): TargetCell {
+    return { section: cell.section, row: cell.row, col: Math.max(0, cell.col - 1) };
+}
+
+function targetMovedRowUp(cell: CellCoords): TargetCell {
+    return cell.row === 0
+        ? { section: 'header', row: 0, col: cell.col }
+        : { section: 'body', row: cell.row - 1, col: cell.col };
+}
+
+function targetMovedRowDown(cell: CellCoords): TargetCell {
+    return cell.section === 'header'
+        ? { section: 'body', row: 0, col: cell.col }
+        : { section: 'body', row: cell.row + 1, col: cell.col };
+}
+
+export function applyStructuralTableCommand(
+    table: MarkdownTable,
+    activeCell: CellCoords,
+    command: StructuralTableCommand
+): StructuralTableCommandResult {
+    switch (command.type) {
+        case 'insertRowBefore':
+            return commandResult(
+                table,
+                activeCell,
+                table.insertRowRelativeTo(activeCell.section, activeCell.row, 'before'),
+                targetInsertedRowBefore(activeCell)
+            );
+        case 'insertRowAfter':
+            return commandResult(
+                table,
+                activeCell,
+                table.insertRowRelativeTo(activeCell.section, activeCell.row, 'after'),
+                targetInsertedRowAfter(activeCell, command.targetCol)
+            );
+        case 'insertColumnBefore':
+            return commandResult(table, activeCell, table.insertColumn(activeCell.col, 'before'), sameCell(activeCell));
+        case 'insertColumnAfter':
+            return commandResult(table, activeCell, table.insertColumn(activeCell.col, 'after'), {
+                section: activeCell.section,
+                row: activeCell.row,
+                col: activeCell.col + 1,
+            });
+        case 'deleteRow':
+            return commandResult(
+                table,
+                activeCell,
+                table.deleteRowAt(activeCell.section, activeCell.row),
+                targetDeletedRow(activeCell)
+            );
+        case 'deleteColumn':
+            return commandResult(
+                table,
+                activeCell,
+                table.deleteColumn(activeCell.col),
+                targetDeletedColumn(activeCell)
+            );
+        case 'moveRowUp':
+            return commandResult(
+                table,
+                activeCell,
+                table.moveRow(activeCell.section, activeCell.row, 'up'),
+                targetMovedRowUp(activeCell)
+            );
+        case 'moveRowDown':
+            return commandResult(
+                table,
+                activeCell,
+                table.moveRow(activeCell.section, activeCell.row, 'down'),
+                targetMovedRowDown(activeCell)
+            );
+        case 'moveColumnLeft':
+            return commandResult(table, activeCell, table.swapColumns(activeCell.col, activeCell.col - 1), {
+                ...activeCell,
+                col: activeCell.col - 1,
+            });
+        case 'moveColumnRight':
+            return commandResult(table, activeCell, table.swapColumns(activeCell.col, activeCell.col + 1), {
+                ...activeCell,
+                col: activeCell.col + 1,
+            });
+        case 'clearTable':
+            return commandResult(table, activeCell, table.clearAllCells(), sameCell(activeCell));
+        case 'clearRow':
+            return commandResult(
+                table,
+                activeCell,
+                table.clearRow(activeCell.section, activeCell.row),
+                sameCell(activeCell)
+            );
+        case 'clearColumn':
+            return commandResult(table, activeCell, table.clearColumn(activeCell.col), sameCell(activeCell));
+        case 'alignColumn':
+            return commandResult(
+                table,
+                activeCell,
+                table.updateColumnAlignment(activeCell.col, command.alignment),
+                sameCell(activeCell)
+            );
+    }
+}

--- a/src/contentScript/tableRuntime/operations/runStructuralMutation.ts
+++ b/src/contentScript/tableRuntime/operations/runStructuralMutation.ts
@@ -3,6 +3,7 @@ import { type ActiveCell } from '../../tableState/activeCellState';
 import { rebuildTableWidgetsEffect } from '../../tableState/tableWidgetEffects';
 import { MarkdownTable } from '../../tableModel/MarkdownTable';
 import type { TargetCell } from '../../tableModel/activeCellForTableText';
+import type { StructuralTableCommandResult } from '../../tableModel/structuralCommandSemantics';
 import { prepareOpenCellRequestTransaction } from '../openCellRequest';
 import { createActiveCellForTableText } from '../activeCell/activeCellFactory';
 import type { ResolvedActiveCell } from '../activeCell/resolvedActiveCell';
@@ -11,12 +12,20 @@ function isSameCellCoords(a: ActiveCell, b: ActiveCell): boolean {
     return a.section === b.section && a.row === b.row && a.col === b.col;
 }
 
-interface StructuralMutationPreparationParams {
+interface StructuralMutationCallbackParams {
     view: EditorView;
     resolvedCell: ResolvedActiveCell;
     operation: (table: MarkdownTable, cell: ActiveCell) => MarkdownTable;
     computeTargetCell: (cell: ActiveCell, oldTable: MarkdownTable, newTable: MarkdownTable) => TargetCell;
 }
+
+interface PreparedStructuralMutationParams {
+    view: EditorView;
+    resolvedCell: ResolvedActiveCell;
+    prepareMutation: (table: MarkdownTable, cell: ActiveCell) => StructuralTableCommandResult;
+}
+
+type StructuralMutationPreparationParams = StructuralMutationCallbackParams | PreparedStructuralMutationParams;
 
 export interface StructuralReopenOptions {
     initialCursorPos?: 'start' | 'end' | 'lastLineStart';
@@ -25,8 +34,7 @@ export interface StructuralReopenOptions {
     suppressKeys?: boolean;
 }
 
-export interface RunStructuralMutationAndReopenParams
-    extends StructuralMutationPreparationParams, StructuralReopenOptions {}
+export type RunStructuralMutationAndReopenParams = StructuralMutationPreparationParams & StructuralReopenOptions;
 
 interface PreparedStructuralMutation {
     tableFrom: number;
@@ -37,19 +45,33 @@ interface PreparedStructuralMutation {
 }
 
 function prepareStructuralMutation(params: StructuralMutationPreparationParams): PreparedStructuralMutation | null {
-    const { resolvedCell, operation, computeTargetCell } = params;
+    const { resolvedCell } = params;
     const cell = resolvedCell.activeCell;
     const { tableFrom, tableTo, ctx } = resolvedCell;
     const text = ctx.text;
 
-    const newTableData = operation(ctx.table, cell);
+    const mutationResult = (() => {
+        if ('prepareMutation' in params) {
+            return params.prepareMutation(ctx.table, cell);
+        }
+
+        const table = params.operation(ctx.table, cell);
+        return {
+            table,
+            targetCell: params.computeTargetCell(cell, ctx.table, table),
+        };
+    })();
+    const newTableData = mutationResult.table;
     if (newTableData === ctx.table) {
         return null;
     }
     const newText = newTableData.serialize();
 
-    const target = computeTargetCell(cell, ctx.table, newTableData);
-    const nextActiveCell = createActiveCellForTableText({ tableFrom, tableText: newText, target });
+    const nextActiveCell = createActiveCellForTableText({
+        tableFrom,
+        tableText: newText,
+        target: mutationResult.targetCell,
+    });
     if (!nextActiveCell) {
         return null;
     }

--- a/src/contentScript/tableRuntime/operations/runStructuralMutation.ts
+++ b/src/contentScript/tableRuntime/operations/runStructuralMutation.ts
@@ -1,9 +1,7 @@
 import { EditorView } from '@codemirror/view';
 import { type ActiveCell } from '../../tableState/activeCellState';
 import { rebuildTableWidgetsEffect } from '../../tableState/tableWidgetEffects';
-import { MarkdownTable } from '../../tableModel/MarkdownTable';
-import type { TargetCell } from '../../tableModel/activeCellForTableText';
-import type { StructuralTableCommandResult } from '../../tableModel/structuralCommandSemantics';
+import { applyStructuralTableCommand, type StructuralTableCommand } from '../../tableModel/structuralCommandSemantics';
 import { prepareOpenCellRequestTransaction } from '../openCellRequest';
 import { createActiveCellForTableText } from '../activeCell/activeCellFactory';
 import type { ResolvedActiveCell } from '../activeCell/resolvedActiveCell';
@@ -12,21 +10,6 @@ function isSameCellCoords(a: ActiveCell, b: ActiveCell): boolean {
     return a.section === b.section && a.row === b.row && a.col === b.col;
 }
 
-interface StructuralMutationCallbackParams {
-    view: EditorView;
-    resolvedCell: ResolvedActiveCell;
-    operation: (table: MarkdownTable, cell: ActiveCell) => MarkdownTable;
-    computeTargetCell: (cell: ActiveCell, oldTable: MarkdownTable, newTable: MarkdownTable) => TargetCell;
-}
-
-interface PreparedStructuralMutationParams {
-    view: EditorView;
-    resolvedCell: ResolvedActiveCell;
-    prepareMutation: (table: MarkdownTable, cell: ActiveCell) => StructuralTableCommandResult;
-}
-
-type StructuralMutationPreparationParams = StructuralMutationCallbackParams | PreparedStructuralMutationParams;
-
 export interface StructuralReopenOptions {
     initialCursorPos?: 'start' | 'end' | 'lastLineStart';
     afterDispatch?: () => void;
@@ -34,7 +17,11 @@ export interface StructuralReopenOptions {
     suppressKeys?: boolean;
 }
 
-export type RunStructuralMutationAndReopenParams = StructuralMutationPreparationParams & StructuralReopenOptions;
+export interface RunStructuralMutationAndReopenParams extends StructuralReopenOptions {
+    view: EditorView;
+    resolvedCell: ResolvedActiveCell;
+    command: StructuralTableCommand;
+}
 
 interface PreparedStructuralMutation {
     tableFrom: number;
@@ -44,23 +31,13 @@ interface PreparedStructuralMutation {
     nextActiveCell: NonNullable<ReturnType<typeof createActiveCellForTableText>>;
 }
 
-function prepareStructuralMutation(params: StructuralMutationPreparationParams): PreparedStructuralMutation | null {
+function prepareStructuralMutation(params: RunStructuralMutationAndReopenParams): PreparedStructuralMutation | null {
     const { resolvedCell } = params;
     const cell = resolvedCell.activeCell;
     const { tableFrom, tableTo, ctx } = resolvedCell;
     const text = ctx.text;
 
-    const mutationResult = (() => {
-        if ('prepareMutation' in params) {
-            return params.prepareMutation(ctx.table, cell);
-        }
-
-        const table = params.operation(ctx.table, cell);
-        return {
-            table,
-            targetCell: params.computeTargetCell(cell, ctx.table, table),
-        };
-    })();
+    const mutationResult = applyStructuralTableCommand(ctx.table, cell, params.command);
     const newTableData = mutationResult.table;
     if (newTableData === ctx.table) {
         return null;

--- a/src/contentScript/tableRuntime/operations/structuralOperations.ts
+++ b/src/contentScript/tableRuntime/operations/structuralOperations.ts
@@ -1,8 +1,8 @@
 import { EditorView } from '@codemirror/view';
-import { clearActiveCellEffect, type ActiveCell } from '../../tableState/activeCellState';
+import { clearActiveCellEffect } from '../../tableState/activeCellState';
 import { rebuildTableWidgetsEffect } from '../../tableState/tableWidgetEffects';
-import { MarkdownTable, type TableAlignment } from '../../tableModel/MarkdownTable';
-import type { TargetCell } from '../../tableModel/activeCellForTableText';
+import type { TableAlignment } from '../../tableModel/MarkdownTable';
+import { applyStructuralTableCommand, type StructuralTableCommand } from '../../tableModel/structuralCommandSemantics';
 import type { ResolvedActiveCell } from '../activeCell/resolvedActiveCell';
 import { activateTableCell } from '../activeCell/cellActivation';
 import { focusMainEditorWithoutScroll } from '../../shared/mainEditorFocus';
@@ -14,50 +14,6 @@ export type RowInsertOpenOptions = StructuralReopenOptions;
 
 const DEFAULT_INSERTED_TABLE_MARKDOWN = ['|  |  |', '| --- | --- |', '|  |  |'].join('\n');
 const DEFAULT_INSERTED_TABLE_SELECTION_OFFSET = 2;
-
-function sameCell(cell: ActiveCell): TargetCell {
-    return cell;
-}
-
-function targetInsertedRowBefore(cell: ActiveCell): TargetCell {
-    return cell.section === 'header'
-        ? { section: 'header', row: 0, col: cell.col }
-        : { section: 'body', row: cell.row, col: cell.col };
-}
-
-function targetInsertedRowAfter(cell: ActiveCell): TargetCell {
-    return cell.section === 'header'
-        ? { section: 'body', row: 0, col: cell.col }
-        : { section: 'body', row: cell.row + 1, col: cell.col };
-}
-
-function targetInsertedRowAtBottom(cell: ActiveCell, targetCol: number): TargetCell {
-    return cell.section === 'header'
-        ? { section: 'body', row: 0, col: targetCol }
-        : { section: 'body', row: cell.row + 1, col: targetCol };
-}
-
-function targetDeletedRow(cell: ActiveCell): TargetCell {
-    return cell.section === 'header'
-        ? { section: 'header', row: 0, col: cell.col }
-        : { section: 'body', row: Math.max(0, cell.row - 1), col: cell.col };
-}
-
-function targetDeletedColumn(cell: ActiveCell): TargetCell {
-    return { section: cell.section, row: cell.row, col: Math.max(0, cell.col - 1) };
-}
-
-function targetMovedRowUp(cell: ActiveCell): TargetCell {
-    return cell.row === 0
-        ? { section: 'header', row: 0, col: cell.col }
-        : { section: 'body', row: cell.row - 1, col: cell.col };
-}
-
-function targetMovedRowDown(cell: ActiveCell): TargetCell {
-    return cell.section === 'header'
-        ? { section: 'body', row: 0, col: cell.col }
-        : { section: 'body', row: cell.row + 1, col: cell.col };
-}
 
 export function getDefaultStructuralReopenOptions(view: EditorView): StructuralReopenOptions {
     return {
@@ -72,100 +28,53 @@ export function getDefaultRowInsertOpenOptions(view: EditorView): RowInsertOpenO
     };
 }
 
-function createReopeningStructuralOperation(
-    operation: (table: MarkdownTable, cell: ActiveCell) => MarkdownTable,
-    computeTargetCell: (cell: ActiveCell, oldTable: MarkdownTable, newTable: MarkdownTable) => TargetCell
-) {
+function createReopeningStructuralOperation(command: StructuralTableCommand) {
     return (view: EditorView, resolvedCell: ResolvedActiveCell, options?: StructuralReopenOptions): boolean =>
         runStructuralMutationAndReopen({
             view,
             resolvedCell,
-            operation,
-            computeTargetCell,
+            prepareMutation: (table, cell) => applyStructuralTableCommand(table, cell, command),
             ...getDefaultStructuralReopenOptions(view),
             ...options,
         });
 }
 
-function createRowInsertOperation(
-    operation: (table: MarkdownTable, cell: ActiveCell) => MarkdownTable,
-    computeTargetCell: (cell: ActiveCell, oldTable: MarkdownTable, newTable: MarkdownTable) => TargetCell
-) {
+function createRowInsertOperation(command: StructuralTableCommand) {
     return (view: EditorView, resolvedCell: ResolvedActiveCell, options?: RowInsertOpenOptions): boolean =>
         runStructuralMutationAndReopen({
             view,
             resolvedCell,
-            operation,
-            computeTargetCell,
+            prepareMutation: (table, cell) => applyStructuralTableCommand(table, cell, command),
             ...getDefaultRowInsertOpenOptions(view),
             ...options,
         });
 }
 
-export const insertRowAbove = createRowInsertOperation(
-    (table, cell) => table.insertRowRelativeTo(cell.section, cell.row, 'before'),
-    (cell) => targetInsertedRowBefore(cell)
-);
+export const insertRowAbove = createRowInsertOperation({ type: 'insertRowBefore' });
 
-export const insertRowBelow = createRowInsertOperation(
-    (table, cell) => table.insertRowRelativeTo(cell.section, cell.row, 'after'),
-    (cell) => targetInsertedRowAfter(cell)
-);
+export const insertRowBelow = createRowInsertOperation({ type: 'insertRowAfter' });
 
-export const insertColumnLeft = createReopeningStructuralOperation(
-    (table, cell) => table.insertColumn(cell.col, 'before'),
-    (cell) => sameCell(cell)
-);
+export const insertColumnLeft = createReopeningStructuralOperation({ type: 'insertColumnBefore' });
 
-export const insertColumnRight = createReopeningStructuralOperation(
-    (table, cell) => table.insertColumn(cell.col, 'after'),
-    (cell) => ({ section: cell.section, row: cell.row, col: cell.col + 1 })
-);
+export const insertColumnRight = createReopeningStructuralOperation({ type: 'insertColumnAfter' });
 
-export const deleteRow = createReopeningStructuralOperation(
-    (table, cell) => table.deleteRowAt(cell.section, cell.row),
-    (cell) => targetDeletedRow(cell)
-);
+export const deleteRow = createReopeningStructuralOperation({ type: 'deleteRow' });
 
-export const deleteColumn = createReopeningStructuralOperation(
-    (table, cell) => table.deleteColumn(cell.col),
-    (cell) => targetDeletedColumn(cell)
-);
+export const deleteColumn = createReopeningStructuralOperation({ type: 'deleteColumn' });
 
-export const moveRowUp = createReopeningStructuralOperation(
-    (table, cell) => table.moveRow(cell.section, cell.row, 'up'),
-    (cell) => targetMovedRowUp(cell)
-);
+export const moveRowUp = createReopeningStructuralOperation({ type: 'moveRowUp' });
 
-export const moveRowDown = createReopeningStructuralOperation(
-    (table, cell) => table.moveRow(cell.section, cell.row, 'down'),
-    (cell) => targetMovedRowDown(cell)
-);
+export const moveRowDown = createReopeningStructuralOperation({ type: 'moveRowDown' });
 
-export const moveColumnLeft = createReopeningStructuralOperation(
-    (table, cell) => table.swapColumns(cell.col, cell.col - 1),
-    (cell) => ({ ...cell, col: cell.col - 1 })
-);
+export const moveColumnLeft = createReopeningStructuralOperation({ type: 'moveColumnLeft' });
 
-export const moveColumnRight = createReopeningStructuralOperation(
-    (table, cell) => table.swapColumns(cell.col, cell.col + 1),
-    (cell) => ({ ...cell, col: cell.col + 1 })
-);
+export const moveColumnRight = createReopeningStructuralOperation({ type: 'moveColumnRight' });
 
-export const clearTable = createReopeningStructuralOperation(
-    (table) => table.clearAllCells(),
-    (cell) => sameCell(cell)
-);
+export const clearTable = createReopeningStructuralOperation({ type: 'clearTable' });
 
-export const clearRow = createReopeningStructuralOperation(
-    (table, cell) => table.clearRow(cell.section, cell.row),
-    (cell) => sameCell(cell)
-);
+export const clearRow = createReopeningStructuralOperation({ type: 'clearRow' });
 
-export const clearColumn = createReopeningStructuralOperation(
-    (table, cell) => table.clearColumn(cell.col),
-    (cell) => sameCell(cell)
-);
+export const clearColumn = createReopeningStructuralOperation({ type: 'clearColumn' });
 
 export function deleteTable(view: EditorView, resolvedCell: ResolvedActiveCell): boolean {
     view.dispatch({
@@ -190,8 +99,8 @@ export function updateAlignment(
     return runStructuralMutationAndReopen({
         view,
         resolvedCell,
-        operation: (table, currentCell) => table.updateColumnAlignment(currentCell.col, align),
-        computeTargetCell: (currentCell) => sameCell(currentCell),
+        prepareMutation: (table, currentCell) =>
+            applyStructuralTableCommand(table, currentCell, { type: 'alignColumn', alignment: align }),
         ...getDefaultStructuralReopenOptions(view),
         ...options,
     });
@@ -206,8 +115,8 @@ export function insertRowAtBottom(
     return runStructuralMutationAndReopen({
         view,
         resolvedCell,
-        operation: (table, currentCell) => table.insertRowRelativeTo(currentCell.section, currentCell.row, 'after'),
-        computeTargetCell: (currentCell) => targetInsertedRowAtBottom(currentCell, targetCol),
+        prepareMutation: (table, currentCell) =>
+            applyStructuralTableCommand(table, currentCell, { type: 'insertRowAfter', targetCol }),
         ...getDefaultRowInsertOpenOptions(view),
         ...options,
     });

--- a/src/contentScript/tableRuntime/operations/structuralOperations.ts
+++ b/src/contentScript/tableRuntime/operations/structuralOperations.ts
@@ -2,7 +2,7 @@ import { EditorView } from '@codemirror/view';
 import { clearActiveCellEffect } from '../../tableState/activeCellState';
 import { rebuildTableWidgetsEffect } from '../../tableState/tableWidgetEffects';
 import type { TableAlignment } from '../../tableModel/MarkdownTable';
-import { applyStructuralTableCommand, type StructuralTableCommand } from '../../tableModel/structuralCommandSemantics';
+import type { StructuralTableCommand } from '../../tableModel/structuralCommandSemantics';
 import type { ResolvedActiveCell } from '../activeCell/resolvedActiveCell';
 import { activateTableCell } from '../activeCell/cellActivation';
 import { focusMainEditorWithoutScroll } from '../../shared/mainEditorFocus';
@@ -33,7 +33,7 @@ function createReopeningStructuralOperation(command: StructuralTableCommand) {
         runStructuralMutationAndReopen({
             view,
             resolvedCell,
-            prepareMutation: (table, cell) => applyStructuralTableCommand(table, cell, command),
+            command,
             ...getDefaultStructuralReopenOptions(view),
             ...options,
         });
@@ -44,7 +44,7 @@ function createRowInsertOperation(command: StructuralTableCommand) {
         runStructuralMutationAndReopen({
             view,
             resolvedCell,
-            prepareMutation: (table, cell) => applyStructuralTableCommand(table, cell, command),
+            command,
             ...getDefaultRowInsertOpenOptions(view),
             ...options,
         });
@@ -99,8 +99,7 @@ export function updateAlignment(
     return runStructuralMutationAndReopen({
         view,
         resolvedCell,
-        prepareMutation: (table, currentCell) =>
-            applyStructuralTableCommand(table, currentCell, { type: 'alignColumn', alignment: align }),
+        command: { type: 'alignColumn', alignment: align },
         ...getDefaultStructuralReopenOptions(view),
         ...options,
     });
@@ -115,8 +114,7 @@ export function insertRowAtBottom(
     return runStructuralMutationAndReopen({
         view,
         resolvedCell,
-        prepareMutation: (table, currentCell) =>
-            applyStructuralTableCommand(table, currentCell, { type: 'insertRowAfter', targetCol }),
+        command: { type: 'insertRowAfter', targetCol },
         ...getDefaultRowInsertOpenOptions(view),
         ...options,
     });


### PR DESCRIPTION
Extract structural command semantics from the runtime layer into a dedicated table model module. This change enhances the clarity and separation of concerns in the codebase, allowing for more straightforward command-based table mutations. Additionally, new lint rules and tests have been introduced to ensure code quality and correctness.