### PR TITLE
fix: #123 selection jumping to cell beginning after toolbar command with newer @codemirror/view

### DIFF
--- a/src/contentScript/__tests__/rootDomSelection.test.ts
+++ b/src/contentScript/__tests__/rootDomSelection.test.ts
@@ -1,0 +1,72 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { afterEach, describe, expect, it } from '@jest/globals';
+import { EditorSelection, EditorState } from '@codemirror/state';
+import { EditorView } from '@codemirror/view';
+import { forceRootDomSelection } from '../editorBridge/rootDomSelection';
+
+if (!Range.prototype.getClientRects) {
+    Object.defineProperty(Range.prototype, 'getClientRects', {
+        configurable: true,
+        value: () => [],
+    });
+}
+
+if (!Range.prototype.getBoundingClientRect) {
+    Object.defineProperty(Range.prototype, 'getBoundingClientRect', {
+        configurable: true,
+        value: () => new DOMRect(),
+    });
+}
+
+function createView(doc: string): EditorView {
+    const parent = document.createElement('div');
+    document.body.appendChild(parent);
+
+    return new EditorView({
+        parent,
+        state: EditorState.create({
+            doc,
+            selection: EditorSelection.single(0),
+        }),
+    });
+}
+
+function getSelectionPositions(view: EditorView): { anchor: number; head: number } {
+    const selection = document.getSelection();
+    if (!selection?.anchorNode || !selection.focusNode) {
+        throw new Error('Expected DOM selection');
+    }
+
+    return {
+        anchor: view.posAtDOM(selection.anchorNode, selection.anchorOffset),
+        head: view.posAtDOM(selection.focusNode, selection.focusOffset),
+    };
+}
+
+describe('forceRootDomSelection', () => {
+    afterEach(() => {
+        document.getSelection()?.removeAllRanges();
+        document.body.innerHTML = '';
+    });
+
+    it('writes the browser DOM selection for a forward editor selection', () => {
+        const view = createView('abcdef');
+
+        expect(forceRootDomSelection(view, { anchor: 2, head: 5 })).toBe(true);
+        expect(getSelectionPositions(view)).toEqual({ anchor: 2, head: 5 });
+
+        view.destroy();
+    });
+
+    it('preserves backward selection direction when the DOM API supports it', () => {
+        const view = createView('abcdef');
+
+        expect(forceRootDomSelection(view, { anchor: 5, head: 2 })).toBe(true);
+        expect(getSelectionPositions(view)).toEqual({ anchor: 5, head: 2 });
+
+        view.destroy();
+    });
+});

--- a/src/contentScript/editorBridge/rootDomSelection.ts
+++ b/src/contentScript/editorBridge/rootDomSelection.ts
@@ -1,0 +1,65 @@
+import type { EditorView } from '@codemirror/view';
+import { getViewDocument } from '../shared/domContext';
+
+interface DomSelectionEndpoint {
+    node: Node;
+    offset: number;
+}
+
+function clampPosition(view: EditorView, pos: number): number {
+    return Math.max(0, Math.min(view.state.doc.length, pos));
+}
+
+function getDomSelectionEndpoint(view: EditorView, pos: number, side: -1 | 1): DomSelectionEndpoint {
+    return view.domAtPos(clampPosition(view, pos), side);
+}
+
+function isSelectionEndpointInView(view: EditorView, endpoint: DomSelectionEndpoint): boolean {
+    return view.contentDOM.contains(endpoint.node);
+}
+
+function setForwardDomSelection(
+    documentSelection: Selection,
+    doc: Document,
+    anchor: DomSelectionEndpoint,
+    head: DomSelectionEndpoint
+): void {
+    const range = doc.createRange();
+    range.setStart(anchor.node, anchor.offset);
+    range.setEnd(head.node, head.offset);
+    documentSelection.removeAllRanges();
+    documentSelection.addRange(range);
+}
+
+/**
+ * Mirrors CodeMirror's state selection into the browser DOM selection even when
+ * the root editor is blurred. This keeps host editor focus restoration from
+ * reconciling against a stale DOM selection after command-driven root edits.
+ */
+export function forceRootDomSelection(view: EditorView, selection: { anchor: number; head: number }): boolean {
+    const doc = getViewDocument(view);
+    const documentSelection = doc.getSelection();
+    if (!documentSelection) {
+        return false;
+    }
+
+    const forward = selection.anchor <= selection.head;
+    const anchor = getDomSelectionEndpoint(view, selection.anchor, forward ? -1 : 1);
+    const head = getDomSelectionEndpoint(view, selection.head, forward ? 1 : -1);
+    if (!isSelectionEndpointInView(view, anchor) || !isSelectionEndpointInView(view, head)) {
+        return false;
+    }
+
+    try {
+        if (documentSelection.setBaseAndExtent) {
+            documentSelection.setBaseAndExtent(anchor.node, anchor.offset, head.node, head.offset);
+        } else if (forward) {
+            setForwardDomSelection(documentSelection, doc, anchor, head);
+        } else {
+            setForwardDomSelection(documentSelection, doc, head, anchor);
+        }
+        return true;
+    } catch {
+        return false;
+    }
+}

--- a/src/contentScript/nestedEditor/nestedEditorController.ts
+++ b/src/contentScript/nestedEditor/nestedEditorController.ts
@@ -14,6 +14,7 @@ import {
     toRootSelection,
     unsanitizeRootText,
 } from '../editorBridge/cellTextCodec';
+import { forceRootDomSelection } from '../editorBridge/rootDomSelection';
 import { syncAnnotation } from '../editorBridge/syncAnnotation';
 import { ensureCellWrapper } from './mounting';
 import {
@@ -210,6 +211,12 @@ class NestedEditorController {
 
         const rootText = update.state.doc.sliceString(resolved.editableFrom, resolved.editableTo);
         const rootSelection = toRelativeSelection(update.state.selection, resolved.editableFrom, resolved.editableTo);
+        const mainSelection = update.state.selection.main;
+
+        forceRootDomSelection(this.mainView, {
+            anchor: mainSelection.anchor,
+            head: mainSelection.head,
+        });
 
         this.session.root = {
             text: rootText,


### PR DESCRIPTION
issue #123

toolbar commands previously worked, only due to implicit codemirror behavior that was removed in this commit codemirror/view@c946a84

fix: after a non-sync main editor update from a host command, the plugin now forces the DOM selection to update.state.selection.main before rebasing the nested editor