### PR TITLE
Refactor CSS for dual selection handling

### DIFF
--- a/src/contentScript/nestedEditor/nestedEditorTheme.ts
+++ b/src/contentScript/nestedEditor/nestedEditorTheme.ts
@@ -11,26 +11,13 @@ export function createNestedEditorTheme(isDarkTheme: boolean): Extension {
             backgroundColor: 'transparent',
         },
 
-        // --- Selection conflict overrides ---
-        // The main Joplin CM editor applies `&.cm-focused ::selection { ... }` which
-        // targets ALL descendants, including the nested editor DOM. The nested editor
-        // uses CM's drawSelection(), which paints its own .cm-selectionBackground layer.
-        // If the browser's native ::selection overlay also fires, both paint simultaneously.
-        // Force ::selection to transparent here so the native overlay never wins.
+        // --- Selection rendering ---
+        // CM's drawSelection() paints .cm-selectionBackground; style its color here.
+        // Native ::selection suppression is handled on the root editor in
+        // rootEditorSelectionTheme.ts, which has higher specificity than Joplin's
+        // cascading `&.cm-focused ::selection` rule.
         '&.cm-focused > .cm-scroller > .cm-selectionLayer .cm-selectionBackground': {
             backgroundColor: 'var(--rt-nested-selection-bg) !important',
-        },
-        // NOTE: `::selection` must be attached to an element selector.
-        // Joplin applies `&.cm-focused ::selection` on the *main* editor, and the
-        // nested editor lives inside the main editor DOM. Use higher specificity
-        // + !important so the browser's default blue overlay never wins here.
-        '&.cm-editor.cm-focused .cm-content::selection, &.cm-editor.cm-focused .cm-content *::selection': {
-            backgroundColor: 'transparent !important',
-            color: 'inherit !important',
-        },
-        '&.cm-editor .cm-content::selection, &.cm-editor .cm-content *::selection': {
-            backgroundColor: 'transparent !important',
-            color: 'inherit !important',
         },
 
         // --- Joplin/CM environment resets ---

--- a/src/contentScript/nestedEditor/rootEditorSelectionTheme.ts
+++ b/src/contentScript/nestedEditor/rootEditorSelectionTheme.ts
@@ -1,0 +1,25 @@
+import { EditorView } from '@codemirror/view';
+import { activeCellField, getActiveCell } from '../tableState/activeCellState';
+import { CLASS_CELL_EDITOR } from '../shared/tableDomClasses';
+
+// Set data-rt-nested-active on Joplin's root .cm-editor when a cell is being edited.
+// This attribute lets the suppression theme below scope its selectors from the root.
+export const rootEditorActiveCellAttribute = EditorView.editorAttributes.compute(
+    [activeCellField],
+    (state): Record<string, string> => (getActiveCell(state) ? { 'data-rt-nested-active': '' } : {})
+);
+
+// Suppress the browser's native ::selection highlight inside the nested cell editor.
+// Registered on the root editor so `&` resolves to Joplin's .cm-editor, giving the
+// selector 1 attribute + 3 classes of specificity — enough to beat Joplin's own
+// `&.cm-focused ::selection !important` rule (2 classes) regardless of source order.
+export const rootEditorSelectionSuppression = EditorView.baseTheme({
+    [`&[data-rt-nested-active] .${CLASS_CELL_EDITOR} .cm-content::selection`]: {
+        'background-color': 'transparent !important',
+        color: 'inherit !important',
+    },
+    [`&[data-rt-nested-active] .${CLASS_CELL_EDITOR} .cm-content *::selection`]: {
+        'background-color': 'transparent !important',
+        color: 'inherit !important',
+    },
+});

--- a/src/contentScript/tableWidget/tableWidgetExtension.ts
+++ b/src/contentScript/tableWidget/tableWidgetExtension.ts
@@ -36,6 +36,10 @@ import {
 } from '../tableRuntime/interaction/outsideTableInteraction';
 import { createStartupCursorCorrection } from '../tableRuntime/startupCursorCorrection';
 import { tableDecorationField } from './tableDecorationField';
+import {
+    rootEditorActiveCellAttribute,
+    rootEditorSelectionSuppression,
+} from '../nestedEditor/rootEditorSelectionTheme';
 
 const tableWidgetInteractionHandlers = EditorView.domEventHandlers({
     mousedown: (event, view) => {
@@ -112,6 +116,8 @@ async function registerTableWidgetExtension(
         documentDefinitionsField,
         richTableThemeVars,
         tableStyles,
+        rootEditorActiveCellAttribute,
+        rootEditorSelectionSuppression,
         tableToolbarTheme,
         tableToolbarPlugin,
     ]);


### PR DESCRIPTION
Enhance the CSS handling for selection in the nested editor to ensure proper rendering and suppression of native selection highlights. This refactor improves robustness and specificity in the selection styles.