### PR TITLE
refactor: structural operations to reduce duplication

### DIFF
--- a/docs/Architecture/Structural-Commands-and-Serialization.md
+++ b/docs/Architecture/Structural-Commands-and-Serialization.md
@@ -12,9 +12,9 @@ User Action (keyboard/toolbar)
          ↓
     tableCommands.ts / tableToolbarPlugin.ts ← Resolve active cell once
          ↓
-   operations/structuralActions.ts      ← Shared action registry
+   operations/structuralActions.ts      ← Shared action-to-command adapter
           ↓
-   operations/structuralOperations.ts   ← Choose StructuralTableCommand + reopen defaults
+   operations/structuralOperations.ts   ← Run StructuralTableCommand + reopen defaults
             ↓
    operations/runStructuralMutation.ts ← Requires command object (no mutation callbacks)
            ↓
@@ -76,8 +76,9 @@ define paragraph-splitting behavior.
    main-editor selection, registers an explicit open-cell request, dispatches its id-only open signal,
    forces a widget rebuild, and can run an immediate post-dispatch callback such as main-editor focus handoff.
 
-`structuralActions.ts` maps shared action IDs to runtime operations so keyboard commands and toolbar buttons do not
-maintain separate operation switchboards.
+`structuralActions.ts` maps shared action IDs to canonical `StructuralTableCommand` objects so keyboard commands and
+toolbar buttons do not maintain separate switchboards. Runtime-only actions, such as full table deletion, stay explicit
+in this adapter.
 
 `structuralCommandSemantics.ts` owns editor-independent command semantics:
 
@@ -86,7 +87,7 @@ maintain separate operation switchboards.
 
 `structuralOperations.ts` is the runtime adapter on top of the runner:
 
-- It groups entry points into reopening structural-operation families rather than ad hoc wrappers.
+- It applies shared reopen defaults for canonical `StructuralTableCommand` objects.
 - It owns shared reopen defaults such as main-editor focus handoff.
 - Row-insert helpers extend those defaults with `initialCursorPos: 'start'`.
 - It passes command objects to `runStructuralMutationAndReopen()`; callers cannot provide arbitrary mutation callbacks.

--- a/src/contentScript/__tests__/structuralActions.test.ts
+++ b/src/contentScript/__tests__/structuralActions.test.ts
@@ -1,0 +1,115 @@
+import type { EditorView } from '@codemirror/view';
+import type { ActiveCell } from '../tableState/activeCellState';
+import { MarkdownTable, type TableAlignment } from '../tableModel/MarkdownTable';
+import type { StructuralTableCommand } from '../tableModel/structuralCommandSemantics';
+import type { ResolvedActiveCell } from '../tableRuntime/activeCell/resolvedActiveCell';
+import { runStructuralMutationAndReopen } from '../tableRuntime/operations/runStructuralMutation';
+import { runStructuralAction, type StructuralActionId } from '../tableRuntime/operations/structuralActions';
+
+jest.mock('../tableRuntime/operations/runStructuralMutation', () => ({
+    runStructuralMutationAndReopen: jest.fn(),
+}));
+
+describe('structuralActions', () => {
+    let view: EditorView;
+    let resolvedCell: ResolvedActiveCell;
+    let mockRunStructuralMutationAndReopen: jest.Mock;
+
+    const createResolvedCell = (): ResolvedActiveCell => {
+        const activeCell: ActiveCell = {
+            tableFrom: 10,
+            section: 'body',
+            row: 1,
+            col: 0,
+        };
+
+        return {
+            activeCell,
+            tableFrom: activeCell.tableFrom,
+            tableTo: 100,
+            contentFrom: 0,
+            contentTo: 0,
+            editableFrom: 0,
+            editableTo: 0,
+            ctx: {
+                from: activeCell.tableFrom,
+                to: 100,
+                text: '',
+                table: {} as MarkdownTable,
+                cellRanges: { headers: [], rows: [] },
+            },
+        };
+    };
+
+    beforeEach(() => {
+        view = {
+            dispatch: jest.fn(),
+            contentDOM: {
+                focus: jest.fn(),
+            },
+        } as unknown as EditorView;
+        resolvedCell = createResolvedCell();
+        mockRunStructuralMutationAndReopen = runStructuralMutationAndReopen as jest.Mock;
+        mockRunStructuralMutationAndReopen.mockReset();
+        mockRunStructuralMutationAndReopen.mockReturnValue(true);
+    });
+
+    it.each([
+        ['insertRowBefore', { type: 'insertRowBefore' }],
+        ['insertRowAfter', { type: 'insertRowAfter' }],
+        ['insertColumnBefore', { type: 'insertColumnBefore' }],
+        ['insertColumnAfter', { type: 'insertColumnAfter' }],
+        ['deleteRow', { type: 'deleteRow' }],
+        ['deleteColumn', { type: 'deleteColumn' }],
+        ['moveRowUp', { type: 'moveRowUp' }],
+        ['moveRowDown', { type: 'moveRowDown' }],
+        ['moveColumnLeft', { type: 'moveColumnLeft' }],
+        ['moveColumnRight', { type: 'moveColumnRight' }],
+        ['clearRow', { type: 'clearRow' }],
+        ['clearColumn', { type: 'clearColumn' }],
+        ['clearTable', { type: 'clearTable' }],
+    ] satisfies Array<[StructuralActionId, StructuralTableCommand]>)(
+        'maps model-backed action %s to its canonical command',
+        (actionId, command) => {
+            expect(runStructuralAction(view, actionId, resolvedCell)).toBe(true);
+
+            expect(mockRunStructuralMutationAndReopen).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    view,
+                    resolvedCell,
+                    command,
+                })
+            );
+        }
+    );
+
+    it.each([
+        ['alignLeft', 'left'],
+        ['alignCenter', 'center'],
+        ['alignRight', 'right'],
+    ] satisfies Array<[StructuralActionId, TableAlignment]>)(
+        'maps alignment action %s to an alignColumn command',
+        (actionId, alignment) => {
+            expect(runStructuralAction(view, actionId, resolvedCell)).toBe(true);
+
+            expect(mockRunStructuralMutationAndReopen).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    view,
+                    resolvedCell,
+                    command: { type: 'alignColumn', alignment },
+                })
+            );
+        }
+    );
+
+    it('keeps deleteTable as a runtime-only action', () => {
+        expect(runStructuralAction(view, 'deleteTable', resolvedCell)).toBe(true);
+
+        expect(mockRunStructuralMutationAndReopen).not.toHaveBeenCalled();
+        expect(view.dispatch).toHaveBeenCalledWith(
+            expect.objectContaining({
+                changes: { from: 10, to: 100, insert: '' },
+            })
+        );
+    });
+});

--- a/src/contentScript/__tests__/tableCommands.test.ts
+++ b/src/contentScript/__tests__/tableCommands.test.ts
@@ -8,8 +8,7 @@ import {
     deleteTable,
     getDefaultRowInsertOpenOptions,
     getDefaultStructuralReopenOptions,
-    insertColumnRight,
-    insertRowBelow,
+    runStructuralCommand,
     updateAlignment,
 } from '../tableRuntime/operations/structuralOperations';
 
@@ -68,7 +67,7 @@ describe('tableCommands', () => {
             const cell = createCell('body', 1, 1);
             const resolvedCell = createResolvedCell(cell);
 
-            insertRowBelow(mockView, resolvedCell);
+            runStructuralCommand(mockView, resolvedCell, { type: 'insertRowAfter' });
 
             expect(mockRunStructuralMutationAndReopen).toHaveBeenCalledWith(
                 expect.objectContaining({
@@ -88,7 +87,7 @@ describe('tableCommands', () => {
             const cell = createCell('body', 2, 3);
             const resolvedCell = createResolvedCell(cell);
 
-            insertColumnRight(mockView, resolvedCell);
+            runStructuralCommand(mockView, resolvedCell, { type: 'insertColumnAfter' });
 
             expect(mockRunStructuralMutationAndReopen).toHaveBeenCalledWith(
                 expect.objectContaining({

--- a/src/contentScript/tableModel/structuralCommandSemantics.ts
+++ b/src/contentScript/tableModel/structuralCommandSemantics.ts
@@ -2,29 +2,53 @@ import { MarkdownTable, type TableAlignment } from './MarkdownTable';
 import type { TargetCell } from './activeCellForTableText';
 import type { CellCoords } from './types';
 
-export type StructuralTableCommandId =
-    | 'insertRowBefore'
-    | 'insertRowAfter'
-    | 'insertColumnBefore'
-    | 'insertColumnAfter'
-    | 'deleteRow'
-    | 'deleteColumn'
-    | 'moveRowUp'
-    | 'moveRowDown'
-    | 'moveColumnLeft'
-    | 'moveColumnRight'
-    | 'clearRow'
-    | 'clearColumn'
-    | 'clearTable';
+export type StructuralTableCommandById = {
+    insertRowBefore: {
+        type: 'insertRowBefore';
+    };
+    insertRowAfter: {
+        type: 'insertRowAfter';
+        targetCol?: number;
+    };
+    insertColumnBefore: {
+        type: 'insertColumnBefore';
+    };
+    insertColumnAfter: {
+        type: 'insertColumnAfter';
+    };
+    deleteRow: {
+        type: 'deleteRow';
+    };
+    deleteColumn: {
+        type: 'deleteColumn';
+    };
+    moveRowUp: {
+        type: 'moveRowUp';
+    };
+    moveRowDown: {
+        type: 'moveRowDown';
+    };
+    moveColumnLeft: {
+        type: 'moveColumnLeft';
+    };
+    moveColumnRight: {
+        type: 'moveColumnRight';
+    };
+    clearRow: {
+        type: 'clearRow';
+    };
+    clearColumn: {
+        type: 'clearColumn';
+    };
+    clearTable: {
+        type: 'clearTable';
+    };
+};
+
+export type StructuralTableCommandId = keyof StructuralTableCommandById;
 
 export type StructuralTableCommand =
-    | {
-          type: Exclude<StructuralTableCommandId, 'insertRowAfter'>;
-      }
-    | {
-          type: 'insertRowAfter';
-          targetCol?: number;
-      }
+    | StructuralTableCommandById[StructuralTableCommandId]
     | {
           type: 'alignColumn';
           alignment: TableAlignment;

--- a/src/contentScript/tableRuntime/operations/structuralActions.ts
+++ b/src/contentScript/tableRuntime/operations/structuralActions.ts
@@ -1,68 +1,85 @@
 import type { EditorView } from '@codemirror/view';
+import type { TableAlignment } from '../../tableModel/MarkdownTable';
+import type { StructuralTableCommandById } from '../../tableModel/structuralCommandSemantics';
 import type { ResolvedActiveCell } from '../activeCell/resolvedActiveCell';
-import {
-    clearColumn,
-    clearRow,
-    clearTable,
-    deleteColumn,
-    deleteRow,
-    deleteTable,
-    insertColumnLeft,
-    insertColumnRight,
-    insertRowAbove,
-    insertRowBelow,
-    moveColumnLeft,
-    moveColumnRight,
-    moveRowDown,
-    moveRowUp,
-    updateAlignment,
-} from './structuralOperations';
+import { deleteTable, runStructuralCommand } from './structuralOperations';
+
+type ModelBackedStructuralActionId = keyof StructuralTableCommandById;
+type CommandForId<Id extends ModelBackedStructuralActionId> = StructuralTableCommandById[Id];
+type AlignmentStructuralActionId = 'alignLeft' | 'alignCenter' | 'alignRight';
+type RuntimeOnlyStructuralActionId = 'deleteTable';
 
 export type StructuralActionId =
-    | 'insertRowBefore'
-    | 'insertRowAfter'
-    | 'deleteRow'
-    | 'insertColumnBefore'
-    | 'insertColumnAfter'
-    | 'deleteColumn'
-    | 'deleteTable'
-    | 'moveRowUp'
-    | 'moveRowDown'
-    | 'moveColumnLeft'
-    | 'moveColumnRight'
-    | 'clearRow'
-    | 'clearColumn'
-    | 'clearTable'
-    | 'alignLeft'
-    | 'alignCenter'
-    | 'alignRight';
+    | ModelBackedStructuralActionId
+    | AlignmentStructuralActionId
+    | RuntimeOnlyStructuralActionId;
 
-type StructuralActionHandler = (view: EditorView, resolvedCell: ResolvedActiveCell) => boolean;
+const modelBackedCommands = {
+    insertRowBefore: { type: 'insertRowBefore' },
+    insertRowAfter: { type: 'insertRowAfter' },
+    insertColumnBefore: { type: 'insertColumnBefore' },
+    insertColumnAfter: { type: 'insertColumnAfter' },
+    deleteRow: { type: 'deleteRow' },
+    deleteColumn: { type: 'deleteColumn' },
+    moveRowUp: { type: 'moveRowUp' },
+    moveRowDown: { type: 'moveRowDown' },
+    moveColumnLeft: { type: 'moveColumnLeft' },
+    moveColumnRight: { type: 'moveColumnRight' },
+    clearRow: { type: 'clearRow' },
+    clearColumn: { type: 'clearColumn' },
+    clearTable: { type: 'clearTable' },
+} satisfies { [Id in ModelBackedStructuralActionId]: CommandForId<Id> };
 
-export const structuralActions: Record<StructuralActionId, StructuralActionHandler> = {
-    insertRowBefore: insertRowAbove,
-    insertRowAfter: insertRowBelow,
-    deleteRow,
-    insertColumnBefore: insertColumnLeft,
-    insertColumnAfter: insertColumnRight,
-    deleteColumn,
+const alignmentCommands = {
+    alignLeft: 'left',
+    alignCenter: 'center',
+    alignRight: 'right',
+} satisfies Record<AlignmentStructuralActionId, TableAlignment>;
+
+function isModelBackedAction(actionId: StructuralActionId): actionId is ModelBackedStructuralActionId {
+    return Object.prototype.hasOwnProperty.call(modelBackedCommands, actionId);
+}
+
+function isAlignmentAction(actionId: StructuralActionId): actionId is AlignmentStructuralActionId {
+    return Object.prototype.hasOwnProperty.call(alignmentCommands, actionId);
+}
+
+function assertNeverAction(actionId: never): never {
+    throw new Error(`Unhandled structural action: ${actionId}`);
+}
+
+const runtimeOnlyActions = {
     deleteTable,
-    moveRowUp,
-    moveRowDown,
-    moveColumnLeft,
-    moveColumnRight,
-    clearRow,
-    clearColumn,
-    clearTable,
-    alignLeft: (view, resolvedCell) => updateAlignment(view, resolvedCell, 'left'),
-    alignCenter: (view, resolvedCell) => updateAlignment(view, resolvedCell, 'center'),
-    alignRight: (view, resolvedCell) => updateAlignment(view, resolvedCell, 'right'),
-};
+} satisfies Record<RuntimeOnlyStructuralActionId, typeof deleteTable>;
+
+function runRuntimeOnlyAction(
+    view: EditorView,
+    actionId: RuntimeOnlyStructuralActionId,
+    resolvedCell: ResolvedActiveCell
+): boolean {
+    switch (actionId) {
+        case 'deleteTable':
+            return runtimeOnlyActions.deleteTable(view, resolvedCell);
+        default:
+            return assertNeverAction(actionId);
+    }
+}
 
 export function runStructuralAction(
     view: EditorView,
     actionId: StructuralActionId,
     resolvedCell: ResolvedActiveCell
 ): boolean {
-    return structuralActions[actionId](view, resolvedCell);
+    if (isModelBackedAction(actionId)) {
+        return runStructuralCommand(view, resolvedCell, modelBackedCommands[actionId]);
+    }
+
+    if (isAlignmentAction(actionId)) {
+        return runStructuralCommand(view, resolvedCell, {
+            type: 'alignColumn',
+            alignment: alignmentCommands[actionId],
+        });
+    }
+
+    return runRuntimeOnlyAction(view, actionId, resolvedCell);
 }

--- a/src/contentScript/tableRuntime/operations/structuralOperations.ts
+++ b/src/contentScript/tableRuntime/operations/structuralOperations.ts
@@ -28,53 +28,28 @@ export function getDefaultRowInsertOpenOptions(view: EditorView): RowInsertOpenO
     };
 }
 
-function createReopeningStructuralOperation(command: StructuralTableCommand) {
-    return (view: EditorView, resolvedCell: ResolvedActiveCell, options?: StructuralReopenOptions): boolean =>
-        runStructuralMutationAndReopen({
-            view,
-            resolvedCell,
-            command,
-            ...getDefaultStructuralReopenOptions(view),
-            ...options,
-        });
+function commandUsesRowInsertDefaults(command: StructuralTableCommand): boolean {
+    return command.type === 'insertRowBefore' || command.type === 'insertRowAfter';
 }
 
-function createRowInsertOperation(command: StructuralTableCommand) {
-    return (view: EditorView, resolvedCell: ResolvedActiveCell, options?: RowInsertOpenOptions): boolean =>
-        runStructuralMutationAndReopen({
-            view,
-            resolvedCell,
-            command,
-            ...getDefaultRowInsertOpenOptions(view),
-            ...options,
-        });
+export function runStructuralCommand(
+    view: EditorView,
+    resolvedCell: ResolvedActiveCell,
+    command: StructuralTableCommand,
+    options?: StructuralReopenOptions
+): boolean {
+    const defaults = commandUsesRowInsertDefaults(command)
+        ? getDefaultRowInsertOpenOptions(view)
+        : getDefaultStructuralReopenOptions(view);
+
+    return runStructuralMutationAndReopen({
+        view,
+        resolvedCell,
+        command,
+        ...defaults,
+        ...options,
+    });
 }
-
-export const insertRowAbove = createRowInsertOperation({ type: 'insertRowBefore' });
-
-export const insertRowBelow = createRowInsertOperation({ type: 'insertRowAfter' });
-
-export const insertColumnLeft = createReopeningStructuralOperation({ type: 'insertColumnBefore' });
-
-export const insertColumnRight = createReopeningStructuralOperation({ type: 'insertColumnAfter' });
-
-export const deleteRow = createReopeningStructuralOperation({ type: 'deleteRow' });
-
-export const deleteColumn = createReopeningStructuralOperation({ type: 'deleteColumn' });
-
-export const moveRowUp = createReopeningStructuralOperation({ type: 'moveRowUp' });
-
-export const moveRowDown = createReopeningStructuralOperation({ type: 'moveRowDown' });
-
-export const moveColumnLeft = createReopeningStructuralOperation({ type: 'moveColumnLeft' });
-
-export const moveColumnRight = createReopeningStructuralOperation({ type: 'moveColumnRight' });
-
-export const clearTable = createReopeningStructuralOperation({ type: 'clearTable' });
-
-export const clearRow = createReopeningStructuralOperation({ type: 'clearRow' });
-
-export const clearColumn = createReopeningStructuralOperation({ type: 'clearColumn' });
 
 export function deleteTable(view: EditorView, resolvedCell: ResolvedActiveCell): boolean {
     view.dispatch({
@@ -96,13 +71,7 @@ export function updateAlignment(
     align: CommandColumnAlignment,
     options?: StructuralReopenOptions
 ): boolean {
-    return runStructuralMutationAndReopen({
-        view,
-        resolvedCell,
-        command: { type: 'alignColumn', alignment: align },
-        ...getDefaultStructuralReopenOptions(view),
-        ...options,
-    });
+    return runStructuralCommand(view, resolvedCell, { type: 'alignColumn', alignment: align }, options);
 }
 
 export function insertRowAtBottom(
@@ -111,13 +80,7 @@ export function insertRowAtBottom(
     targetCol: number,
     options?: RowInsertOpenOptions
 ): boolean {
-    return runStructuralMutationAndReopen({
-        view,
-        resolvedCell,
-        command: { type: 'insertRowAfter', targetCol },
-        ...getDefaultRowInsertOpenOptions(view),
-        ...options,
-    });
+    return runStructuralCommand(view, resolvedCell, { type: 'insertRowAfter', targetCol }, options);
 }
 
 export function insertTableAndActivate(view: EditorView): boolean {


### PR DESCRIPTION
Refactor the handling of structural table commands to eliminate code duplication and streamline command execution. This change consolidates command logic into a single function, improving maintainability and clarity.