### PR TITLE
refactor: Expand Lifecycle Policy Into A Runtime Reducer

### DIFF
--- a/docs/Architecture/Overview.md
+++ b/docs/Architecture/Overview.md
@@ -20,6 +20,7 @@ than calling back into Joplin or keeping module-level settings caches.
 ## Documentation Index
 
 - [Table-Display.md](./Table-Display.md) - Rendering, optimizations, display modes.
+- [Table-Runtime-Invariants.md](./Table-Runtime-Invariants.md) - Cross-module runtime rules for active cells, sync, rebuilds, and focus.
 - [Nested-Editor-Architecture.md](./Nested-Editor-Architecture.md) - Synchronization, boundary enforcement, undo/redo.
 - [Interaction-and-Navigation.md](./Interaction-and-Navigation.md) - Keyboard navigation, selection logic.
 - [Structural-Commands-and-Serialization.md](./Structural-Commands-and-Serialization.md) - Command flow, serialization.

--- a/docs/Architecture/Table-Runtime-Invariants.md
+++ b/docs/Architecture/Table-Runtime-Invariants.md
@@ -1,0 +1,77 @@
+# Table Runtime Invariants
+
+The table runtime is a cross-file state machine. These invariants define the rules that must stay true across active-cell state, widget decorations, nested editing, structural commands, selection, and focus handling.
+
+## Source of Truth
+
+- The main CodeMirror document is the only authoritative table state.
+- `MarkdownTable`, `TableContext`, and cell ranges are derived from current document text.
+- Widget DOM is a projection of document state. It must not be used as durable table state.
+- Nested editor text is temporary local state for one active cell. It must be synchronized back to the main document before commands depend on it.
+
+## Active Cell Identity
+
+- `ActiveCell` is logical identity: table start position, section, row, column, and selection anchor intent.
+- `ResolvedActiveCell` is a derived lookup against the current document. Treat it as disposable after document changes.
+- Runtime code must re-resolve an active cell before using document offsets such as editable cell bounds.
+- If the active cell can no longer resolve after a non-sync document change, clear it instead of keeping stale positions.
+
+## Cell Bounds
+
+- Semantic cell bounds and editable text bounds are not interchangeable.
+- Semantic bounds identify the Markdown cell span, including delimiters and padding.
+- Editable bounds identify the user-editable cell content.
+- Cross-editor selection conversion must use editable bounds and `cellTextCodec` helpers.
+- Structural table commands must operate on the parsed table model, not on nested editor DOM.
+
+## Sync Transactions
+
+- Any transaction forwarding changes between the main editor and nested editor must carry `syncAnnotation`.
+- Sync transactions must not trigger another mirrored sync pass.
+- Nested-editor local transactions should not create independent undo history for mirrored main-document edits.
+- Runtime logic must distinguish user edits from sync edits before deciding to close, reopen, rebuild, or clear active-cell state.
+
+## Explicit Cell Opening
+
+- Cell opening is explicit whenever the initiating action knows the intended destination.
+- Mouse activation, keyboard navigation, inserted-table activation, and structural commands should emit a durable open request for the exact target cell.
+- Structural commands that create or move cells must precompute the post-mutation target cell instead of relying on lifecycle inference.
+- Explicit open requests take priority over generic lifecycle reactions such as close, clear, reposition, or cursor restoration.
+- Lifecycle inference is only a fallback for cases without a command-level destination, such as source-mode exit or undo/redo repositioning.
+
+## Widget Rebuilds
+
+- Decoration policy owns only the table projection decision: keep, map, rebuild, or hide widgets.
+- Widget rebuilds can invalidate DOM references and focus assumptions.
+- Code that needs an editor to remain active across a rebuild must express that as open intent, not by assuming DOM continuity.
+- `TableWidget` may reuse DOM for equivalent content, but runtime correctness must not depend on DOM reuse.
+- Block decorations must remain provided by `StateField`, not `ViewPlugin`.
+
+## Focus and Editing Ownership
+
+- While a nested editor is open, it owns text input for the active cell.
+- Main-editor guards must prevent edits that would corrupt the active cell or create sync loops.
+- Focus changes alone are not reliable lifecycle signals. Use explicit requests, transaction annotations, and resolved active-cell state.
+- Mobile IME stability depends on avoiding unnecessary close/reopen gaps. Explicit open requests should be executed as one open path when switching or creating cells.
+
+## Raw Source Mode
+
+- Source/search raw mode owns table display while active.
+- Entering raw mode must not leave a nested editor mounted over hidden or source-rendered table text.
+- Exiting raw mode may reactivate a cell at the cursor, but only through the lifecycle fallback path unless an explicit open request exists.
+- Selection changes caused by source-mode transitions must be filtered separately from normal table-selection changes.
+
+## Selection and Clipboard
+
+- Cell selection state is logical table state, not DOM selection.
+- Clipboard extraction and paste rewrites must resolve against current `TableContext`.
+- Selection transitions must be annotated so lifecycle logic does not treat them as ordinary cursor movement outside the table.
+- Pasting over a selected range should produce one table rewrite and one explicit post-rewrite selection or open intent.
+
+## Lifecycle Policy Boundary
+
+- Edge modules should report facts or intents; lifecycle policy decides consequences.
+- Interaction handlers may identify requested targets and input source, but should not decide rebuild, close, sync, or stale-state cleanup behavior.
+- Open-cell request code should carry durable target, reason, and focus-continuity requirements without spreading timing policy.
+- Decoration policy should not infer activation.
+- The impure executor may dispatch effects, schedule animation frames, open/close nested editors, and scroll. It should not invent new lifecycle decisions.

--- a/docs/Architecture/Table-Runtime-Invariants.md
+++ b/docs/Architecture/Table-Runtime-Invariants.md
@@ -1,6 +1,6 @@
 # Table Runtime Invariants
 
-The table runtime is a cross-file state machine. These invariants define the rules that must stay true across active-cell state, widget decorations, nested editing, structural commands, selection, and focus handling.
+The table runtime behaves like a cross-file state machine. These invariants define the rules that must stay true across active-cell state, widget decorations, nested editing, structural commands, selection, and focus handling.
 
 ## Source of Truth
 

--- a/src/contentScript/__tests__/runtimeEventClassifier.test.ts
+++ b/src/contentScript/__tests__/runtimeEventClassifier.test.ts
@@ -1,0 +1,217 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { type Extension, Transaction } from '@codemirror/state';
+import { EditorView, type ViewUpdate } from '@codemirror/view';
+import { describe, expect, it } from '@jest/globals';
+import { syncAnnotation } from '../editorBridge/syncAnnotation';
+import { triggerOpenCellRequestEffect } from '../tableRuntime/openCellRequest';
+import {
+    classifyTableRuntimeEvent,
+    createTableRuntimeSnapshot,
+    type PreviousTableRuntimeState,
+} from '../tableRuntime/lifecycle/runtimeEventClassifier';
+import { normalizeBeforeEditAnnotation } from '../tableRuntime/lifecycle/tableNormalization';
+import { activeCellField, setActiveCellEffect, type ActiveCell } from '../tableState/activeCellState';
+import { cellSelectionTransitionAnnotation } from '../tableState/cellSelectionState';
+import { searchForceSourceModeField, setSearchForceSourceModeEffect } from '../tableState/searchForceSourceMode';
+import { sourceModeField, toggleSourceModeEffect } from '../tableState/sourceMode';
+import { createMarkdownState } from './testMarkdownState';
+
+const TABLE_DOC = ['| H1 | H2 |', '| --- | --- |', '| a1 | a2 |'].join('\n');
+const DOC_WITH_SURROUNDING_TEXT = ['before', '', TABLE_DOC, '', 'after'].join('\n');
+const SURROUNDING_TABLE_FROM = 'before\n\n'.length;
+
+const DEFAULT_PREVIOUS: PreviousTableRuntimeState = {
+    nestedEditorOpen: false,
+    hadActiveCellBeforeUpdate: false,
+    pendingFullReplaceRebuild: false,
+    previousEffectiveRawMode: false,
+};
+
+function getHeaderCell(tableFrom = 0): ActiveCell {
+    return {
+        tableFrom,
+        section: 'header',
+        row: 0,
+        col: 0,
+    };
+}
+
+function dispatchAndCaptureUpdate(params: {
+    dispatch: (view: EditorView) => void;
+    doc?: string;
+    activeCell?: ActiveCell | null;
+    extensions?: Extension[];
+}): ViewUpdate {
+    let captured: ViewUpdate | null = null;
+    const parent = document.createElement('div');
+    document.body.appendChild(parent);
+
+    let state = createMarkdownState(params.doc ?? TABLE_DOC, [
+        activeCellField,
+        sourceModeField,
+        searchForceSourceModeField,
+        EditorView.updateListener.of((update) => {
+            if (update.transactions.length > 0) {
+                captured = update;
+            }
+        }),
+        ...(params.extensions ?? []),
+    ]);
+
+    if (params.activeCell) {
+        state = state.update({ effects: setActiveCellEffect.of(params.activeCell) }).state;
+    }
+
+    const view = new EditorView({ parent, state });
+    params.dispatch(view);
+
+    view.destroy();
+    parent.remove();
+
+    expect(captured).not.toBeNull();
+    if (!captured) {
+        throw new Error('Expected dispatch to produce a ViewUpdate');
+    }
+
+    return captured;
+}
+
+describe('runtimeEventClassifier', () => {
+    it('creates a runtime snapshot from current state and previous runtime flags', () => {
+        const previous: PreviousTableRuntimeState = {
+            ...DEFAULT_PREVIOUS,
+            nestedEditorOpen: true,
+            hadActiveCellBeforeUpdate: true,
+            pendingFullReplaceRebuild: true,
+        };
+        const update = dispatchAndCaptureUpdate({
+            activeCell: getHeaderCell(),
+            dispatch(view) {
+                view.dispatch({ selection: { anchor: 3 } });
+            },
+        });
+
+        expect(createTableRuntimeSnapshot(update, previous)).toEqual({
+            hasActiveCell: true,
+            currentActiveCellResolved: true,
+            effectiveRawMode: false,
+            nestedEditorOpen: true,
+            hadActiveCellBeforeUpdate: true,
+            pendingFullReplaceRebuild: true,
+        });
+    });
+
+    it('classifies annotations, raw mode entry, and the latest open request id', () => {
+        const update = dispatchAndCaptureUpdate({
+            activeCell: getHeaderCell(),
+            dispatch(view) {
+                view.dispatch({
+                    effects: [
+                        toggleSourceModeEffect.of(true),
+                        setSearchForceSourceModeEffect.of(true),
+                        triggerOpenCellRequestEffect.of({ requestId: 'first-request' }),
+                        triggerOpenCellRequestEffect.of({ requestId: 'latest-request' }),
+                    ],
+                    annotations: [normalizeBeforeEditAnnotation.of(true), cellSelectionTransitionAnnotation.of(true)],
+                });
+            },
+        });
+        const snapshot = createTableRuntimeSnapshot(update, DEFAULT_PREVIOUS);
+        const event = classifyTableRuntimeEvent(update, snapshot, DEFAULT_PREVIOUS);
+
+        expect(event.isNormalizeBeforeEdit).toBe(true);
+        expect(event.isCellSelectionTransition).toBe(true);
+        expect(event.openRequestId).toBe('latest-request');
+        expect(event.rawModeTransition).toEqual({
+            enteredRawMode: true,
+            exitedRawMode: false,
+            exitedSourceMode: false,
+            exitedSearchForce: false,
+        });
+    });
+
+    it('classifies same-cell selection updates as nested sync work', () => {
+        const previous: PreviousTableRuntimeState = {
+            ...DEFAULT_PREVIOUS,
+            nestedEditorOpen: true,
+            hadActiveCellBeforeUpdate: true,
+        };
+        const update = dispatchAndCaptureUpdate({
+            activeCell: getHeaderCell(),
+            dispatch(view) {
+                view.dispatch({ selection: { anchor: 4 } });
+            },
+        });
+        const snapshot = createTableRuntimeSnapshot(update, previous);
+        const event = classifyTableRuntimeEvent(update, snapshot, previous);
+
+        expect(event.selectionChanged).toBe(true);
+        expect(event.isSync).toBe(false);
+        expect(event.shouldSyncMainToNested).toBe(true);
+    });
+
+    it('does not request nested sync for sync-annotated selection updates', () => {
+        const previous: PreviousTableRuntimeState = {
+            ...DEFAULT_PREVIOUS,
+            nestedEditorOpen: true,
+            hadActiveCellBeforeUpdate: true,
+        };
+        const update = dispatchAndCaptureUpdate({
+            activeCell: getHeaderCell(),
+            dispatch(view) {
+                view.dispatch({
+                    selection: { anchor: 4 },
+                    annotations: syncAnnotation.of(true),
+                });
+            },
+        });
+        const snapshot = createTableRuntimeSnapshot(update, previous);
+        const event = classifyTableRuntimeEvent(update, snapshot, previous);
+
+        expect(event.isSync).toBe(true);
+        expect(event.shouldSyncMainToNested).toBe(false);
+    });
+
+    it('detects when selection leaves the resolved active table', () => {
+        const previous: PreviousTableRuntimeState = {
+            ...DEFAULT_PREVIOUS,
+            nestedEditorOpen: true,
+            hadActiveCellBeforeUpdate: true,
+        };
+        const update = dispatchAndCaptureUpdate({
+            doc: DOC_WITH_SURROUNDING_TEXT,
+            activeCell: getHeaderCell(SURROUNDING_TABLE_FROM),
+            dispatch(view) {
+                view.dispatch({ selection: { anchor: 0 } });
+            },
+        });
+        const snapshot = createTableRuntimeSnapshot(update, previous);
+        const event = classifyTableRuntimeEvent(update, snapshot, previous);
+
+        expect(event.selectionLeftActiveTable).toBe(true);
+    });
+
+    it('detects redo edits outside the active cell as reposition events', () => {
+        const previous: PreviousTableRuntimeState = {
+            ...DEFAULT_PREVIOUS,
+            hadActiveCellBeforeUpdate: true,
+        };
+        const update = dispatchAndCaptureUpdate({
+            activeCell: getHeaderCell(),
+            dispatch(view) {
+                view.dispatch({
+                    changes: { from: 0, to: 0, insert: 'note\n' },
+                    annotations: Transaction.userEvent.of('redo'),
+                });
+            },
+        });
+        const snapshot = createTableRuntimeSnapshot(update, previous);
+        const event = classifyTableRuntimeEvent(update, snapshot, previous);
+
+        expect(event.docChanged).toBe(true);
+        expect(event.requiresCellReposition).toBe(true);
+    });
+});

--- a/src/contentScript/__tests__/tableRuntimePolicies.test.ts
+++ b/src/contentScript/__tests__/tableRuntimePolicies.test.ts
@@ -13,9 +13,9 @@ import { rebuildTableWidgetsEffect } from '../tableState/tableWidgetEffects';
 import { sourceModeField, toggleSourceModeEffect } from '../tableState/sourceMode';
 import { searchForceSourceModeField, setSearchForceSourceModeEffect } from '../tableState/searchForceSourceMode';
 import {
-    planTableLifecycleActions,
-    type TableLifecyclePolicyEvent,
-    type TableLifecyclePolicyState,
+    reduceTableRuntime,
+    type TableRuntimeEvent,
+    type TableRuntimeSnapshot,
 } from '../tableRuntime/lifecycle/lifecyclePolicy';
 import { transactionRequiresTableRebuild } from '../tableRuntime/tableTransactionHelpers';
 import { decideMainEditorGuardTransaction } from '../editorBridge/mainEditorGuardPolicy';
@@ -59,7 +59,7 @@ function requireResolvedActiveCell(state: EditorState) {
     return resolved;
 }
 
-function defaultPolicyState(overrides: Partial<TableLifecyclePolicyState> = {}): TableLifecyclePolicyState {
+function defaultRuntimeSnapshot(overrides: Partial<TableRuntimeSnapshot> = {}): TableRuntimeSnapshot {
     return {
         hasActiveCell: false,
         currentActiveCellResolved: false,
@@ -71,7 +71,7 @@ function defaultPolicyState(overrides: Partial<TableLifecyclePolicyState> = {}):
     };
 }
 
-function defaultPolicyEvent(overrides: Partial<TableLifecyclePolicyEvent> = {}): TableLifecyclePolicyEvent {
+function defaultRuntimeEvent(overrides: Partial<TableRuntimeEvent> = {}): TableRuntimeEvent {
     return {
         docChanged: false,
         selectionChanged: false,
@@ -308,11 +308,11 @@ describe('tableRuntimePolicies', () => {
     });
 
     it('plans raw mode exit as cursor reactivation', () => {
-        const state = defaultPolicyState({
+        const state = defaultRuntimeSnapshot({
             hasActiveCell: true,
             hadActiveCellBeforeUpdate: true,
         });
-        const event = defaultPolicyEvent({
+        const event = defaultRuntimeEvent({
             rawModeTransition: {
                 enteredRawMode: false,
                 exitedRawMode: true,
@@ -321,7 +321,7 @@ describe('tableRuntimePolicies', () => {
             },
         });
 
-        expect(planTableLifecycleActions(state, event)).toEqual([
+        expect(reduceTableRuntime(state, event)).toEqual([
             {
                 type: 'scheduleActivateCellAtCursor',
                 reason: 'rawModeExit',
@@ -364,7 +364,7 @@ describe('tableRuntimePolicies', () => {
             ],
             annotations: normalizeBeforeEditAnnotation.of(true),
         });
-        const state = defaultPolicyState({
+        const state = defaultRuntimeSnapshot({
             hasActiveCell: true,
             currentActiveCellResolved: true,
             hadActiveCellBeforeUpdate: true,
@@ -375,9 +375,9 @@ describe('tableRuntimePolicies', () => {
             type: 'allowTransaction',
         });
         expect(
-            planTableLifecycleActions(
+            reduceTableRuntime(
                 state,
-                defaultPolicyEvent({
+                defaultRuntimeEvent({
                     docChanged: true,
                     selectionChanged: true,
                     isNormalizeBeforeEdit: true,
@@ -389,38 +389,38 @@ describe('tableRuntimePolicies', () => {
     });
 
     it('does not plan a generic reopen for rebuild-only transactions', () => {
-        const state = defaultPolicyState({
+        const state = defaultRuntimeSnapshot({
             hasActiveCell: true,
             currentActiveCellResolved: true,
             nestedEditorOpen: true,
             hadActiveCellBeforeUpdate: true,
         });
 
-        expect(planTableLifecycleActions(state, defaultPolicyEvent())).toEqual([]);
+        expect(reduceTableRuntime(state, defaultRuntimeEvent())).toEqual([]);
     });
 
     it('plans nested editor sync from a single sync fact', () => {
-        const state = defaultPolicyState({
+        const state = defaultRuntimeSnapshot({
             hasActiveCell: true,
             currentActiveCellResolved: true,
             nestedEditorOpen: true,
             hadActiveCellBeforeUpdate: true,
         });
 
-        expect(planTableLifecycleActions(state, defaultPolicyEvent({ shouldSyncMainToNested: true }))).toContainEqual({
+        expect(reduceTableRuntime(state, defaultRuntimeEvent({ shouldSyncMainToNested: true }))).toContainEqual({
             type: 'syncMainToNested',
         });
-        expect(planTableLifecycleActions(state, defaultPolicyEvent({ shouldSyncMainToNested: false }))).toEqual([]);
+        expect(reduceTableRuntime(state, defaultRuntimeEvent({ shouldSyncMainToNested: false }))).toEqual([]);
     });
 
     it('prefers an explicit open request over generic branches', () => {
-        const state = defaultPolicyState({
+        const state = defaultRuntimeSnapshot({
             hasActiveCell: true,
             currentActiveCellResolved: true,
             nestedEditorOpen: true,
             hadActiveCellBeforeUpdate: true,
         });
-        const event = defaultPolicyEvent({
+        const event = defaultRuntimeEvent({
             docChanged: true,
             hasFullDocumentReplace: true,
             openRequestId: 'explicit-request',
@@ -430,27 +430,25 @@ describe('tableRuntimePolicies', () => {
             shouldSyncMainToNested: true,
         });
 
-        expect(planTableLifecycleActions(state, event)).toEqual([
+        expect(reduceTableRuntime(state, event)).toEqual([
             { type: 'openRequestedCell', requestId: 'explicit-request' },
         ]);
     });
 
     it('uses the compact open request id selected by the adapter', () => {
-        const state = defaultPolicyState({
+        const state = defaultRuntimeSnapshot({
             hasActiveCell: true,
             currentActiveCellResolved: true,
             nestedEditorOpen: true,
             hadActiveCellBeforeUpdate: true,
         });
-        const event = defaultPolicyEvent({ openRequestId: 'latest-request' });
+        const event = defaultRuntimeEvent({ openRequestId: 'latest-request' });
 
-        expect(planTableLifecycleActions(state, event)).toEqual([
-            { type: 'openRequestedCell', requestId: 'latest-request' },
-        ]);
+        expect(reduceTableRuntime(state, event)).toEqual([{ type: 'openRequestedCell', requestId: 'latest-request' }]);
     });
 
     it('uses the resolved update range when undo or redo repositions the active cell', () => {
-        const state = defaultPolicyState({
+        const state = defaultRuntimeSnapshot({
             hasActiveCell: true,
             currentActiveCellResolved: true,
             nestedEditorOpen: true,
@@ -458,9 +456,9 @@ describe('tableRuntimePolicies', () => {
         });
 
         expect(
-            planTableLifecycleActions(
+            reduceTableRuntime(
                 state,
-                defaultPolicyEvent({
+                defaultRuntimeEvent({
                     docChanged: true,
                     requiresCellReposition: true,
                 })
@@ -475,7 +473,7 @@ describe('tableRuntimePolicies', () => {
     });
 
     it('closes and clears the active cell when selection moves outside the active table', () => {
-        const state = defaultPolicyState({
+        const state = defaultRuntimeSnapshot({
             hasActiveCell: true,
             currentActiveCellResolved: true,
             nestedEditorOpen: true,
@@ -483,9 +481,9 @@ describe('tableRuntimePolicies', () => {
         });
 
         expect(
-            planTableLifecycleActions(
+            reduceTableRuntime(
                 state,
-                defaultPolicyEvent({
+                defaultRuntimeEvent({
                     selectionChanged: true,
                     selectionLeftActiveTable: true,
                 })
@@ -494,31 +492,31 @@ describe('tableRuntimePolicies', () => {
     });
 
     it('suppresses selection-left-table cleanup during raw mode, cell selection, and sync updates', () => {
-        const state = defaultPolicyState({
+        const state = defaultRuntimeSnapshot({
             hasActiveCell: true,
             currentActiveCellResolved: true,
             nestedEditorOpen: true,
             hadActiveCellBeforeUpdate: true,
         });
-        const event = defaultPolicyEvent({
+        const event = defaultRuntimeEvent({
             selectionChanged: true,
             selectionLeftActiveTable: true,
         });
 
-        expect(planTableLifecycleActions(defaultPolicyState({ ...state, effectiveRawMode: true }), event)).toEqual([]);
+        expect(reduceTableRuntime(defaultRuntimeSnapshot({ ...state, effectiveRawMode: true }), event)).toEqual([]);
         expect(
-            planTableLifecycleActions(
+            reduceTableRuntime(
                 state,
-                defaultPolicyEvent({
+                defaultRuntimeEvent({
                     ...event,
                     isCellSelectionTransition: true,
                 })
             )
         ).toEqual([]);
         expect(
-            planTableLifecycleActions(
+            reduceTableRuntime(
                 state,
-                defaultPolicyEvent({
+                defaultRuntimeEvent({
                     ...event,
                     isSync: true,
                 })
@@ -527,7 +525,7 @@ describe('tableRuntimePolicies', () => {
     });
 
     it('does not clear the active cell when selection leaves the table after the nested editor already closed', () => {
-        const state = defaultPolicyState({
+        const state = defaultRuntimeSnapshot({
             hasActiveCell: true,
             currentActiveCellResolved: true,
             nestedEditorOpen: false,
@@ -535,9 +533,9 @@ describe('tableRuntimePolicies', () => {
         });
 
         expect(
-            planTableLifecycleActions(
+            reduceTableRuntime(
                 state,
-                defaultPolicyEvent({
+                defaultRuntimeEvent({
                     selectionChanged: true,
                     selectionLeftActiveTable: true,
                 })
@@ -546,7 +544,7 @@ describe('tableRuntimePolicies', () => {
     });
 
     it('plans stale active cell cleanup when the nested editor is gone', () => {
-        const state = defaultPolicyState({
+        const state = defaultRuntimeSnapshot({
             hasActiveCell: true,
             currentActiveCellResolved: true,
             nestedEditorOpen: false,
@@ -554,9 +552,9 @@ describe('tableRuntimePolicies', () => {
         });
 
         expect(
-            planTableLifecycleActions(
+            reduceTableRuntime(
                 state,
-                defaultPolicyEvent({
+                defaultRuntimeEvent({
                     docChanged: true,
                 })
             )
@@ -585,7 +583,7 @@ describe('tableRuntimePolicies', () => {
     });
 
     it('clears stale active cell when the resolver cannot find the table', () => {
-        const state = defaultPolicyState({
+        const state = defaultRuntimeSnapshot({
             hasActiveCell: true,
             currentActiveCellResolved: false,
             nestedEditorOpen: false,
@@ -593,9 +591,9 @@ describe('tableRuntimePolicies', () => {
         });
 
         expect(
-            planTableLifecycleActions(
+            reduceTableRuntime(
                 state,
-                defaultPolicyEvent({
+                defaultRuntimeEvent({
                     docChanged: true,
                 })
             )

--- a/src/contentScript/tableRuntime/lifecycle/lifecyclePolicy.ts
+++ b/src/contentScript/tableRuntime/lifecycle/lifecyclePolicy.ts
@@ -1,4 +1,4 @@
-export interface TableLifecyclePolicyState {
+export interface TableRuntimeSnapshot {
     hasActiveCell: boolean;
     currentActiveCellResolved: boolean;
     effectiveRawMode: boolean;
@@ -7,7 +7,7 @@ export interface TableLifecyclePolicyState {
     pendingFullReplaceRebuild: boolean;
 }
 
-export interface TableLifecyclePolicyEvent {
+export interface TableRuntimeEvent {
     docChanged: boolean;
     selectionChanged: boolean;
     isSync: boolean;
@@ -47,10 +47,7 @@ export type TableRuntimeAction =
     | { type: 'scheduleEnsureCursorVisible'; mode: 'enteredRawMode' | 'exitedRawModeWithoutActiveCell' }
     | { type: 'scheduleRebuildAllAfterFullReplace' };
 
-export function planTableLifecycleActions(
-    state: TableLifecyclePolicyState,
-    event: TableLifecyclePolicyEvent
-): TableRuntimeAction[] {
+export function reduceTableRuntime(snapshot: TableRuntimeSnapshot, event: TableRuntimeEvent): TableRuntimeAction[] {
     const actions: TableRuntimeAction[] = [];
 
     if (event.openRequestId) {
@@ -67,10 +64,10 @@ export function planTableLifecycleActions(
     }
 
     if (
-        state.hadActiveCellBeforeUpdate &&
+        snapshot.hadActiveCellBeforeUpdate &&
         event.hasFullDocumentReplace &&
         !event.isNormalizeBeforeEdit &&
-        !state.pendingFullReplaceRebuild
+        !snapshot.pendingFullReplaceRebuild
     ) {
         actions.push({ type: 'scheduleRebuildAllAfterFullReplace' });
     }
@@ -87,12 +84,12 @@ export function planTableLifecycleActions(
         actions.push({ type: 'scheduleEnsureCursorVisible', mode: 'enteredRawMode' });
     }
 
-    if (event.rawModeTransition.exitedRawMode && !state.hasActiveCell && !event.isCellSelectionTransition) {
+    if (event.rawModeTransition.exitedRawMode && !snapshot.hasActiveCell && !event.isCellSelectionTransition) {
         actions.push({ type: 'scheduleEnsureCursorVisible', mode: 'exitedRawModeWithoutActiveCell' });
     }
 
     if (event.requiresCellReposition) {
-        if (state.nestedEditorOpen) {
+        if (snapshot.nestedEditorOpen) {
             actions.push({ type: 'closeNestedEditorUsingResolvedUpdateRange' });
         }
         actions.push({
@@ -102,15 +99,15 @@ export function planTableLifecycleActions(
         return actions;
     }
 
-    if (shouldClearActiveCellWhenSelectionLeavesTable(state, event)) {
-        if (state.nestedEditorOpen) {
+    if (shouldClearActiveCellWhenSelectionLeavesTable(snapshot, event)) {
+        if (snapshot.nestedEditorOpen) {
             actions.push({ type: 'closeNestedEditor' });
         }
         actions.push({ type: 'clearActiveCell' });
         return actions;
     }
 
-    if (!state.hasActiveCell && state.hadActiveCellBeforeUpdate) {
+    if (!snapshot.hasActiveCell && snapshot.hadActiveCellBeforeUpdate) {
         actions.push({ type: 'closeNestedEditor' });
     }
 
@@ -118,21 +115,18 @@ export function planTableLifecycleActions(
         actions.push({ type: 'syncMainToNested' });
     }
 
-    if (event.docChanged && state.hasActiveCell && !state.currentActiveCellResolved && !event.isSync) {
+    if (event.docChanged && snapshot.hasActiveCell && !snapshot.currentActiveCellResolved && !event.isSync) {
         actions.push({ type: 'clearActiveCell' });
     }
 
-    if (event.docChanged && state.currentActiveCellResolved && !state.nestedEditorOpen && !event.isSync) {
+    if (event.docChanged && snapshot.currentActiveCellResolved && !snapshot.nestedEditorOpen && !event.isSync) {
         actions.push({ type: 'clearActiveCell' });
     }
 
     return actions;
 }
 
-function shouldClearActiveCellWhenSelectionLeavesTable(
-    state: TableLifecyclePolicyState,
-    event: TableLifecyclePolicyEvent
-): boolean {
+function shouldClearActiveCellWhenSelectionLeavesTable(state: TableRuntimeSnapshot, event: TableRuntimeEvent): boolean {
     return (
         event.selectionChanged &&
         !event.isSync &&

--- a/src/contentScript/tableRuntime/lifecycle/nestedEditorLifecycle.ts
+++ b/src/contentScript/tableRuntime/lifecycle/nestedEditorLifecycle.ts
@@ -79,6 +79,12 @@ function mapActiveCellThroughUpdate(update: ViewUpdate, activeCell: ActiveCell |
 
 type NormalizeBeforeOpenResult = 'not-needed' | 'normalized' | 'aborted';
 
+interface OpenRequestExecutionGuardResult {
+    request: NonNullable<ReturnType<typeof getOpenCellRequestById>>;
+    resolvedActiveCell: ResolvedActiveCell;
+    cellElement: HTMLElement;
+}
+
 interface ActivateCellAtCursorOptions {
     clearIfOutside: boolean;
     ensureCursorVisibleIfNotActivated: boolean;
@@ -279,42 +285,15 @@ export const nestedEditorLifecyclePlugin = ViewPlugin.fromClass(
 
         private scheduleOpenRequestedCell(requestId: string): void {
             requestViewAnimationFrame(this.view, () => {
-                const request = getOpenCellRequestById(this.view.state, requestId);
-                if (!request) {
-                    return;
-                }
-
-                const targetActiveCell = request.activeCell;
-                const normalizeIfNeeded = request.normalizeIfNeeded;
-                if (!this.view.dom.isConnected) {
-                    this.failOpenRequest(requestId);
-                    return;
-                }
-                if (!isSameActiveCell(getActiveCell(this.view.state), targetActiveCell)) {
-                    this.failOpenRequest(requestId);
-                    return;
-                }
-                const resolvedActiveCell = getResolvedActiveCell(this.view.state);
-                if (!resolvedActiveCell) {
-                    this.failOpenRequest(requestId);
-                    this.view.dispatch({ effects: clearActiveCellEffect.of(undefined) });
-                    return;
-                }
-                const cellElement = findCellElement(
-                    this.view,
-                    makeTableId(targetActiveCell.tableFrom),
-                    targetActiveCell
-                );
-                if (!cellElement) {
-                    this.failOpenRequest(requestId);
-                    this.view.dispatch({ effects: clearActiveCellEffect.of(undefined) });
+                const guardResult = this.validateOpenRequestForExecution(requestId);
+                if (!guardResult) {
                     return;
                 }
 
                 const normalizeResult = normalizeTableBeforeOpen({
                     view: this.view,
-                    resolvedActiveCell,
-                    normalizeIfNeeded,
+                    resolvedActiveCell: guardResult.resolvedActiveCell,
+                    normalizeIfNeeded: guardResult.request.normalizeIfNeeded,
                     requestId,
                 });
                 if (normalizeResult === 'normalized') {
@@ -327,9 +306,9 @@ export const nestedEditorLifecyclePlugin = ViewPlugin.fromClass(
 
                 const opened = openNestedEditor({
                     mainView: this.view,
-                    cellElement,
+                    cellElement: guardResult.cellElement,
                     featureSettings: this.view.state.facet(hostEditorConfigFacet).nestedEditor,
-                    initialCursorPos: request.initialCursorPos,
+                    initialCursorPos: guardResult.request.initialCursorPos,
                 });
                 if (!opened) {
                     this.failOpenRequest(requestId);
@@ -341,6 +320,44 @@ export const nestedEditorLifecyclePlugin = ViewPlugin.fromClass(
                     });
                 });
             });
+        }
+
+        private validateOpenRequestForExecution(requestId: string): OpenRequestExecutionGuardResult | null {
+            const request = getOpenCellRequestById(this.view.state, requestId);
+            if (!request) {
+                return null;
+            }
+
+            const targetActiveCell = request.activeCell;
+            if (!this.view.dom.isConnected) {
+                this.failOpenRequest(requestId);
+                return null;
+            }
+
+            if (!isSameActiveCell(getActiveCell(this.view.state), targetActiveCell)) {
+                this.failOpenRequest(requestId);
+                return null;
+            }
+
+            const resolvedActiveCell = getResolvedActiveCell(this.view.state);
+            if (!resolvedActiveCell) {
+                this.failOpenRequest(requestId);
+                this.view.dispatch({ effects: clearActiveCellEffect.of(undefined) });
+                return null;
+            }
+
+            const cellElement = findCellElement(this.view, makeTableId(targetActiveCell.tableFrom), targetActiveCell);
+            if (!cellElement) {
+                this.failOpenRequest(requestId);
+                this.view.dispatch({ effects: clearActiveCellEffect.of(undefined) });
+                return null;
+            }
+
+            return {
+                request,
+                resolvedActiveCell,
+                cellElement,
+            };
         }
 
         private failOpenRequest(requestId: string): void {

--- a/src/contentScript/tableRuntime/lifecycle/nestedEditorLifecycle.ts
+++ b/src/contentScript/tableRuntime/lifecycle/nestedEditorLifecycle.ts
@@ -6,14 +6,8 @@ import {
     setActiveCellEffect,
     type ActiveCell,
 } from '../../tableState/activeCellState';
-import { cellSelectionTransitionAnnotation } from '../../tableState/cellSelectionState';
 import { activateInsertedTableEffect } from '../../tableState/insertedTableActivation';
-import { syncAnnotation } from '../../editorBridge/syncAnnotation';
-import {
-    exitSearchForceSourceModeEffect,
-    setSearchForceSourceModeEffect,
-} from '../../tableState/searchForceSourceMode';
-import { exitSourceModeEffect, isEffectiveRawMode, toggleSourceModeEffect } from '../../tableState/sourceMode';
+import { isEffectiveRawMode } from '../../tableState/sourceMode';
 import { rebuildAllTableWidgetsEffect, rebuildTableWidgetsEffect } from '../../tableState/tableWidgetEffects';
 import { getResolvedActiveCell, type ResolvedActiveCell } from '../activeCell/resolvedActiveCell';
 import {
@@ -24,7 +18,6 @@ import {
 } from '../../nestedEditor/nestedEditorController';
 import { findCellElement } from '../../tableWidget/domHelpers';
 import { makeTableId } from '../../tableModel/types';
-import { findTableRanges } from '../tableResolution';
 import { createActiveCellForTableText } from '../activeCell/activeCellFactory';
 import { activateCellAtPosition, activateTableCell } from '../activeCell/cellActivation';
 import {
@@ -35,11 +28,9 @@ import {
 } from '../openCellRequest';
 import { getNormalizedTableReplacementIfChanged, normalizeBeforeEditAnnotation } from './tableNormalization';
 import { hostEditorConfigFacet } from '../../services/hostEditorConfig';
-import { planTableLifecycleActions, type ActivateCellAtCursorReason, type TableRuntimeAction } from './lifecyclePolicy';
+import { reduceTableRuntime, type ActivateCellAtCursorReason, type TableRuntimeAction } from './lifecyclePolicy';
+import { classifyTableRuntimeEvent, createTableRuntimeSnapshot } from './runtimeEventClassifier';
 import { requestViewAnimationFrame } from '../../shared/domContext';
-import { isFullDocumentReplace } from '../../shared/transactionUtils';
-import { transactionRequiresTableRebuild } from '../tableTransactionHelpers';
-import type { TableLifecyclePolicyEvent, TableLifecyclePolicyState } from './lifecyclePolicy';
 
 // ============================================================================
 // Utilities
@@ -83,149 +74,6 @@ function mapActiveCellThroughUpdate(update: ViewUpdate, activeCell: ActiveCell |
     return {
         ...activeCell,
         tableFrom: mappedTableFrom,
-    };
-}
-
-function scanRawModeTransitionFacts(update: ViewUpdate, previousEffectiveRawMode: boolean) {
-    let exitedSourceMode = false;
-    let exitedSearchForce = false;
-    let hadRawModeToggle = false;
-
-    for (const tr of update.transactions) {
-        for (const effect of tr.effects) {
-            if (effect.is(exitSourceModeEffect)) {
-                exitedSourceMode = true;
-                hadRawModeToggle = true;
-            }
-            if (effect.is(exitSearchForceSourceModeEffect)) {
-                exitedSearchForce = true;
-                hadRawModeToggle = true;
-            }
-            if (effect.is(toggleSourceModeEffect) || effect.is(setSearchForceSourceModeEffect)) {
-                hadRawModeToggle = true;
-            }
-        }
-    }
-
-    const effectiveRawMode = isEffectiveRawMode(update.state);
-
-    return {
-        enteredRawMode: hadRawModeToggle && !previousEffectiveRawMode && effectiveRawMode,
-        exitedRawMode: hadRawModeToggle && previousEffectiveRawMode && !effectiveRawMode,
-        exitedSourceMode,
-        exitedSearchForce,
-    };
-}
-
-function extractOpenRequestId(update: ViewUpdate): string | null {
-    let requestId: string | null = null;
-
-    for (const tr of update.transactions) {
-        for (const effect of tr.effects) {
-            if (effect.is(triggerOpenCellRequestEffect)) {
-                requestId = effect.value.requestId;
-            }
-        }
-    }
-
-    return requestId;
-}
-
-function isPositionInsideRange(pos: number, from: number, to: number): boolean {
-    return pos >= from && pos <= to;
-}
-
-function isSelectionOutsideResolvedTable(update: ViewUpdate, resolvedActiveCell: ResolvedActiveCell | null): boolean {
-    if (!resolvedActiveCell) {
-        return false;
-    }
-
-    const { main } = update.state.selection;
-    return (
-        !isPositionInsideRange(main.anchor, resolvedActiveCell.tableFrom, resolvedActiveCell.tableTo) ||
-        !isPositionInsideRange(main.head, resolvedActiveCell.tableFrom, resolvedActiveCell.tableTo)
-    );
-}
-
-function cursorInsideAnyTable(update: ViewUpdate): boolean {
-    const cursorPos = update.state.selection.main.head;
-    return findTableRanges(update.state).some((table) => cursorPos >= table.from && cursorPos <= table.to);
-}
-
-function updateRequiresCellReposition(params: {
-    update: ViewUpdate;
-    effectiveRawMode: boolean;
-    hadActiveCellBeforeUpdate: boolean;
-    resolvedPrevActiveCell: ResolvedActiveCell | null;
-    isSync: boolean;
-}): boolean {
-    if (!params.update.docChanged || params.isSync || params.effectiveRawMode) {
-        return false;
-    }
-
-    if (params.hadActiveCellBeforeUpdate && params.resolvedPrevActiveCell) {
-        return params.update.transactions.some((tr) =>
-            transactionRequiresTableRebuild(tr, params.resolvedPrevActiveCell)
-        );
-    }
-
-    const isUndoRedo = params.update.transactions.some((tr) => tr.isUserEvent('undo') || tr.isUserEvent('redo'));
-    return isUndoRedo && cursorInsideAnyTable(params.update);
-}
-
-function collectLifecyclePlannerInput(params: {
-    update: ViewUpdate;
-    nestedEditorOpen: boolean;
-    hadActiveCellBeforeUpdate: boolean;
-    pendingFullReplaceRebuild: boolean;
-    previousEffectiveRawMode: boolean;
-}): { state: TableLifecyclePolicyState; event: TableLifecyclePolicyEvent } {
-    const activeCell = getActiveCell(params.update.state);
-    const prevActiveCell = getActiveCell(params.update.startState);
-    const resolvedActiveCell = getResolvedActiveCell(params.update.state);
-    const resolvedPrevActiveCell = getResolvedActiveCell(params.update.startState);
-    const effectiveRawMode = isEffectiveRawMode(params.update.state);
-    const isSync = params.update.transactions.some((tr) => Boolean(tr.annotation(syncAnnotation)));
-    const shouldSyncDoc = params.update.docChanged && Boolean(resolvedActiveCell) && params.nestedEditorOpen && !isSync;
-    const shouldSyncSelection =
-        params.update.selectionSet &&
-        isSameActiveCell(prevActiveCell, activeCell) &&
-        Boolean(resolvedActiveCell) &&
-        params.nestedEditorOpen &&
-        !isSync;
-
-    return {
-        state: {
-            hasActiveCell: Boolean(activeCell),
-            currentActiveCellResolved: Boolean(resolvedActiveCell),
-            effectiveRawMode,
-            nestedEditorOpen: params.nestedEditorOpen,
-            hadActiveCellBeforeUpdate: params.hadActiveCellBeforeUpdate,
-            pendingFullReplaceRebuild: params.pendingFullReplaceRebuild,
-        },
-        event: {
-            docChanged: params.update.docChanged,
-            selectionChanged: params.update.selectionSet,
-            isSync,
-            isNormalizeBeforeEdit: params.update.transactions.some((tr) =>
-                Boolean(tr.annotation(normalizeBeforeEditAnnotation))
-            ),
-            isCellSelectionTransition: params.update.transactions.some((tr) =>
-                Boolean(tr.annotation(cellSelectionTransitionAnnotation))
-            ),
-            rawModeTransition: scanRawModeTransitionFacts(params.update, params.previousEffectiveRawMode),
-            hasFullDocumentReplace: params.update.transactions.some((tr) => isFullDocumentReplace(tr)),
-            openRequestId: extractOpenRequestId(params.update),
-            selectionLeftActiveTable: isSelectionOutsideResolvedTable(params.update, resolvedActiveCell),
-            requiresCellReposition: updateRequiresCellReposition({
-                update: params.update,
-                effectiveRawMode,
-                hadActiveCellBeforeUpdate: params.hadActiveCellBeforeUpdate,
-                resolvedPrevActiveCell,
-                isSync,
-            }),
-            shouldSyncMainToNested: shouldSyncDoc || shouldSyncSelection,
-        },
     };
 }
 
@@ -326,14 +174,15 @@ export const nestedEditorLifecyclePlugin = ViewPlugin.fromClass(
         }
 
         update(update: ViewUpdate): void {
-            const { state, event } = collectLifecyclePlannerInput({
-                update,
+            const previousRuntimeState = {
                 nestedEditorOpen: isNestedEditorOpen(this.view),
                 hadActiveCellBeforeUpdate: this.hadActiveCellBeforeUpdate,
                 pendingFullReplaceRebuild: this.pendingFullReplaceRebuild,
                 previousEffectiveRawMode: this.wasEffectiveRawMode,
-            });
-            const actions = planTableLifecycleActions(state, event);
+            };
+            const snapshot = createTableRuntimeSnapshot(update, previousRuntimeState);
+            const event = classifyTableRuntimeEvent(update, snapshot, previousRuntimeState);
+            const actions = reduceTableRuntime(snapshot, event);
 
             this.executeActions(actions, update);
             this.scheduleInsertedTableActivation(update);

--- a/src/contentScript/tableRuntime/lifecycle/runtimeEventClassifier.ts
+++ b/src/contentScript/tableRuntime/lifecycle/runtimeEventClassifier.ts
@@ -1,0 +1,169 @@
+import { type ViewUpdate } from '@codemirror/view';
+import { getActiveCell, isSameActiveCell } from '../../tableState/activeCellState';
+import { cellSelectionTransitionAnnotation } from '../../tableState/cellSelectionState';
+import { syncAnnotation } from '../../editorBridge/syncAnnotation';
+import {
+    exitSearchForceSourceModeEffect,
+    setSearchForceSourceModeEffect,
+} from '../../tableState/searchForceSourceMode';
+import { exitSourceModeEffect, isEffectiveRawMode, toggleSourceModeEffect } from '../../tableState/sourceMode';
+import { getResolvedActiveCell, type ResolvedActiveCell } from '../activeCell/resolvedActiveCell';
+import { findTableRanges } from '../tableResolution';
+import { isFullDocumentReplace } from '../../shared/transactionUtils';
+import { transactionRequiresTableRebuild } from '../tableTransactionHelpers';
+import { triggerOpenCellRequestEffect } from '../openCellRequest';
+import { normalizeBeforeEditAnnotation } from './tableNormalization';
+import type { RawModeTransitionFacts, TableRuntimeEvent, TableRuntimeSnapshot } from './lifecyclePolicy';
+
+export interface PreviousTableRuntimeState {
+    nestedEditorOpen: boolean;
+    hadActiveCellBeforeUpdate: boolean;
+    pendingFullReplaceRebuild: boolean;
+    previousEffectiveRawMode: boolean;
+}
+
+export function createTableRuntimeSnapshot(
+    update: ViewUpdate,
+    previous: PreviousTableRuntimeState
+): TableRuntimeSnapshot {
+    const activeCell = getActiveCell(update.state);
+    const resolvedActiveCell = getResolvedActiveCell(update.state);
+    const effectiveRawMode = isEffectiveRawMode(update.state);
+
+    return {
+        hasActiveCell: Boolean(activeCell),
+        currentActiveCellResolved: Boolean(resolvedActiveCell),
+        effectiveRawMode,
+        nestedEditorOpen: previous.nestedEditorOpen,
+        hadActiveCellBeforeUpdate: previous.hadActiveCellBeforeUpdate,
+        pendingFullReplaceRebuild: previous.pendingFullReplaceRebuild,
+    };
+}
+
+export function classifyTableRuntimeEvent(
+    update: ViewUpdate,
+    snapshot: TableRuntimeSnapshot,
+    previous: PreviousTableRuntimeState
+): TableRuntimeEvent {
+    const activeCell = getActiveCell(update.state);
+    const prevActiveCell = getActiveCell(update.startState);
+    const resolvedActiveCell = getResolvedActiveCell(update.state);
+    const resolvedPrevActiveCell = getResolvedActiveCell(update.startState);
+    const isSync = update.transactions.some((tr) => Boolean(tr.annotation(syncAnnotation)));
+    const shouldSyncDoc = update.docChanged && Boolean(resolvedActiveCell) && snapshot.nestedEditorOpen && !isSync;
+    const shouldSyncSelection =
+        update.selectionSet &&
+        isSameActiveCell(prevActiveCell, activeCell) &&
+        Boolean(resolvedActiveCell) &&
+        snapshot.nestedEditorOpen &&
+        !isSync;
+
+    return {
+        docChanged: update.docChanged,
+        selectionChanged: update.selectionSet,
+        isSync,
+        isNormalizeBeforeEdit: update.transactions.some((tr) => Boolean(tr.annotation(normalizeBeforeEditAnnotation))),
+        isCellSelectionTransition: update.transactions.some((tr) =>
+            Boolean(tr.annotation(cellSelectionTransitionAnnotation))
+        ),
+        rawModeTransition: scanRawModeTransitionFacts(update, previous.previousEffectiveRawMode),
+        hasFullDocumentReplace: update.transactions.some((tr) => isFullDocumentReplace(tr)),
+        openRequestId: extractOpenRequestId(update),
+        selectionLeftActiveTable: isSelectionOutsideResolvedTable(update, resolvedActiveCell),
+        requiresCellReposition: updateRequiresCellReposition({
+            update,
+            effectiveRawMode: snapshot.effectiveRawMode,
+            hadActiveCellBeforeUpdate: snapshot.hadActiveCellBeforeUpdate,
+            resolvedPrevActiveCell,
+            isSync,
+        }),
+        shouldSyncMainToNested: shouldSyncDoc || shouldSyncSelection,
+    };
+}
+
+function scanRawModeTransitionFacts(update: ViewUpdate, previousEffectiveRawMode: boolean): RawModeTransitionFacts {
+    let exitedSourceMode = false;
+    let exitedSearchForce = false;
+    let hadRawModeToggle = false;
+
+    for (const tr of update.transactions) {
+        for (const effect of tr.effects) {
+            if (effect.is(exitSourceModeEffect)) {
+                exitedSourceMode = true;
+                hadRawModeToggle = true;
+            }
+            if (effect.is(exitSearchForceSourceModeEffect)) {
+                exitedSearchForce = true;
+                hadRawModeToggle = true;
+            }
+            if (effect.is(toggleSourceModeEffect) || effect.is(setSearchForceSourceModeEffect)) {
+                hadRawModeToggle = true;
+            }
+        }
+    }
+
+    const effectiveRawMode = isEffectiveRawMode(update.state);
+
+    return {
+        enteredRawMode: hadRawModeToggle && !previousEffectiveRawMode && effectiveRawMode,
+        exitedRawMode: hadRawModeToggle && previousEffectiveRawMode && !effectiveRawMode,
+        exitedSourceMode,
+        exitedSearchForce,
+    };
+}
+
+function extractOpenRequestId(update: ViewUpdate): string | null {
+    let requestId: string | null = null;
+
+    for (const tr of update.transactions) {
+        for (const effect of tr.effects) {
+            if (effect.is(triggerOpenCellRequestEffect)) {
+                requestId = effect.value.requestId;
+            }
+        }
+    }
+
+    return requestId;
+}
+
+function isPositionInsideRange(pos: number, from: number, to: number): boolean {
+    return pos >= from && pos <= to;
+}
+
+function isSelectionOutsideResolvedTable(update: ViewUpdate, resolvedActiveCell: ResolvedActiveCell | null): boolean {
+    if (!resolvedActiveCell) {
+        return false;
+    }
+
+    const { main } = update.state.selection;
+    return (
+        !isPositionInsideRange(main.anchor, resolvedActiveCell.tableFrom, resolvedActiveCell.tableTo) ||
+        !isPositionInsideRange(main.head, resolvedActiveCell.tableFrom, resolvedActiveCell.tableTo)
+    );
+}
+
+function cursorInsideAnyTable(update: ViewUpdate): boolean {
+    const cursorPos = update.state.selection.main.head;
+    return findTableRanges(update.state).some((table) => cursorPos >= table.from && cursorPos <= table.to);
+}
+
+function updateRequiresCellReposition(params: {
+    update: ViewUpdate;
+    effectiveRawMode: boolean;
+    hadActiveCellBeforeUpdate: boolean;
+    resolvedPrevActiveCell: ResolvedActiveCell | null;
+    isSync: boolean;
+}): boolean {
+    if (!params.update.docChanged || params.isSync || params.effectiveRawMode) {
+        return false;
+    }
+
+    if (params.hadActiveCellBeforeUpdate && params.resolvedPrevActiveCell) {
+        return params.update.transactions.some((tr) =>
+            transactionRequiresTableRebuild(tr, params.resolvedPrevActiveCell)
+        );
+    }
+
+    const isUndoRedo = params.update.transactions.some((tr) => tr.isUserEvent('undo') || tr.isUserEvent('redo'));
+    return isUndoRedo && cursorInsideAnyTable(params.update);
+}


### PR DESCRIPTION
Refactor the table lifecycle policy to improve clarity and maintainability by introducing a runtime reducer pattern. Update documentation to reflect these changes and add tests to ensure functionality.