### PR TITLE
fix: backslash escape briefly visible during fallback text to rendered html transition

### DIFF
--- a/src/contentScript/__tests__/cellContentUtils.test.ts
+++ b/src/contentScript/__tests__/cellContentUtils.test.ts
@@ -40,9 +40,10 @@ describe('escapeLeadingBlockMarkers', () => {
 });
 
 describe('buildRenderableContent', () => {
-    it('escapes leading block markers in displayText', () => {
+    it('keeps fallback display text unescaped while escaping the render cache key', () => {
         const result = buildRenderableContent('# Heading');
-        expect(result.displayText).toBe('\\# Heading');
+        expect(result.displayText).toBe('# Heading');
+        expect(result.cacheKey).toBe('\\# Heading');
     });
 
     it('uses the normalized display text as the cache key for reference-looking links', () => {

--- a/src/contentScript/nestedEditor/nestedEditorController.ts
+++ b/src/contentScript/nestedEditor/nestedEditorController.ts
@@ -253,7 +253,7 @@ class NestedEditorController {
                 this.contentEl.innerHTML = cached;
             } else {
                 this.contentEl.innerHTML = escapeHtmlPreservingBr(displayText);
-                if (containsMarkdown(displayText)) {
+                if (containsMarkdown(cacheKey)) {
                     const contentEl = this.contentEl;
                     renderer.renderAsync(cacheKey, (html) => {
                         if (contentEl.isConnected) {

--- a/src/contentScript/shared/cellContentUtils.ts
+++ b/src/contentScript/shared/cellContentUtils.ts
@@ -69,11 +69,11 @@ export interface RenderableContent {
 
 /**
  * Builds the content strings used for rendering and cache lookup.
- * Unescapes pipes and escapes leading block markers for isolated cell rendering.
+ * Unescapes pipes for display, then escapes leading block markers for isolated cell rendering.
  */
 export function buildRenderableContent(cellText: string): RenderableContent {
-    const displayText = escapeLeadingBlockMarkers(unescapePipesForRendering(cellText));
-    const cacheKey = displayText;
+    const displayText = unescapePipesForRendering(cellText);
+    const cacheKey = escapeLeadingBlockMarkers(displayText);
 
     return { displayText, cacheKey };
 }

--- a/src/contentScript/tableWidget/TableWidget.ts
+++ b/src/contentScript/tableWidget/TableWidget.ts
@@ -228,7 +228,7 @@ export class TableWidget extends WidgetType {
         contentWrapper.innerHTML = escapeHtmlPreservingBr(displayText);
 
         // Check if content likely contains markdown (optimization)
-        if (containsMarkdown(displayText)) {
+        if (containsMarkdown(cacheKey)) {
             // Request async rendering and update when ready
             renderer.renderAsync(cacheKey, (html) => {
                 // Only update if the wrapper is still in the DOM.


### PR DESCRIPTION
Changed cellContentUtils.ts so displayText stays unescaped for the fallback, while cacheKey remains the escaped render input.