### PR TITLE
Refactor table deletion and improve toolbar options

### DIFF
--- a/docs/Architecture/Structural-Commands-and-Serialization.md
+++ b/docs/Architecture/Structural-Commands-and-Serialization.md
@@ -16,9 +16,9 @@ User Action (keyboard/toolbar)
           ↓
    operations/structuralOperations.ts   ← Run StructuralTableCommand + reopen defaults
             ↓
-     operations/runStructuralMutation.ts ← Prepares and Dispatches (accepts StructuralTableCommand; no callback mutations)
+     operations/runStructuralMutation.ts ← Prepares and Dispatches surviving-table or table-deletion results
            ↓
-      tableModel/structuralCommandSemantics.ts ← Apply command, return { table, targetCell }
+      tableModel/structuralCommandSemantics.ts ← Apply command, return surviving table or table deletion
            ↓
       MarkdownTable.ts          ← Runtime model + structural operations
 ```
@@ -77,12 +77,12 @@ define paragraph-splitting behavior.
    forces a widget rebuild, and can run an immediate post-dispatch callback such as main-editor focus handoff.
 
 `structuralActions.ts` maps shared action IDs to canonical `StructuralTableCommand` objects so keyboard commands and
-toolbar buttons do not maintain separate switchboards. Runtime-only actions, such as full table deletion, stay explicit
-in this adapter.
+toolbar buttons do not maintain separate switchboards.
 
 `structuralCommandSemantics.ts` owns editor-independent command semantics:
 
-- It maps table-local command IDs plus active cell coordinates to a new `MarkdownTable` and target-cell intent.
+- It maps table-local command IDs plus active cell coordinates to either a new `MarkdownTable` plus target-cell intent,
+  or a table-deletion result.
 - It does not import CodeMirror or runtime state.
 
 `structuralOperations.ts` is the runtime adapter on top of the runner:
@@ -92,8 +92,9 @@ in this adapter.
 - Row-insert helpers extend those defaults with `initialCursorPos: 'start'`.
 - It passes command objects to `runStructuralMutationAndReopen()`; callers cannot provide arbitrary mutation callbacks.
 
-All active-cell-preserving structural mutations use `runStructuralMutationAndReopen()`: row/column insert,
-delete, move, clear, and alignment updates. That means command-driven structural edits don't rely on lifecycle
+All surviving-table structural mutations use `runStructuralMutationAndReopen()`: row/column insert,
+delete, move, clear, and alignment updates. Whole-table deletion uses the same runner but clears active-cell state
+instead of reopening a cell. That means command-driven structural edits don't rely on lifecycle
 inferring reopen intent from a rebuild-only transaction. Reopen intent is explicit: if a transition should reopen,
 it must dispatch an open-cell request alongside the rebuild.
 

--- a/src/__tests__/contentScriptMessageHandler.test.ts
+++ b/src/__tests__/contentScriptMessageHandler.test.ts
@@ -60,6 +60,7 @@ describe('contentScriptMessageHandler', () => {
             'floatingToolbar.showMoveButtons': false,
             'floatingToolbar.showClearButtons': true,
             'floatingToolbar.showAlignmentButtons': false,
+            'floatingToolbar.showDeleteTableButton': true,
         });
 
         const result = await handler({
@@ -71,6 +72,7 @@ describe('contentScriptMessageHandler', () => {
             'floatingToolbar.showMoveButtons',
             'floatingToolbar.showClearButtons',
             'floatingToolbar.showAlignmentButtons',
+            'floatingToolbar.showDeleteTableButton',
         ]);
         expect(result).toEqual({
             nestedEditor: {
@@ -80,6 +82,7 @@ describe('contentScriptMessageHandler', () => {
                 showMoveButtons: false,
                 showClearButtons: true,
                 showAlignmentButtons: false,
+                showDeleteTableButton: true,
             },
         });
     });

--- a/src/__tests__/hostEditorConfigBridge.test.ts
+++ b/src/__tests__/hostEditorConfigBridge.test.ts
@@ -6,6 +6,7 @@ import {
     readHostEditorConfig,
     TOOLBAR_SHOW_ALIGNMENT_BUTTONS_SETTING_KEY,
     TOOLBAR_SHOW_CLEAR_BUTTONS_SETTING_KEY,
+    TOOLBAR_SHOW_DELETE_TABLE_BUTTON_SETTING_KEY,
     TOOLBAR_SHOW_MOVE_BUTTONS_SETTING_KEY,
 } from '../contentScriptBridge/hostEditorConfigBridge';
 
@@ -37,6 +38,7 @@ describe('hostEditorConfigBridge', () => {
             [TOOLBAR_SHOW_MOVE_BUTTONS_SETTING_KEY]: false,
             [TOOLBAR_SHOW_CLEAR_BUTTONS_SETTING_KEY]: true,
             [TOOLBAR_SHOW_ALIGNMENT_BUTTONS_SETTING_KEY]: false,
+            [TOOLBAR_SHOW_DELETE_TABLE_BUTTON_SETTING_KEY]: true,
         });
 
         const result = await readHostEditorConfig(deps);
@@ -46,6 +48,7 @@ describe('hostEditorConfigBridge', () => {
             TOOLBAR_SHOW_MOVE_BUTTONS_SETTING_KEY,
             TOOLBAR_SHOW_CLEAR_BUTTONS_SETTING_KEY,
             TOOLBAR_SHOW_ALIGNMENT_BUTTONS_SETTING_KEY,
+            TOOLBAR_SHOW_DELETE_TABLE_BUTTON_SETTING_KEY,
         ]);
         expect(result).toEqual({
             nestedEditor: {
@@ -55,6 +58,7 @@ describe('hostEditorConfigBridge', () => {
                 showMoveButtons: false,
                 showClearButtons: true,
                 showAlignmentButtons: false,
+                showDeleteTableButton: true,
             },
         });
     });
@@ -74,6 +78,7 @@ describe('hostEditorConfigBridge', () => {
                 showMoveButtons: false,
                 showClearButtons: true,
                 showAlignmentButtons: true,
+                showDeleteTableButton: true,
             },
         });
     });
@@ -84,6 +89,7 @@ describe('hostEditorConfigBridge', () => {
             [TOOLBAR_SHOW_MOVE_BUTTONS_SETTING_KEY]: false,
             [TOOLBAR_SHOW_CLEAR_BUTTONS_SETTING_KEY]: false,
             [TOOLBAR_SHOW_ALIGNMENT_BUTTONS_SETTING_KEY]: false,
+            [TOOLBAR_SHOW_DELETE_TABLE_BUTTON_SETTING_KEY]: false,
         });
 
         await expect(readHostEditorConfig(deps)).resolves.toEqual({
@@ -92,6 +98,7 @@ describe('hostEditorConfigBridge', () => {
                 showMoveButtons: false,
                 showClearButtons: false,
                 showAlignmentButtons: false,
+                showDeleteTableButton: false,
             },
         });
     });

--- a/src/contentScript/__tests__/cellSelectionClipboard.test.ts
+++ b/src/contentScript/__tests__/cellSelectionClipboard.test.ts
@@ -263,6 +263,66 @@ describe('cellSelectionClipboard', () => {
         expect(rewrite?.selectionAnchorPos).toBe(0);
     });
 
+    it('deletes the whole table when an empty full-row selection exhausts all rows', () => {
+        const emptyHeaderOnlyDoc = ['|  |  |', '| --- | --- |'].join('\n');
+        const state = createMarkdownState(emptyHeaderOnlyDoc);
+        const rewrite = buildSelectionRemovalRewrite(
+            state,
+            selection({ section: 'header', row: 0, col: 0 }, { section: 'header', row: 0, col: 1 })
+        );
+
+        expect(rewrite).not.toBeNull();
+        expect(rewrite?.tableText).toBe('');
+        expect(rewrite?.selection).toBeNull();
+        expect(rewrite?.clearActiveCell).toBe(true);
+    });
+
+    it('deletes the whole table when an empty full-column selection exhausts all columns', () => {
+        const emptySingleColumnDoc = ['|  |', '| --- |', '|  |'].join('\n');
+        const state = createMarkdownState(emptySingleColumnDoc);
+        const rewrite = buildSelectionRemovalRewrite(
+            state,
+            selection({ section: 'header', row: 0, col: 0 }, { section: 'body', row: 0, col: 0 })
+        );
+
+        expect(rewrite).not.toBeNull();
+        expect(rewrite?.tableText).toBe('');
+        expect(rewrite?.selection).toBeNull();
+        expect(rewrite?.clearActiveCell).toBe(true);
+    });
+
+    it('clears non-empty final row selections before deleting structurally', () => {
+        const headerOnlyDoc = ['| H1 | H2 |', '| --- | --- |'].join('\n');
+        const state = createMarkdownState(headerOnlyDoc);
+        const rewrite = buildSelectionRemovalRewrite(
+            state,
+            selection({ section: 'header', row: 0, col: 0 }, { section: 'header', row: 0, col: 1 })
+        );
+
+        expect(rewrite).not.toBeNull();
+        expect(rewrite?.tableText).toBe(['|  |  |', '| --- | --- |'].join('\n'));
+        expect(rewrite?.selection).toEqual(
+            selection({ section: 'header', row: 0, col: 0 }, { section: 'header', row: 0, col: 1 })
+        );
+        expect(rewrite?.clearActiveCell).toBe(false);
+    });
+
+    it('clears non-empty final column selections before deleting structurally', () => {
+        const singleColumnDoc = ['| H1 |', '| --- |', '| A1 |'].join('\n');
+        const state = createMarkdownState(singleColumnDoc);
+        const rewrite = buildSelectionRemovalRewrite(
+            state,
+            selection({ section: 'header', row: 0, col: 0 }, { section: 'body', row: 0, col: 0 })
+        );
+
+        expect(rewrite).not.toBeNull();
+        expect(rewrite?.tableText).toBe(['|  |', '| --- |', '|  |'].join('\n'));
+        expect(rewrite?.selection).toEqual(
+            selection({ section: 'header', row: 0, col: 0 }, { section: 'body', row: 0, col: 0 })
+        );
+        expect(rewrite?.clearActiveCell).toBe(false);
+    });
+
     it('uses the structural empty-row deletion path for Ctrl+X too', () => {
         const emptyRowDoc = ['| H1 | H2 |', '| --- | --- |', '| A1 | A2 |', '|  |  |', '| B1 | B2 |'].join('\n');
         const state = createMarkdownState(emptyRowDoc);

--- a/src/contentScript/__tests__/hostEditorConfig.test.ts
+++ b/src/contentScript/__tests__/hostEditorConfig.test.ts
@@ -22,6 +22,7 @@ describe('hostEditorConfig', () => {
             showMoveButtons: false,
             showClearButtons: true,
             showAlignmentButtons: false,
+            showDeleteTableButton: true,
         },
     };
 

--- a/src/contentScript/__tests__/nestedEditorLifecycle.test.ts
+++ b/src/contentScript/__tests__/nestedEditorLifecycle.test.ts
@@ -43,6 +43,7 @@ const TEST_HOST_CONFIG = {
         showMoveButtons: true,
         showClearButtons: true,
         showAlignmentButtons: true,
+        showDeleteTableButton: true,
     },
 } satisfies HostEditorConfig;
 const nestedEditorControllerMock = jest.requireMock('../nestedEditor/nestedEditorController') as {

--- a/src/contentScript/__tests__/structuralActions.test.ts
+++ b/src/contentScript/__tests__/structuralActions.test.ts
@@ -68,6 +68,7 @@ describe('structuralActions', () => {
         ['clearRow', { type: 'clearRow' }],
         ['clearColumn', { type: 'clearColumn' }],
         ['clearTable', { type: 'clearTable' }],
+        ['deleteTable', { type: 'deleteTable' }],
     ] satisfies Array<[StructuralActionId, StructuralTableCommand]>)(
         'maps model-backed action %s to its canonical command',
         (actionId, command) => {
@@ -101,15 +102,4 @@ describe('structuralActions', () => {
             );
         }
     );
-
-    it('keeps deleteTable as a runtime-only action', () => {
-        expect(runStructuralAction(view, 'deleteTable', resolvedCell)).toBe(true);
-
-        expect(mockRunStructuralMutationAndReopen).not.toHaveBeenCalled();
-        expect(view.dispatch).toHaveBeenCalledWith(
-            expect.objectContaining({
-                changes: { from: 10, to: 100, insert: '' },
-            })
-        );
-    });
 });

--- a/src/contentScript/__tests__/structuralCommandSemantics.test.ts
+++ b/src/contentScript/__tests__/structuralCommandSemantics.test.ts
@@ -186,6 +186,17 @@ describe('structuralCommandSemantics', () => {
         expect(tableResult.table.serialize()).toEqual(headerOnlyTableMarkdown);
     });
 
+    it.each([
+        { section: 'body', row: -1, col: 1 },
+        { section: 'body', row: 5, col: 1 },
+    ] satisfies CellCoords[])('preserves target and table when deleting an invalid body row %#', (activeCell) => {
+        const result = apply(tableMarkdown, activeCell, { type: 'deleteRow' });
+        const tableResult = expectTableResult(result);
+
+        expect(tableResult.targetCell).toEqual(activeCell);
+        expect(tableResult.table.serialize()).toEqual(tableMarkdown);
+    });
+
     it('deletes the table when deleting the only column', () => {
         const singleColumnTableMarkdown = ['| H1 |', '| --- |', '| A1 |'].join('\n');
         const activeCell = { section: 'body', row: 0, col: 0 } satisfies CellCoords;
@@ -215,6 +226,17 @@ describe('structuralCommandSemantics', () => {
         const tableResult = expectTableResult(result);
 
         expect(tableResult.targetCell).toEqual({ section: 'body', row: 0, col: 0 });
+    });
+
+    it.each([
+        { section: 'body', row: 0, col: -1 },
+        { section: 'body', row: 0, col: 5 },
+    ] satisfies CellCoords[])('preserves target and table when deleting an invalid column %#', (activeCell) => {
+        const result = apply(tableMarkdown, activeCell, { type: 'deleteColumn' });
+        const tableResult = expectTableResult(result);
+
+        expect(tableResult.targetCell).toEqual(activeCell);
+        expect(tableResult.table.serialize()).toEqual(tableMarkdown);
     });
 
     it('deletes the table for an explicit deleteTable command', () => {

--- a/src/contentScript/__tests__/structuralCommandSemantics.test.ts
+++ b/src/contentScript/__tests__/structuralCommandSemantics.test.ts
@@ -83,7 +83,7 @@ describe('structuralCommandSemantics', () => {
         ],
         [
             { section: 'body', row: 0, col: 1 },
-            { section: 'header', row: 0, col: 1 },
+            { section: 'body', row: 0, col: 1 },
         ],
         [
             { section: 'body', row: 1, col: 1 },
@@ -193,6 +193,28 @@ describe('structuralCommandSemantics', () => {
         const result = apply(singleColumnTableMarkdown, activeCell, { type: 'deleteColumn' });
 
         expect(result).toEqual({ kind: 'deleteTable' });
+    });
+
+    it('targets the column that shifts into the deleted column visual space', () => {
+        const activeCell = { section: 'body', row: 0, col: 1 } satisfies CellCoords;
+
+        const result = apply(['| H1 | H2 | H3 |', '| --- | --- | --- |', '| A1 | A2 | A3 |'].join('\n'), activeCell, {
+            type: 'deleteColumn',
+        });
+        const tableResult = expectTableResult(result);
+
+        expect(tableResult.targetCell).toEqual({ section: 'body', row: 0, col: 1 });
+    });
+
+    it('targets the column to the left when deleting the last column', () => {
+        const activeCell = { section: 'body', row: 0, col: 1 } satisfies CellCoords;
+
+        const result = apply(['| H1 | H2 |', '| --- | --- |', '| A1 | A2 |'].join('\n'), activeCell, {
+            type: 'deleteColumn',
+        });
+        const tableResult = expectTableResult(result);
+
+        expect(tableResult.targetCell).toEqual({ section: 'body', row: 0, col: 0 });
     });
 
     it('deletes the table for an explicit deleteTable command', () => {

--- a/src/contentScript/__tests__/structuralCommandSemantics.test.ts
+++ b/src/contentScript/__tests__/structuralCommandSemantics.test.ts
@@ -1,6 +1,7 @@
 import { MarkdownTable, type TableAlignment } from '../tableModel/MarkdownTable';
 import {
     applyStructuralTableCommand,
+    type StructuralTableCommandResult,
     type StructuralTableCommand,
     type StructuralTableCommandId,
 } from '../tableModel/structuralCommandSemantics';
@@ -18,6 +19,15 @@ function apply(markdown: string, activeCell: CellCoords, command: StructuralTabl
     return applyStructuralTableCommand(parseTable(markdown), activeCell, command);
 }
 
+function expectTableResult(result: StructuralTableCommandResult) {
+    expect(result.kind).toBe('table');
+    if (result.kind !== 'table') {
+        throw new Error('Expected table result');
+    }
+
+    return result;
+}
+
 describe('structuralCommandSemantics', () => {
     const tableMarkdown = ['| H1 | H2 |', '| --- | --- |', '| a1 | a2 |', '| b1 | b2 |'].join('\n');
 
@@ -32,9 +42,10 @@ describe('structuralCommandSemantics', () => {
         ],
     ] satisfies Array<[CellCoords, CellCoords]>)('targets inserted row before %#', (activeCell, targetCell) => {
         const result = apply(tableMarkdown, activeCell, { type: 'insertRowBefore' });
+        const tableResult = expectTableResult(result);
 
-        expect(result.table.serialize()).toContain('|  |  |');
-        expect(result.targetCell).toEqual(targetCell);
+        expect(tableResult.table.serialize()).toContain('|  |  |');
+        expect(tableResult.targetCell).toEqual(targetCell);
     });
 
     it.each([
@@ -48,9 +59,10 @@ describe('structuralCommandSemantics', () => {
         ],
     ] satisfies Array<[CellCoords, CellCoords]>)('targets inserted row after %#', (activeCell, targetCell) => {
         const result = apply(tableMarkdown, activeCell, { type: 'insertRowAfter' });
+        const tableResult = expectTableResult(result);
 
-        expect(result.table.serialize()).toContain('|  |  |');
-        expect(result.targetCell).toEqual(targetCell);
+        expect(tableResult.table.serialize()).toContain('|  |  |');
+        expect(tableResult.targetCell).toEqual(targetCell);
     });
 
     it('supports a caller-provided target column for inserted rows', () => {
@@ -59,8 +71,9 @@ describe('structuralCommandSemantics', () => {
             { section: 'body', row: 1, col: 1 },
             { type: 'insertRowAfter', targetCol: 0 }
         );
+        const tableResult = expectTableResult(result);
 
-        expect(result.targetCell).toEqual({ section: 'body', row: 2, col: 0 });
+        expect(tableResult.targetCell).toEqual({ section: 'body', row: 2, col: 0 });
     });
 
     it.each([
@@ -78,8 +91,9 @@ describe('structuralCommandSemantics', () => {
         ],
     ] satisfies Array<[CellCoords, CellCoords]>)('targets deleted row %#', (activeCell, targetCell) => {
         const result = apply(tableMarkdown, activeCell, { type: 'deleteRow' });
+        const tableResult = expectTableResult(result);
 
-        expect(result.targetCell).toEqual(targetCell);
+        expect(tableResult.targetCell).toEqual(targetCell);
     });
 
     it.each([
@@ -93,8 +107,9 @@ describe('structuralCommandSemantics', () => {
         'targets column command %s',
         (type, activeCell, targetCell) => {
             const result = apply(tableMarkdown, activeCell, { type });
+            const tableResult = expectTableResult(result);
 
-            expect(result.targetCell).toEqual(targetCell);
+            expect(tableResult.targetCell).toEqual(targetCell);
         }
     );
 
@@ -105,8 +120,9 @@ describe('structuralCommandSemantics', () => {
         'preserves the active target for no-op column moves %s',
         (type, activeCell) => {
             const result = apply(tableMarkdown, activeCell, { type });
+            const tableResult = expectTableResult(result);
 
-            expect(result.targetCell).toEqual(activeCell);
+            expect(tableResult.targetCell).toEqual(activeCell);
         }
     );
 
@@ -117,9 +133,10 @@ describe('structuralCommandSemantics', () => {
         'preserves target and table for no-op row boundaries %s',
         (type, activeCell) => {
             const result = apply(tableMarkdown, activeCell, { type });
+            const tableResult = expectTableResult(result);
 
-            expect(result.targetCell).toEqual(activeCell);
-            expect(result.table.serialize()).toEqual(tableMarkdown);
+            expect(tableResult.targetCell).toEqual(activeCell);
+            expect(tableResult.table.serialize()).toEqual(tableMarkdown);
         }
     );
 
@@ -132,8 +149,9 @@ describe('structuralCommandSemantics', () => {
         'targets row command %s',
         (type, activeCell, targetCell) => {
             const result = apply(tableMarkdown, activeCell, { type });
+            const tableResult = expectTableResult(result);
 
-            expect(result.targetCell).toEqual(targetCell);
+            expect(tableResult.targetCell).toEqual(targetCell);
         }
     );
 
@@ -143,18 +161,33 @@ describe('structuralCommandSemantics', () => {
         ['clearColumn', { section: 'body', row: 0, col: 1 }],
     ] satisfies Array<[StructuralTableCommandId, CellCoords]>)('preserves target cell for %s', (type, activeCell) => {
         const result = apply(tableMarkdown, activeCell, { type });
+        const tableResult = expectTableResult(result);
 
-        expect(result.targetCell).toEqual(activeCell);
+        expect(tableResult.targetCell).toEqual(activeCell);
     });
 
-    it('preserves target and table when header delete is blocked by table invariants', () => {
+    it('deletes the table when deleting the only header row', () => {
         const headerOnlyTableMarkdown = ['| H1 | H2 |', '| --- | --- |'].join('\n');
         const activeCell = { section: 'header', row: 0, col: 1 } satisfies CellCoords;
 
         const result = apply(headerOnlyTableMarkdown, activeCell, { type: 'deleteRow' });
 
-        expect(result.targetCell).toEqual(activeCell);
-        expect(result.table.serialize()).toEqual(headerOnlyTableMarkdown);
+        expect(result).toEqual({ kind: 'deleteTable' });
+    });
+
+    it('deletes the table when deleting the only column', () => {
+        const singleColumnTableMarkdown = ['| H1 |', '| --- |', '| A1 |'].join('\n');
+        const activeCell = { section: 'body', row: 0, col: 0 } satisfies CellCoords;
+
+        const result = apply(singleColumnTableMarkdown, activeCell, { type: 'deleteColumn' });
+
+        expect(result).toEqual({ kind: 'deleteTable' });
+    });
+
+    it('deletes the table for an explicit deleteTable command', () => {
+        const result = apply(tableMarkdown, { section: 'body', row: 0, col: 0 }, { type: 'deleteTable' });
+
+        expect(result).toEqual({ kind: 'deleteTable' });
     });
 
     it.each(['left', 'center', 'right', null] satisfies TableAlignment[])(
@@ -162,8 +195,9 @@ describe('structuralCommandSemantics', () => {
         (alignment) => {
             const activeCell = { section: 'body', row: 0, col: 1 } satisfies CellCoords;
             const result = apply(tableMarkdown, activeCell, { type: 'alignColumn', alignment });
+            const tableResult = expectTableResult(result);
 
-            expect(result.targetCell).toEqual(activeCell);
+            expect(tableResult.targetCell).toEqual(activeCell);
         }
     );
 });

--- a/src/contentScript/__tests__/structuralCommandSemantics.test.ts
+++ b/src/contentScript/__tests__/structuralCommandSemantics.test.ts
@@ -83,7 +83,7 @@ describe('structuralCommandSemantics', () => {
         ],
         [
             { section: 'body', row: 0, col: 1 },
-            { section: 'body', row: 0, col: 1 },
+            { section: 'header', row: 0, col: 1 },
         ],
         [
             { section: 'body', row: 1, col: 1 },
@@ -173,6 +173,17 @@ describe('structuralCommandSemantics', () => {
         const result = apply(headerOnlyTableMarkdown, activeCell, { type: 'deleteRow' });
 
         expect(result).toEqual({ kind: 'deleteTable' });
+    });
+
+    it('preserves target and table when deleting an invalid body row in a header-only table', () => {
+        const headerOnlyTableMarkdown = ['| H1 | H2 |', '| --- | --- |'].join('\n');
+        const activeCell = { section: 'body', row: 0, col: 1 } satisfies CellCoords;
+
+        const result = apply(headerOnlyTableMarkdown, activeCell, { type: 'deleteRow' });
+        const tableResult = expectTableResult(result);
+
+        expect(tableResult.targetCell).toEqual(activeCell);
+        expect(tableResult.table.serialize()).toEqual(headerOnlyTableMarkdown);
     });
 
     it('deletes the table when deleting the only column', () => {

--- a/src/contentScript/__tests__/tableCommands.test.ts
+++ b/src/contentScript/__tests__/tableCommands.test.ts
@@ -5,7 +5,6 @@ import { runStructuralMutationAndReopen } from '../tableRuntime/operations/runSt
 import { MarkdownTable } from '../tableModel/MarkdownTable';
 import { registerTableCommands } from '../tableCommands/tableCommands';
 import {
-    deleteTable,
     getDefaultRowInsertOpenOptions,
     getDefaultStructuralReopenOptions,
     runStructuralCommand,
@@ -126,27 +125,6 @@ describe('tableCommands', () => {
             expect(options.initialCursorPos).toBe('start');
             options.afterDispatch?.();
             expect(mockView.contentDOM.focus).toHaveBeenCalledWith({ preventScroll: true });
-        });
-    });
-
-    describe('deleteTable', () => {
-        it('deleteTable dispatches deletion with clearActiveCellEffect', () => {
-            const dispatchMock = jest.fn();
-            const mockEditorView = {
-                dispatch: dispatchMock,
-                state: {},
-                contentDOM: { focus: jest.fn() },
-            } as unknown as EditorView;
-            const cell = createCell('body', 1, 0);
-            cell.tableFrom = 10;
-            const resolvedCell = createResolvedCell(cell);
-
-            deleteTable(mockEditorView, resolvedCell);
-
-            expect(dispatchMock).toHaveBeenCalledTimes(1);
-            const arg = dispatchMock.mock.calls[0][0];
-            expect(arg.changes).toEqual({ from: 10, to: 100, insert: '' });
-            expect(arg.effects).toHaveLength(2);
         });
     });
 

--- a/src/contentScript/__tests__/tableTransactionHelpers.test.ts
+++ b/src/contentScript/__tests__/tableTransactionHelpers.test.ts
@@ -4,7 +4,7 @@ import type { ActiveCell } from '../tableState/activeCellState';
 import { MarkdownTable } from '../tableModel/MarkdownTable';
 import { computeMarkdownTableCellRanges } from '../tableModel/markdownTableCellRanges';
 import { runStructuralMutationAndReopen } from '../tableRuntime/operations/runStructuralMutation';
-import { setActiveCellEffect } from '../tableState/activeCellState';
+import { clearActiveCellEffect, setActiveCellEffect } from '../tableState/activeCellState';
 import { rebuildTableWidgetsEffect } from '../tableState/tableWidgetEffects';
 import { requestOpenCellEffect } from '../tableRuntime/openCellRequest';
 import { createActiveCellForTableText } from '../tableRuntime/activeCell/activeCellFactory';
@@ -196,5 +196,44 @@ describe('tableTransactionHelpers', () => {
         expect(dispatched.changes?.insert).toBe(updatedTableText);
         expect(dispatched.effects.some((effect) => effect.is?.(requestOpenCellEffect))).toBe(true);
         expect(dispatched.effects.some((effect) => effect.is?.(rebuildTableWidgetsEffect))).toBe(true);
+    });
+
+    it.each([
+        ['deleteTable', '| H1 | H2 |\n| --- | --- |\n| a | b |', { section: 'body', row: 0, col: 0 }],
+        ['deleteRow', '| H1 | H2 |\n| --- | --- |', { section: 'header', row: 0, col: 0 }],
+        ['deleteColumn', '| H1 |\n| --- |\n| a |', { section: 'body', row: 0, col: 0 }],
+    ] as const)('dispatches table deletion for %s without reopen effects', (commandType, tableText, activeCell) => {
+        const view = createView(tableText);
+        const afterDispatch = jest.fn();
+
+        const result = runStructuralMutationAndReopen({
+            view: view as never,
+            resolvedCell: createResolvedCell({
+                tableFrom: 0,
+                ...activeCell,
+            }),
+            command: { type: commandType },
+            afterDispatch,
+        });
+
+        expect(result).toBe(true);
+        expect(view.dispatch).toHaveBeenCalledTimes(1);
+        expect(afterDispatch).toHaveBeenCalledTimes(1);
+
+        const dispatched = view.dispatch.mock.calls[0][0] as {
+            changes?: unknown;
+            selection?: unknown;
+            effects: Array<{ is?: (value: unknown) => boolean }>;
+        };
+        expect(dispatched.changes).toEqual({
+            from: 0,
+            to: tableText.length,
+            insert: '',
+        });
+        expect(dispatched.selection).toBeUndefined();
+        expect(dispatched.effects.some((effect) => effect.is?.(clearActiveCellEffect))).toBe(true);
+        expect(dispatched.effects.some((effect) => effect.is?.(rebuildTableWidgetsEffect))).toBe(true);
+        expect(dispatched.effects.some((effect) => effect.is?.(requestOpenCellEffect))).toBe(false);
+        expect(dispatched.effects.some((effect) => effect.is?.(beginOpenCellRequestEffect))).toBe(false);
     });
 });

--- a/src/contentScript/__tests__/toolbarLayout.test.ts
+++ b/src/contentScript/__tests__/toolbarLayout.test.ts
@@ -32,6 +32,7 @@ describe('toolbarLayout', () => {
                 showMoveButtons: true,
                 showClearButtons: true,
                 showAlignmentButtons: true,
+                showDeleteTableButton: true,
             })
         );
 
@@ -63,6 +64,7 @@ describe('toolbarLayout', () => {
                 showMoveButtons: false,
                 showClearButtons: true,
                 showAlignmentButtons: true,
+                showDeleteTableButton: true,
             })
         );
 
@@ -78,6 +80,7 @@ describe('toolbarLayout', () => {
                 showMoveButtons: true,
                 showClearButtons: false,
                 showAlignmentButtons: true,
+                showDeleteTableButton: true,
             })
         );
 
@@ -94,6 +97,7 @@ describe('toolbarLayout', () => {
                 showMoveButtons: true,
                 showClearButtons: true,
                 showAlignmentButtons: false,
+                showDeleteTableButton: true,
             })
         );
 
@@ -109,6 +113,7 @@ describe('toolbarLayout', () => {
                 showMoveButtons: false,
                 showClearButtons: false,
                 showAlignmentButtons: false,
+                showDeleteTableButton: true,
             })
         );
 
@@ -122,5 +127,41 @@ describe('toolbarLayout', () => {
             'Delete table',
         ]);
         expect(layout.separatorCount).toBe(2);
+    });
+
+    it('hides the delete table button when disabled', () => {
+        const layout = renderLayout(
+            getToolbarButtonGroups({
+                showMoveButtons: true,
+                showClearButtons: true,
+                showAlignmentButtons: true,
+                showDeleteTableButton: false,
+            })
+        );
+
+        expect(layout.labels).toContain('Clear table');
+        expect(layout.labels).not.toContain('Delete table');
+        expect(layout.separatorCount).toBe(3);
+    });
+
+    it('omits the table group when clear and delete table buttons are both disabled', () => {
+        const layout = renderLayout(
+            getToolbarButtonGroups({
+                showMoveButtons: false,
+                showClearButtons: false,
+                showAlignmentButtons: false,
+                showDeleteTableButton: false,
+            })
+        );
+
+        expect(layout.labels).toEqual([
+            'Insert row before',
+            'Insert row after',
+            'Delete row',
+            'Insert column before',
+            'Insert column after',
+            'Delete column',
+        ]);
+        expect(layout.separatorCount).toBe(1);
     });
 });

--- a/src/contentScript/tableModel/structuralCommandSemantics.ts
+++ b/src/contentScript/tableModel/structuralCommandSemantics.ts
@@ -43,6 +43,9 @@ export type StructuralTableCommandById = {
     clearTable: {
         type: 'clearTable';
     };
+    deleteTable: {
+        type: 'deleteTable';
+    };
 };
 
 export type StructuralTableCommandId = keyof StructuralTableCommandById;
@@ -54,10 +57,17 @@ export type StructuralTableCommand =
           alignment: TableAlignment;
       };
 
-export interface StructuralTableCommandResult {
+export interface StructuralTableMutationResult {
+    kind: 'table';
     table: MarkdownTable;
     targetCell: TargetCell;
 }
+
+export interface StructuralTableDeleteResult {
+    kind: 'deleteTable';
+}
+
+export type StructuralTableCommandResult = StructuralTableMutationResult | StructuralTableDeleteResult;
 
 function sameCell(cell: CellCoords): TargetCell {
     return cell;
@@ -68,8 +78,9 @@ function commandResult(
     activeCell: CellCoords,
     table: MarkdownTable,
     targetCell: TargetCell
-): StructuralTableCommandResult {
+): StructuralTableMutationResult {
     return {
+        kind: 'table',
         table,
         targetCell: table === originalTable ? sameCell(activeCell) : targetCell,
     };
@@ -138,6 +149,15 @@ export function applyStructuralTableCommand(
                 col: activeCell.col + 1,
             });
         case 'deleteRow':
+            if (
+                (activeCell.section === 'header' && table.rowCount === 1) ||
+                (activeCell.section === 'body' &&
+                    activeCell.row >= 0 &&
+                    activeCell.row < table.bodyRows.length &&
+                    table.rowCount === 1)
+            ) {
+                return { kind: 'deleteTable' };
+            }
             return commandResult(
                 table,
                 activeCell,
@@ -145,6 +165,12 @@ export function applyStructuralTableCommand(
                 targetDeletedRow(activeCell)
             );
         case 'deleteColumn':
+            if (activeCell.col < 0 || activeCell.col >= table.columnCount) {
+                return commandResult(table, activeCell, table, sameCell(activeCell));
+            }
+            if (table.columnCount === 1) {
+                return { kind: 'deleteTable' };
+            }
             return commandResult(
                 table,
                 activeCell,
@@ -193,5 +219,7 @@ export function applyStructuralTableCommand(
                 table.updateColumnAlignment(activeCell.col, command.alignment),
                 sameCell(activeCell)
             );
+        case 'deleteTable':
+            return { kind: 'deleteTable' };
     }
 }

--- a/src/contentScript/tableModel/structuralCommandSemantics.ts
+++ b/src/contentScript/tableModel/structuralCommandSemantics.ts
@@ -122,6 +122,46 @@ function targetDeletedColumn(cell: CellCoords, table: MarkdownTable): TargetCell
     };
 }
 
+function isValidBodyRow(table: MarkdownTable, row: number): boolean {
+    return row >= 0 && row < table.bodyRows.length;
+}
+
+function isValidColumn(table: MarkdownTable, col: number): boolean {
+    return col >= 0 && col < table.columnCount;
+}
+
+function shouldDeleteWholeTableFromRow(table: MarkdownTable, activeCell: CellCoords): boolean {
+    return (
+        table.rowCount === 1 &&
+        (activeCell.section === 'header' || (activeCell.section === 'body' && isValidBodyRow(table, activeCell.row)))
+    );
+}
+
+function deleteRowResult(table: MarkdownTable, activeCell: CellCoords): StructuralTableCommandResult {
+    if (shouldDeleteWholeTableFromRow(table, activeCell)) {
+        return { kind: 'deleteTable' };
+    }
+
+    return commandResult(
+        table,
+        activeCell,
+        table.deleteRowAt(activeCell.section, activeCell.row),
+        targetDeletedRow(activeCell, table)
+    );
+}
+
+function deleteColumnResult(table: MarkdownTable, activeCell: CellCoords): StructuralTableCommandResult {
+    if (!isValidColumn(table, activeCell.col)) {
+        return commandResult(table, activeCell, table, sameCell(activeCell));
+    }
+
+    if (table.columnCount === 1) {
+        return { kind: 'deleteTable' };
+    }
+
+    return commandResult(table, activeCell, table.deleteColumn(activeCell.col), targetDeletedColumn(activeCell, table));
+}
+
 function targetMovedRowUp(cell: CellCoords): TargetCell {
     return cell.row === 0
         ? { section: 'header', row: 0, col: cell.col }
@@ -163,34 +203,9 @@ export function applyStructuralTableCommand(
                 col: activeCell.col + 1,
             });
         case 'deleteRow':
-            if (
-                (activeCell.section === 'header' && table.rowCount === 1) ||
-                (activeCell.section === 'body' &&
-                    activeCell.row >= 0 &&
-                    activeCell.row < table.bodyRows.length &&
-                    table.rowCount === 1)
-            ) {
-                return { kind: 'deleteTable' };
-            }
-            return commandResult(
-                table,
-                activeCell,
-                table.deleteRowAt(activeCell.section, activeCell.row),
-                targetDeletedRow(activeCell, table)
-            );
+            return deleteRowResult(table, activeCell);
         case 'deleteColumn':
-            if (activeCell.col < 0 || activeCell.col >= table.columnCount) {
-                return commandResult(table, activeCell, table, sameCell(activeCell));
-            }
-            if (table.columnCount === 1) {
-                return { kind: 'deleteTable' };
-            }
-            return commandResult(
-                table,
-                activeCell,
-                table.deleteColumn(activeCell.col),
-                targetDeletedColumn(activeCell, table)
-            );
+            return deleteColumnResult(table, activeCell);
         case 'moveRowUp':
             return commandResult(
                 table,

--- a/src/contentScript/tableModel/structuralCommandSemantics.ts
+++ b/src/contentScript/tableModel/structuralCommandSemantics.ts
@@ -99,9 +99,10 @@ function targetInsertedRowAfter(cell: CellCoords, targetCol: number = cell.col):
 }
 
 function targetDeletedRow(cell: CellCoords): TargetCell {
-    return cell.section === 'header'
-        ? { section: 'header', row: 0, col: cell.col }
-        : { section: 'body', row: Math.max(0, cell.row - 1), col: cell.col };
+    if (cell.section === 'body' && cell.row > 0) {
+        return { section: 'body', row: cell.row - 1, col: cell.col };
+    }
+    return { section: 'header', row: 0, col: cell.col };
 }
 
 function targetDeletedColumn(cell: CellCoords): TargetCell {

--- a/src/contentScript/tableModel/structuralCommandSemantics.ts
+++ b/src/contentScript/tableModel/structuralCommandSemantics.ts
@@ -98,15 +98,28 @@ function targetInsertedRowAfter(cell: CellCoords, targetCol: number = cell.col):
         : { section: 'body', row: cell.row + 1, col: targetCol };
 }
 
-function targetDeletedRow(cell: CellCoords): TargetCell {
-    if (cell.section === 'body' && cell.row > 0) {
+function targetDeletedRow(cell: CellCoords, table: MarkdownTable): TargetCell {
+    if (cell.section === 'header') {
+        return { section: 'header', row: 0, col: cell.col };
+    }
+
+    if (cell.row < table.bodyRows.length - 1) {
+        return { section: 'body', row: cell.row, col: cell.col };
+    }
+
+    if (cell.row > 0) {
         return { section: 'body', row: cell.row - 1, col: cell.col };
     }
+
     return { section: 'header', row: 0, col: cell.col };
 }
 
-function targetDeletedColumn(cell: CellCoords): TargetCell {
-    return { section: cell.section, row: cell.row, col: Math.max(0, cell.col - 1) };
+function targetDeletedColumn(cell: CellCoords, table: MarkdownTable): TargetCell {
+    return {
+        section: cell.section,
+        row: cell.row,
+        col: cell.col < table.columnCount - 1 ? cell.col : cell.col - 1,
+    };
 }
 
 function targetMovedRowUp(cell: CellCoords): TargetCell {
@@ -163,7 +176,7 @@ export function applyStructuralTableCommand(
                 table,
                 activeCell,
                 table.deleteRowAt(activeCell.section, activeCell.row),
-                targetDeletedRow(activeCell)
+                targetDeletedRow(activeCell, table)
             );
         case 'deleteColumn':
             if (activeCell.col < 0 || activeCell.col >= table.columnCount) {
@@ -176,7 +189,7 @@ export function applyStructuralTableCommand(
                 table,
                 activeCell,
                 table.deleteColumn(activeCell.col),
-                targetDeletedColumn(activeCell)
+                targetDeletedColumn(activeCell, table)
             );
         case 'moveRowUp':
             return commandResult(

--- a/src/contentScript/tableRuntime/operations/runStructuralMutation.ts
+++ b/src/contentScript/tableRuntime/operations/runStructuralMutation.ts
@@ -1,5 +1,5 @@
 import { EditorView } from '@codemirror/view';
-import { type ActiveCell } from '../../tableState/activeCellState';
+import { clearActiveCellEffect, type ActiveCell } from '../../tableState/activeCellState';
 import { rebuildTableWidgetsEffect } from '../../tableState/tableWidgetEffects';
 import { applyStructuralTableCommand, type StructuralTableCommand } from '../../tableModel/structuralCommandSemantics';
 import { prepareOpenCellRequestTransaction } from '../openCellRequest';
@@ -23,13 +23,22 @@ export interface RunStructuralMutationAndReopenParams extends StructuralReopenOp
     command: StructuralTableCommand;
 }
 
-interface PreparedStructuralMutation {
+interface PreparedTableMutation {
+    kind: 'table';
     tableFrom: number;
     tableTo: number;
     newText: string;
     hasDocumentChange: boolean;
     nextActiveCell: NonNullable<ReturnType<typeof createActiveCellForTableText>>;
 }
+
+interface PreparedTableDeletion {
+    kind: 'deleteTable';
+    tableFrom: number;
+    tableTo: number;
+}
+
+type PreparedStructuralMutation = PreparedTableMutation | PreparedTableDeletion;
 
 function prepareStructuralMutation(params: RunStructuralMutationAndReopenParams): PreparedStructuralMutation | null {
     const { resolvedCell } = params;
@@ -38,6 +47,14 @@ function prepareStructuralMutation(params: RunStructuralMutationAndReopenParams)
     const text = ctx.text;
 
     const mutationResult = applyStructuralTableCommand(ctx.table, cell, params.command);
+    if (mutationResult.kind === 'deleteTable') {
+        return {
+            kind: 'deleteTable',
+            tableFrom,
+            tableTo,
+        };
+    }
+
     const newTableData = mutationResult.table;
     if (newTableData === ctx.table) {
         return null;
@@ -58,6 +75,7 @@ function prepareStructuralMutation(params: RunStructuralMutationAndReopenParams)
     }
 
     return {
+        kind: 'table',
         tableFrom,
         tableTo,
         newText,
@@ -70,6 +88,19 @@ export function runStructuralMutationAndReopen(params: RunStructuralMutationAndR
     const prepared = prepareStructuralMutation(params);
     if (!prepared) {
         return false;
+    }
+
+    if (prepared.kind === 'deleteTable') {
+        params.view.dispatch({
+            changes: { from: prepared.tableFrom, to: prepared.tableTo, insert: '' },
+            effects: [
+                clearActiveCellEffect.of(undefined),
+                rebuildTableWidgetsEffect.of({ tableFrom: prepared.tableFrom }),
+            ],
+        });
+        params.afterDispatch?.();
+
+        return true;
     }
 
     const openTransaction = prepareOpenCellRequestTransaction({

--- a/src/contentScript/tableRuntime/operations/structuralActions.ts
+++ b/src/contentScript/tableRuntime/operations/structuralActions.ts
@@ -2,17 +2,13 @@ import type { EditorView } from '@codemirror/view';
 import type { TableAlignment } from '../../tableModel/MarkdownTable';
 import type { StructuralTableCommandById } from '../../tableModel/structuralCommandSemantics';
 import type { ResolvedActiveCell } from '../activeCell/resolvedActiveCell';
-import { deleteTable, runStructuralCommand } from './structuralOperations';
+import { runStructuralCommand } from './structuralOperations';
 
 type ModelBackedStructuralActionId = keyof StructuralTableCommandById;
 type CommandForId<Id extends ModelBackedStructuralActionId> = StructuralTableCommandById[Id];
 type AlignmentStructuralActionId = 'alignLeft' | 'alignCenter' | 'alignRight';
-type RuntimeOnlyStructuralActionId = 'deleteTable';
 
-export type StructuralActionId =
-    | ModelBackedStructuralActionId
-    | AlignmentStructuralActionId
-    | RuntimeOnlyStructuralActionId;
+export type StructuralActionId = ModelBackedStructuralActionId | AlignmentStructuralActionId;
 
 const modelBackedCommands = {
     insertRowBefore: { type: 'insertRowBefore' },
@@ -28,6 +24,7 @@ const modelBackedCommands = {
     clearRow: { type: 'clearRow' },
     clearColumn: { type: 'clearColumn' },
     clearTable: { type: 'clearTable' },
+    deleteTable: { type: 'deleteTable' },
 } satisfies { [Id in ModelBackedStructuralActionId]: CommandForId<Id> };
 
 const alignmentCommands = {
@@ -48,23 +45,6 @@ function assertNeverAction(actionId: never): never {
     throw new Error(`Unhandled structural action: ${actionId}`);
 }
 
-const runtimeOnlyActions = {
-    deleteTable,
-} satisfies Record<RuntimeOnlyStructuralActionId, typeof deleteTable>;
-
-function runRuntimeOnlyAction(
-    view: EditorView,
-    actionId: RuntimeOnlyStructuralActionId,
-    resolvedCell: ResolvedActiveCell
-): boolean {
-    switch (actionId) {
-        case 'deleteTable':
-            return runtimeOnlyActions.deleteTable(view, resolvedCell);
-        default:
-            return assertNeverAction(actionId);
-    }
-}
-
 export function runStructuralAction(
     view: EditorView,
     actionId: StructuralActionId,
@@ -81,5 +61,5 @@ export function runStructuralAction(
         });
     }
 
-    return runRuntimeOnlyAction(view, actionId, resolvedCell);
+    return assertNeverAction(actionId);
 }

--- a/src/contentScript/tableRuntime/operations/structuralOperations.ts
+++ b/src/contentScript/tableRuntime/operations/structuralOperations.ts
@@ -1,6 +1,4 @@
 import { EditorView } from '@codemirror/view';
-import { clearActiveCellEffect } from '../../tableState/activeCellState';
-import { rebuildTableWidgetsEffect } from '../../tableState/tableWidgetEffects';
 import type { TableAlignment } from '../../tableModel/MarkdownTable';
 import type { StructuralTableCommand } from '../../tableModel/structuralCommandSemantics';
 import type { ResolvedActiveCell } from '../activeCell/resolvedActiveCell';
@@ -49,20 +47,6 @@ export function runStructuralCommand(
         ...defaults,
         ...options,
     });
-}
-
-export function deleteTable(view: EditorView, resolvedCell: ResolvedActiveCell): boolean {
-    view.dispatch({
-        changes: { from: resolvedCell.tableFrom, to: resolvedCell.tableTo, insert: '' },
-        effects: [
-            clearActiveCellEffect.of(undefined),
-            rebuildTableWidgetsEffect.of({ tableFrom: resolvedCell.tableFrom }),
-        ],
-    });
-
-    focusMainEditorWithoutScroll(view);
-
-    return true;
 }
 
 export function updateAlignment(

--- a/src/contentScript/tableRuntime/selection/cellSelectionClipboard.ts
+++ b/src/contentScript/tableRuntime/selection/cellSelectionClipboard.ts
@@ -174,6 +174,16 @@ function buildTableRewrite(params: {
     };
 }
 
+function buildTableDeletionRewrite(tableFrom: number): TableClipboardRewrite {
+    return {
+        tableFrom,
+        tableText: '',
+        selection: null,
+        clearActiveCell: true,
+        selectionAnchorPos: tableFrom,
+    };
+}
+
 function clampIndex(value: number, max: number): number {
     return Math.max(0, Math.min(value, max));
 }
@@ -226,17 +236,11 @@ export function buildSelectionRemovalRewrite(
     const spansAllRows = rect.minRow === 0 && rect.maxRow === ctx.table.rowCount - 1;
     const spansAllCols = rect.minCol === 0 && rect.maxCol === ctx.table.columnCount - 1;
 
-    if (isEmptySelection && spansAllRows && spansAllCols) {
-        return {
-            tableFrom: ctx.from,
-            tableText: '',
-            selection: null,
-            clearActiveCell: true,
-            selectionAnchorPos: ctx.from,
-        };
-    }
-
     if (isEmptySelection && spansAllCols) {
+        if (rect.minRow === 0 && rect.maxRow === ctx.table.rowCount - 1) {
+            return buildTableDeletionRewrite(ctx.from);
+        }
+
         const nextTable = ctx.table.deleteUnifiedRowRange(rect.minRow, rect.maxRow);
         if (nextTable !== ctx.table) {
             return buildTableRewrite({
@@ -249,6 +253,10 @@ export function buildSelectionRemovalRewrite(
     }
 
     if (isEmptySelection && spansAllRows) {
+        if (rect.minCol === 0 && rect.maxCol === ctx.table.columnCount - 1) {
+            return buildTableDeletionRewrite(ctx.from);
+        }
+
         const nextTable = ctx.table.deleteColumnRange(rect.minCol, rect.maxCol);
         if (nextTable !== ctx.table) {
             return buildTableRewrite({

--- a/src/contentScript/tableRuntime/selection/cellSelectionClipboard.ts
+++ b/src/contentScript/tableRuntime/selection/cellSelectionClipboard.ts
@@ -236,11 +236,11 @@ export function buildSelectionRemovalRewrite(
     const spansAllRows = rect.minRow === 0 && rect.maxRow === ctx.table.rowCount - 1;
     const spansAllCols = rect.minCol === 0 && rect.maxCol === ctx.table.columnCount - 1;
 
-    if (isEmptySelection && spansAllCols) {
-        if (rect.minRow === 0 && rect.maxRow === ctx.table.rowCount - 1) {
-            return buildTableDeletionRewrite(ctx.from);
-        }
+    if (isEmptySelection && spansAllRows && spansAllCols) {
+        return buildTableDeletionRewrite(ctx.from);
+    }
 
+    if (isEmptySelection && spansAllCols) {
         const nextTable = ctx.table.deleteUnifiedRowRange(rect.minRow, rect.maxRow);
         if (nextTable !== ctx.table) {
             return buildTableRewrite({
@@ -253,10 +253,6 @@ export function buildSelectionRemovalRewrite(
     }
 
     if (isEmptySelection && spansAllRows) {
-        if (rect.minCol === 0 && rect.maxCol === ctx.table.columnCount - 1) {
-            return buildTableDeletionRewrite(ctx.from);
-        }
-
         const nextTable = ctx.table.deleteColumnRange(rect.minCol, rect.maxCol);
         if (nextTable !== ctx.table) {
             return buildTableRewrite({

--- a/src/contentScript/toolbar/toolbarLayout.ts
+++ b/src/contentScript/toolbar/toolbarLayout.ts
@@ -141,14 +141,12 @@ const alignmentButtons: ToolbarButtonDescriptor[] = [
     },
 ];
 
-const deleteTableButtons: ToolbarButtonDescriptor[] = [
-    {
-        actionId: 'deleteTable',
-        title: 'Delete table',
-        ariaLabel: 'Delete table',
-        iconFactory: deleteTableIcon,
-    },
-];
+const deleteTableButton: ToolbarButtonDescriptor = {
+    actionId: 'deleteTable',
+    title: 'Delete table',
+    ariaLabel: 'Delete table',
+    iconFactory: deleteTableIcon,
+};
 
 export function getToolbarButtonGroups(settings: ToolbarHostConfig): ToolbarButtonDescriptor[][] {
     const rowButtons = [...baseRowButtons];
@@ -164,16 +162,19 @@ export function getToolbarButtonGroups(settings: ToolbarHostConfig): ToolbarButt
         columnButtons.push(clearColumnButton);
     }
 
-    const tableButtons = settings.showClearButtons
-        ? [clearTableButton, ...deleteTableButtons]
-        : [...deleteTableButtons];
+    const tableButtons = [
+        ...(settings.showClearButtons ? [clearTableButton] : []),
+        ...(settings.showDeleteTableButton ? [deleteTableButton] : []),
+    ];
     const groups: ToolbarButtonDescriptor[][] = [rowButtons, columnButtons];
 
     if (settings.showAlignmentButtons) {
         groups.push(alignmentButtons);
     }
 
-    groups.push(tableButtons);
+    if (tableButtons.length > 0) {
+        groups.push(tableButtons);
+    }
 
     return groups;
 }

--- a/src/contentScriptBridge/hostEditorConfigBridge.ts
+++ b/src/contentScriptBridge/hostEditorConfigBridge.ts
@@ -4,6 +4,7 @@ export const AUTO_MATCHING_BRACES_SETTING_KEY = 'editor.autoMatchingBraces';
 export const TOOLBAR_SHOW_MOVE_BUTTONS_SETTING_KEY = 'floatingToolbar.showMoveButtons';
 export const TOOLBAR_SHOW_CLEAR_BUTTONS_SETTING_KEY = 'floatingToolbar.showClearButtons';
 export const TOOLBAR_SHOW_ALIGNMENT_BUTTONS_SETTING_KEY = 'floatingToolbar.showAlignmentButtons';
+export const TOOLBAR_SHOW_DELETE_TABLE_BUTTON_SETTING_KEY = 'floatingToolbar.showDeleteTableButton';
 
 export interface HostEditorConfig {
     nestedEditor: {
@@ -13,6 +14,7 @@ export interface HostEditorConfig {
         showMoveButtons: boolean;
         showClearButtons: boolean;
         showAlignmentButtons: boolean;
+        showDeleteTableButton: boolean;
     };
 }
 
@@ -39,6 +41,7 @@ export function defaultHostEditorConfig(): HostEditorConfig {
             showMoveButtons: true,
             showClearButtons: true,
             showAlignmentButtons: true,
+            showDeleteTableButton: true,
         },
     };
 }
@@ -60,7 +63,8 @@ export function isHostEditorConfig(value: unknown): value is HostEditorConfig {
         toolbar !== null &&
         typeof toolbar.showMoveButtons === 'boolean' &&
         typeof toolbar.showClearButtons === 'boolean' &&
-        typeof toolbar.showAlignmentButtons === 'boolean'
+        typeof toolbar.showAlignmentButtons === 'boolean' &&
+        typeof toolbar.showDeleteTableButton === 'boolean'
     );
 }
 
@@ -94,6 +98,7 @@ async function readToolbarConfig(deps: HostEditorConfigDeps): Promise<ToolbarHos
             TOOLBAR_SHOW_MOVE_BUTTONS_SETTING_KEY,
             TOOLBAR_SHOW_CLEAR_BUTTONS_SETTING_KEY,
             TOOLBAR_SHOW_ALIGNMENT_BUTTONS_SETTING_KEY,
+            TOOLBAR_SHOW_DELETE_TABLE_BUTTON_SETTING_KEY,
         ]);
 
         return {
@@ -111,6 +116,11 @@ async function readToolbarConfig(deps: HostEditorConfigDeps): Promise<ToolbarHos
                 values,
                 TOOLBAR_SHOW_ALIGNMENT_BUTTONS_SETTING_KEY,
                 defaults.showAlignmentButtons
+            ),
+            showDeleteTableButton: readBooleanSetting(
+                values,
+                TOOLBAR_SHOW_DELETE_TABLE_BUTTON_SETTING_KEY,
+                defaults.showDeleteTableButton
             ),
         };
     } catch (error) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { createContentScriptMessageHandler } from './contentScriptBridge/content
 import {
     TOOLBAR_SHOW_ALIGNMENT_BUTTONS_SETTING_KEY,
     TOOLBAR_SHOW_CLEAR_BUTTONS_SETTING_KEY,
+    TOOLBAR_SHOW_DELETE_TABLE_BUTTON_SETTING_KEY,
     TOOLBAR_SHOW_MOVE_BUTTONS_SETTING_KEY,
 } from './contentScriptBridge/hostEditorConfigBridge';
 
@@ -47,6 +48,14 @@ joplin.plugins.register({
                 section: SETTINGS_SECTION,
                 label: 'Show alignment buttons',
                 description: 'Display align left, center, and right actions in the floating table toolbar.',
+            },
+            [TOOLBAR_SHOW_DELETE_TABLE_BUTTON_SETTING_KEY]: {
+                value: true,
+                type: SettingItemType.Bool,
+                public: true,
+                section: SETTINGS_SECTION,
+                label: 'Show delete table button',
+                description: 'Display the delete table action in the floating table toolbar.',
             },
         });
 


### PR DESCRIPTION
Refactor table deletion to be a model-backed command, ensuring that deleting the last row or column removes the entire table. Improve row/column deletion ux so that the cursor goes to the row/column that would occupy the visual space of the deleted row/column. Make the delete table icon optional in the toolbar.