### PR TITLE
refactor: remove unnecessary effect, clearer naming

### DIFF
--- a/src/contentScript/__tests__/cellSelectionKeymap.test.ts
+++ b/src/contentScript/__tests__/cellSelectionKeymap.test.ts
@@ -14,7 +14,7 @@ import { activeCellField, getActiveCell, setActiveCellEffect } from '../tableSta
 import { setCellSelectionEffect, getCellSelection, cellSelectionField } from '../tableState/cellSelectionState';
 import { startCellSelectionFromActiveCell } from '../tableRuntime/selection/cellSelectionController';
 import { cellSelectionKeyCapturePlugin } from '../tableRuntime/selection/cellSelectionKeymap';
-import { requestOpenCellEffect } from '../tableRuntime/openCellRequest';
+import { triggerOpenCellRequestEffect } from '../tableRuntime/openCellRequest';
 
 const markdownExtension = markdown({
     extensions: [GFM],
@@ -275,7 +275,7 @@ describe('cellSelectionKeymap', () => {
         });
         const lastSpec = dispatchSpy.mock.calls[dispatchSpy.mock.calls.length - 1]?.[0];
         const effects = Array.isArray(lastSpec?.effects) ? lastSpec.effects : [lastSpec?.effects];
-        expect(effects.some((effect) => effect?.is?.(requestOpenCellEffect))).toBe(true);
+        expect(effects.some((effect) => effect?.is?.(triggerOpenCellRequestEffect))).toBe(true);
 
         view.destroy();
     });

--- a/src/contentScript/__tests__/interactiveCellNormalization.test.ts
+++ b/src/contentScript/__tests__/interactiveCellNormalization.test.ts
@@ -9,7 +9,7 @@ import { sourceModeField } from '../tableState/sourceMode';
 import { createMarkdownState } from './testMarkdownState';
 import { handleTableInteraction } from '../tableWidget/tableWidgetInteractions';
 import { navigateCell } from '../tableRuntime/navigation/tableNavigation';
-import { requestOpenCellEffect } from '../tableRuntime/openCellRequest';
+import { triggerOpenCellRequestEffect } from '../tableRuntime/openCellRequest';
 import {
     beginOpenCellRequestEffect,
     getPendingOpenCellRequest,
@@ -47,7 +47,7 @@ function getLastDispatchSpec(view: MutableTestView): TransactionSpec {
 
 function findOpenRequest(spec: TransactionSpec) {
     const effects = Array.isArray(spec.effects) ? spec.effects : [spec.effects];
-    return effects.find((effect) => effect?.is?.(requestOpenCellEffect)) ?? null;
+    return effects.find((effect) => effect?.is?.(triggerOpenCellRequestEffect)) ?? null;
 }
 
 function findBeginOpenRequest(spec: TransactionSpec) {

--- a/src/contentScript/__tests__/nestedEditorLifecycle.test.ts
+++ b/src/contentScript/__tests__/nestedEditorLifecycle.test.ts
@@ -20,7 +20,7 @@ import { rebuildTableWidgetsEffect } from '../tableState/tableWidgetEffects';
 import { markdown } from '@codemirror/lang-markdown';
 import { GFM } from '@lezer/markdown';
 import { resolveActiveCell } from '../tableRuntime/activeCell/resolvedActiveCell';
-import { requestOpenCellEffect } from '../tableRuntime/openCellRequest';
+import { triggerOpenCellRequestEffect } from '../tableRuntime/openCellRequest';
 import {
     beginOpenCellRequestEffect,
     getPendingOpenCellRequest,
@@ -70,7 +70,7 @@ function openRequestEffects(params: {
 
     return [
         beginOpenCellRequestEffect.of(request),
-        requestOpenCellEffect.of({
+        triggerOpenCellRequestEffect.of({
             requestId: params.requestId,
         }),
     ];
@@ -483,7 +483,7 @@ describe('nestedEditorLifecycle', () => {
         });
 
         view.dispatch({
-            effects: requestOpenCellEffect.of({ requestId: 'missing-request' }),
+            effects: triggerOpenCellRequestEffect.of({ requestId: 'missing-request' }),
         });
         flushAnimationFrames();
 
@@ -548,7 +548,8 @@ describe('nestedEditorLifecycle', () => {
                     ) &&
                     effects.some(
                         (effect) =>
-                            effect?.is?.(requestOpenCellEffect) && effect.value?.requestId === 'request-normalize'
+                            effect?.is?.(triggerOpenCellRequestEffect) &&
+                            effect.value?.requestId === 'request-normalize'
                     )
                 );
             });

--- a/src/contentScript/__tests__/openCellRequest.test.ts
+++ b/src/contentScript/__tests__/openCellRequest.test.ts
@@ -7,8 +7,7 @@ import { EditorView } from '@codemirror/view';
 import { activeCellField, type ActiveCell } from '../tableState/activeCellState';
 import {
     beginOpenCellRequestEffect,
-    completeOpenCellRequestEffect,
-    failOpenCellRequestEffect,
+    clearOpenCellRequestEffect,
     getPendingOpenCellRequest,
     openCellRequestField,
     openCellRequestTimeoutPlugin,
@@ -58,29 +57,29 @@ describe('openCellRequestField', () => {
         });
     });
 
-    it('clears only the matching request on completion', () => {
+    it('clears only the matching request', () => {
         const state = beginRequest(createState());
 
-        const staleComplete = state.update({
-            effects: completeOpenCellRequestEffect.of({ requestId: 'stale' }),
+        const staleClear = state.update({
+            effects: clearOpenCellRequestEffect.of({ requestId: 'stale' }),
         }).state;
-        expect(getPendingOpenCellRequest(staleComplete)?.requestId).toBe('request-1');
+        expect(getPendingOpenCellRequest(staleClear)?.requestId).toBe('request-1');
 
-        const complete = staleComplete.update({
-            effects: completeOpenCellRequestEffect.of({ requestId: 'request-1' }),
+        const cleared = staleClear.update({
+            effects: clearOpenCellRequestEffect.of({ requestId: 'request-1' }),
         }).state;
-        expect(getPendingOpenCellRequest(complete)).toBeNull();
+        expect(getPendingOpenCellRequest(cleared)).toBeNull();
     });
 
-    it('does not let stale failure clear a newer request', () => {
+    it('does not let stale clear remove a newer request', () => {
         const first = beginRequest(createState(), { requestId: 'request-1' });
         const second = beginRequest(first, { requestId: 'request-2' });
 
-        const failed = second.update({
-            effects: failOpenCellRequestEffect.of({ requestId: 'request-1' }),
+        const cleared = second.update({
+            effects: clearOpenCellRequestEffect.of({ requestId: 'request-1' }),
         }).state;
 
-        expect(getPendingOpenCellRequest(failed)?.requestId).toBe('request-2');
+        expect(getPendingOpenCellRequest(cleared)?.requestId).toBe('request-2');
     });
 
     it('maps active cell table start through document changes', () => {

--- a/src/contentScript/__tests__/tableNavigation.test.ts
+++ b/src/contentScript/__tests__/tableNavigation.test.ts
@@ -5,7 +5,7 @@ import { getResolvedActiveCell, resolveCellWithinResolvedTable } from '../tableR
 import { SECTION_BODY, SECTION_HEADER } from '../tableWidget/domHelpers';
 
 import { setActiveCellEffect } from '../tableState/activeCellState';
-import { requestOpenCellEffect } from '../tableRuntime/openCellRequest';
+import { triggerOpenCellRequestEffect } from '../tableRuntime/openCellRequest';
 import { insertRowAtBottom } from '../tableRuntime/operations/structuralOperations';
 import { beginOpenCellRequestEffect } from '../tableRuntime/openCellRequest';
 
@@ -69,7 +69,7 @@ describe('navigateCell', () => {
     };
 
     const getSetActiveCellValue = () => getEffects().find((effect) => effect.is?.(setActiveCellEffect))?.value;
-    const getOpenRequestValue = () => getEffects().find((effect) => effect.is?.(requestOpenCellEffect))?.value;
+    const getOpenRequestValue = () => getEffects().find((effect) => effect.is?.(triggerOpenCellRequestEffect))?.value;
     const getBeginRequestValue = () => getEffects().find((effect) => effect.is?.(beginOpenCellRequestEffect))?.value;
 
     const setupTable = (rows: number, cols: number) => {

--- a/src/contentScript/__tests__/tableRuntimePolicies.test.ts
+++ b/src/contentScript/__tests__/tableRuntimePolicies.test.ts
@@ -25,7 +25,7 @@ import { syncAnnotation } from '../editorBridge/syncAnnotation';
 import { createMarkdownState } from './testMarkdownState';
 import { normalizeBeforeEditAnnotation } from '../tableRuntime/lifecycle/tableNormalization';
 import { createActiveCellForTableText } from '../tableRuntime/activeCell/activeCellFactory';
-import { requestOpenCellEffect } from '../tableRuntime/openCellRequest';
+import { triggerOpenCellRequestEffect } from '../tableRuntime/openCellRequest';
 
 const doc = ['| H1 | H2 |', '| --- | --- |', '| a1 | a2 |'].join('\n');
 
@@ -367,7 +367,7 @@ describe('tableRuntimePolicies', () => {
             effects: [
                 setActiveCellEffect.of(nextActiveCell.activeCell),
                 rebuildTableWidgetsEffect.of({ tableFrom: 0 }),
-                requestOpenCellEffect.of({
+                triggerOpenCellRequestEffect.of({
                     requestId: 'normalize-request',
                 }),
             ],
@@ -435,7 +435,7 @@ describe('tableRuntimePolicies', () => {
         const startState = createState({ activeCell });
         const { event } = createViewUpdate(startState, {
             effects: [
-                requestOpenCellEffect.of({
+                triggerOpenCellRequestEffect.of({
                     requestId: 'explicit-request',
                 }),
                 rebuildTableWidgetsEffect.of({ tableFrom: activeCell.tableFrom }),
@@ -462,10 +462,10 @@ describe('tableRuntimePolicies', () => {
         const startState = createState({ activeCell });
         const { event } = createViewUpdate(startState, {
             effects: [
-                requestOpenCellEffect.of({
+                triggerOpenCellRequestEffect.of({
                     requestId: 'stale-request',
                 }),
-                requestOpenCellEffect.of({
+                triggerOpenCellRequestEffect.of({
                     requestId: 'latest-request',
                 }),
             ],

--- a/src/contentScript/__tests__/tableTransactionHelpers.test.ts
+++ b/src/contentScript/__tests__/tableTransactionHelpers.test.ts
@@ -6,7 +6,7 @@ import { computeMarkdownTableCellRanges } from '../tableModel/markdownTableCellR
 import { runStructuralMutationAndReopen } from '../tableRuntime/operations/runStructuralMutation';
 import { clearActiveCellEffect, setActiveCellEffect } from '../tableState/activeCellState';
 import { rebuildTableWidgetsEffect } from '../tableState/tableWidgetEffects';
-import { requestOpenCellEffect } from '../tableRuntime/openCellRequest';
+import { triggerOpenCellRequestEffect } from '../tableRuntime/openCellRequest';
 import { createActiveCellForTableText } from '../tableRuntime/activeCell/activeCellFactory';
 import { beginOpenCellRequestEffect } from '../tableRuntime/openCellRequest';
 
@@ -106,7 +106,7 @@ describe('tableTransactionHelpers', () => {
             effects.some((effect: { is?: (value: unknown) => boolean }) => effect.is?.(rebuildTableWidgetsEffect))
         ).toBe(true);
         const openRequest = effects.find((effect: { is?: (value: unknown) => boolean }) =>
-            effect.is?.(requestOpenCellEffect)
+            effect.is?.(triggerOpenCellRequestEffect)
         );
         const beginRequest = effects.find((effect: { is?: (value: unknown) => boolean }) =>
             effect.is?.(beginOpenCellRequestEffect)
@@ -160,7 +160,7 @@ describe('tableTransactionHelpers', () => {
 
         const effects = dispatched.effects;
         expect(effects.some((effect) => effect.is?.(setActiveCellEffect))).toBe(true);
-        expect(effects.some((effect) => effect.is?.(requestOpenCellEffect))).toBe(true);
+        expect(effects.some((effect) => effect.is?.(triggerOpenCellRequestEffect))).toBe(true);
         expect(effects.some((effect) => effect.is?.(rebuildTableWidgetsEffect))).toBe(true);
     });
 
@@ -194,7 +194,7 @@ describe('tableTransactionHelpers', () => {
             effects: Array<{ is?: (value: unknown) => boolean; value?: unknown }>;
         };
         expect(dispatched.changes?.insert).toBe(updatedTableText);
-        expect(dispatched.effects.some((effect) => effect.is?.(requestOpenCellEffect))).toBe(true);
+        expect(dispatched.effects.some((effect) => effect.is?.(triggerOpenCellRequestEffect))).toBe(true);
         expect(dispatched.effects.some((effect) => effect.is?.(rebuildTableWidgetsEffect))).toBe(true);
     });
 
@@ -233,7 +233,7 @@ describe('tableTransactionHelpers', () => {
         expect(dispatched.selection).toBeUndefined();
         expect(dispatched.effects.some((effect) => effect.is?.(clearActiveCellEffect))).toBe(true);
         expect(dispatched.effects.some((effect) => effect.is?.(rebuildTableWidgetsEffect))).toBe(true);
-        expect(dispatched.effects.some((effect) => effect.is?.(requestOpenCellEffect))).toBe(false);
+        expect(dispatched.effects.some((effect) => effect.is?.(triggerOpenCellRequestEffect))).toBe(false);
         expect(dispatched.effects.some((effect) => effect.is?.(beginOpenCellRequestEffect))).toBe(false);
     });
 });

--- a/src/contentScript/tableRuntime/lifecycle/lifecyclePolicy.ts
+++ b/src/contentScript/tableRuntime/lifecycle/lifecyclePolicy.ts
@@ -12,7 +12,7 @@ import { syncAnnotation } from '../../editorBridge/syncAnnotation';
 import { getResolvedActiveCell, type ResolvedActiveCell } from '../activeCell/resolvedActiveCell';
 import { isFullDocumentReplace } from '../../shared/transactionUtils';
 import { normalizeBeforeEditAnnotation } from './tableNormalization';
-import { requestOpenCellEffect } from '../openCellRequest';
+import { triggerOpenCellRequestEffect } from '../openCellRequest';
 import { transactionRequiresTableRebuild } from '../tableTransactionHelpers';
 
 export interface TableRuntimeSnapshot {
@@ -90,7 +90,7 @@ function extractOpenRequestId(update: ViewUpdate): string | null {
 
     for (const tr of update.transactions) {
         for (const effect of tr.effects) {
-            if (effect.is(requestOpenCellEffect)) {
+            if (effect.is(triggerOpenCellRequestEffect)) {
                 requestId = effect.value.requestId;
             }
         }

--- a/src/contentScript/tableRuntime/lifecycle/nestedEditorLifecycle.ts
+++ b/src/contentScript/tableRuntime/lifecycle/nestedEditorLifecycle.ts
@@ -23,10 +23,9 @@ import { createActiveCellForTableText } from '../activeCell/activeCellFactory';
 import { activateCellAtPosition, activateTableCell } from '../activeCell/cellActivation';
 import {
     beginOpenCellRequestEffect,
-    completeOpenCellRequestEffect,
-    failOpenCellRequestEffect,
+    clearOpenCellRequestEffect,
     getOpenCellRequestById,
-    requestOpenCellEffect,
+    triggerOpenCellRequestEffect,
 } from '../openCellRequest';
 import { getNormalizedTableReplacementIfChanged, normalizeBeforeEditAnnotation } from './tableNormalization';
 import { hostEditorConfigFacet } from '../../services/hostEditorConfig';
@@ -128,7 +127,7 @@ function normalizeTableBeforeOpen(params: {
                 activeCell: nextActiveCell.activeCell,
                 normalizeIfNeeded: false,
             }),
-            requestOpenCellEffect.of({ requestId: currentRequest.requestId }),
+            triggerOpenCellRequestEffect.of({ requestId: currentRequest.requestId }),
             rebuildTableWidgetsEffect.of({ tableFrom: replacement.tableFrom }),
         ],
         annotations: normalizeBeforeEditAnnotation.of(true),
@@ -190,7 +189,7 @@ export const nestedEditorLifecyclePlugin = ViewPlugin.fromClass(
         private executeActions(actions: readonly TableRuntimeAction[], update: ViewUpdate): void {
             const failOpenRequest = (requestId: string | undefined): void => {
                 if (!requestId) return;
-                this.view.dispatch({ effects: failOpenCellRequestEffect.of({ requestId }) });
+                this.view.dispatch({ effects: clearOpenCellRequestEffect.of({ requestId }) });
             };
 
             for (const action of actions) {
@@ -305,7 +304,7 @@ export const nestedEditorLifecyclePlugin = ViewPlugin.fromClass(
                             }
                             requestViewAnimationFrame(this.view, () => {
                                 this.view.dispatch({
-                                    effects: completeOpenCellRequestEffect.of({ requestId }),
+                                    effects: clearOpenCellRequestEffect.of({ requestId }),
                                 });
                             });
                         });

--- a/src/contentScript/tableRuntime/openCellRequest.ts
+++ b/src/contentScript/tableRuntime/openCellRequest.ts
@@ -5,6 +5,8 @@ import { setActiveCellEffect, type ActiveCell } from '../tableState/activeCellSt
 import { clearCellSelectionEffect } from '../tableState/cellSelectionState';
 import type { ResolvedActiveCell } from './activeCell/resolvedActiveCell';
 
+// Explicit open requests are single-flight, may survive normalization/rebuilds,
+// and temporarily suppress navigation until settled.
 const OPEN_CELL_REQUEST_TIMEOUT_MS = 1000;
 
 export interface OpenCellRequest {
@@ -15,7 +17,7 @@ export interface OpenCellRequest {
     suppressKeys: boolean;
 }
 
-export interface FinishOpenCellRequest {
+export interface ClearOpenCellRequest {
     requestId: string;
 }
 
@@ -85,9 +87,8 @@ export const beginOpenCellRequestEffect = StateEffect.define<OpenCellRequest>({
     },
 });
 
-export const completeOpenCellRequestEffect = StateEffect.define<FinishOpenCellRequest>();
-export const failOpenCellRequestEffect = StateEffect.define<FinishOpenCellRequest>();
-export const requestOpenCellEffect = StateEffect.define<OpenCellRequestSignal>();
+export const clearOpenCellRequestEffect = StateEffect.define<ClearOpenCellRequest>();
+export const triggerOpenCellRequestEffect = StateEffect.define<OpenCellRequestSignal>();
 
 function resolveOpenCellRequestTarget(target: OpenCellRequestTarget): {
     activeCell: ActiveCell;
@@ -121,7 +122,7 @@ export function prepareOpenCellRequestTransaction(params: RequestOpenCellParams)
             ...(params.clearCellSelection ? [clearCellSelectionEffect.of(undefined)] : []),
             setActiveCellEffect.of(activeCell),
             beginOpenCellRequestEffect.of(request),
-            requestOpenCellEffect.of({
+            triggerOpenCellRequestEffect.of({
                 requestId,
             }),
         ],
@@ -151,11 +152,7 @@ export const openCellRequestField = StateField.define<OpenCellRequest | null>({
                 continue;
             }
 
-            if (
-                nextValue &&
-                (effect.is(completeOpenCellRequestEffect) || effect.is(failOpenCellRequestEffect)) &&
-                effect.value.requestId === nextValue.requestId
-            ) {
+            if (nextValue && effect.is(clearOpenCellRequestEffect) && effect.value.requestId === nextValue.requestId) {
                 nextValue = null;
             }
         }
@@ -243,7 +240,7 @@ export const openCellRequestTimeoutPlugin = ViewPlugin.fromClass(
 
                 logger.warn('Open-cell request timed out - forcing release');
                 this.view.dispatch({
-                    effects: failOpenCellRequestEffect.of({ requestId: request.requestId }),
+                    effects: clearOpenCellRequestEffect.of({ requestId: request.requestId }),
                 });
             }, OPEN_CELL_REQUEST_TIMEOUT_MS);
         }


### PR DESCRIPTION
- Remove the split between completed/fail; no code consumed them differently, so two effects were maintaining a semantic distinction that existed nowhere in the actual logic

- rename requestOpenCellEffect > triggerOpenCellRequestEffect clearly indicating that it's just a signal, not a new request