### PR TITLE
Fix table insertion and activation reliability

### DIFF
--- a/src/contentScript/__tests__/mainEditorGuard.test.ts
+++ b/src/contentScript/__tests__/mainEditorGuard.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from '@jest/globals';
 import { activeCellField, getActiveCell, setActiveCellEffect } from '../tableState/activeCellState';
 import { cellSelectionField, getCellSelection } from '../tableState/cellSelectionState';
-import { activateInsertedTableEffect } from '../tableState/insertedTableActivation';
+import { activateInsertedTableEffect, insertedTableActivationField } from '../tableState/insertedTableActivation';
 import { createMainEditorActiveCellGuard } from '../editorBridge/mainEditorGuard';
 import { computeMarkdownTableCellRanges } from '../tableModel/markdownTableCellRanges';
 import { searchForceSourceModeField, setSearchForceSourceModeEffect } from '../tableState/searchForceSourceMode';
@@ -15,6 +15,7 @@ function createState(params: { doc: string; nestedOpen: boolean }) {
         cellSelectionField,
         searchForceSourceModeField,
         sourceModeField,
+        insertedTableActivationField,
         createMainEditorActiveCellGuard(() => params.nestedOpen),
     ]);
 }
@@ -282,7 +283,7 @@ describe('createMainEditorActiveCellGuard', () => {
         expect(tr.effects.some((effect) => effect.is(activateInsertedTableEffect))).toBe(true);
     });
 
-    it('leaves mid-line table paste unchanged in the plain root editor', () => {
+    it('rewrites mid-line table paste with canonical spacing and activation effect', () => {
         const doc = 'before after';
         const state = createState({ doc, nestedOpen: false });
         const pasteText = ['|H1|H2|', '|---|---|', '|a|b|'].join('\n');
@@ -293,8 +294,11 @@ describe('createMainEditorActiveCellGuard', () => {
             userEvent: 'input.paste',
         });
 
-        expect(tr.state.doc.toString()).toBe(`before${pasteText} after`);
-        expect(tr.effects.some((effect) => effect.is(activateInsertedTableEffect))).toBe(false);
+        expect(tr.state.doc.toString()).toBe(
+            `before\n\n${['| H1 | H2 |', '| --- | --- |', '| a | b |'].join('\n')}\n\n after`
+        );
+        expect(tr.state.selection.main.head).toBe(pastePos + 2);
+        expect(tr.effects.some((effect) => effect.is(activateInsertedTableEffect))).toBe(true);
     });
 
     it('leaves table paste unchanged in source mode', () => {

--- a/src/contentScript/__tests__/nestedEditorLifecycle.test.ts
+++ b/src/contentScript/__tests__/nestedEditorLifecycle.test.ts
@@ -6,7 +6,11 @@ import { EditorState, Transaction } from '@codemirror/state';
 import { EditorView } from '@codemirror/view';
 import { describe, expect, it, beforeEach, afterEach, jest } from '@jest/globals';
 import { nestedEditorLifecyclePlugin } from '../tableRuntime/lifecycle/nestedEditorLifecycle';
-import { activateInsertedTableEffect } from '../tableState/insertedTableActivation';
+import {
+    activateInsertedTableEffect,
+    getPendingInsertedTableActivation,
+    insertedTableActivationField,
+} from '../tableState/insertedTableActivation';
 import {
     activeCellField,
     clearActiveCellEffect,
@@ -137,6 +141,7 @@ describe('nestedEditorLifecycle', () => {
                     markdown({ extensions: [GFM] }),
                     activeCellField,
                     openCellRequestField,
+                    insertedTableActivationField,
                     searchForceSourceModeField,
                     sourceModeField,
                     hostEditorConfigFacet.of(TEST_HOST_CONFIG),
@@ -158,6 +163,49 @@ describe('nestedEditorLifecycle', () => {
             row: 0,
             col: 0,
         });
+
+        view.destroy();
+    });
+
+    it('uses the mapped pending inserted-table activation when text shifts before the scheduled frame', () => {
+        const parent = document.createElement('div');
+        document.body.appendChild(parent);
+
+        const doc = ['before', '', CANONICAL_DOC].join('\n');
+        const tableFrom = 'before\n\n'.length;
+        const insertedText = 'top\n';
+        const view = new EditorView({
+            parent,
+            state: EditorState.create({
+                doc,
+                extensions: [
+                    markdown({ extensions: [GFM] }),
+                    activeCellField,
+                    openCellRequestField,
+                    insertedTableActivationField,
+                    searchForceSourceModeField,
+                    sourceModeField,
+                    hostEditorConfigFacet.of(TEST_HOST_CONFIG),
+                    nestedEditorLifecyclePlugin,
+                ],
+            }),
+        });
+
+        view.dispatch({
+            effects: activateInsertedTableEffect.of({
+                tableFrom,
+                target: { section: 'header', row: 0, col: 0 },
+            }),
+        });
+        view.dispatch({ changes: { from: 0, to: 0, insert: insertedText } });
+        flushAnimationFrames();
+
+        expect(activateTableCellMock).toHaveBeenCalledWith(view, tableFrom + insertedText.length, {
+            section: 'header',
+            row: 0,
+            col: 0,
+        });
+        expect(getPendingInsertedTableActivation(view.state)).toBeNull();
 
         view.destroy();
     });

--- a/src/contentScript/__tests__/pasteTableNormalizer.test.ts
+++ b/src/contentScript/__tests__/pasteTableNormalizer.test.ts
@@ -85,22 +85,35 @@ describe('pasteTableNormalizer', () => {
             expect(nextDoc).toBe(['before', '', ...CANONICAL_TABLE.split('\n'), ''].join('\n'));
         });
 
-        it('rejects paste when caret is mid-line inside text', () => {
+        it('adds canonical spacing when pasting a table mid-line inside text', () => {
             const doc = 'before after';
             const state = createMarkdownState(doc);
+            const insertionPos = doc.indexOf(' ');
+            const rewrite = buildRootTablePasteRewrite(state, insertionPos, insertionPos, NON_CANONICAL_TABLE);
 
-            expect(
-                buildRootTablePasteRewrite(state, doc.indexOf(' '), doc.indexOf(' '), NON_CANONICAL_TABLE)
-            ).toBeNull();
+            expect(rewrite).toEqual({
+                changes: {
+                    from: insertionPos,
+                    to: insertionPos,
+                    insert: `\n\n${CANONICAL_TABLE}\n\n`,
+                },
+                selectionAnchor: insertionPos + 2,
+                tableFrom: insertionPos + 2,
+            });
         });
 
-        it('rejects paste when the touched boundary line keeps non-whitespace content', () => {
+        it('adds canonical spacing when replacing whitespace after line content', () => {
             const doc = ['before', 'abc   ', 'after'].join('\n');
             const state = createMarkdownState(doc);
             const from = doc.indexOf('   ');
             const to = from + 3;
+            const rewrite = buildRootTablePasteRewrite(state, from, to, NON_CANONICAL_TABLE);
 
-            expect(buildRootTablePasteRewrite(state, from, to, NON_CANONICAL_TABLE)).toBeNull();
+            expect(rewrite).not.toBeNull();
+            const nextDoc = state.update({ changes: rewrite!.changes }).state.doc.toString();
+
+            expect(nextDoc).toBe(['before', 'abc', '', ...CANONICAL_TABLE.split('\n'), '', 'after'].join('\n'));
+            expect(rewrite?.tableFrom).toBe(from + 2);
         });
 
         it('returns an absolute table start in the post-change document', () => {

--- a/src/contentScript/__tests__/tableInsertCommand.test.ts
+++ b/src/contentScript/__tests__/tableInsertCommand.test.ts
@@ -72,9 +72,7 @@ describe('insertTableAndActivate', () => {
 
         insertTableAndActivate(view);
 
-        expect(view.state.doc.toString()).toBe(
-            `before\n\n${DEFAULT_INSERTED_TABLE_MARKDOWN}\n\n after`
-        );
+        expect(view.state.doc.toString()).toBe(`before\n\n${DEFAULT_INSERTED_TABLE_MARKDOWN}\n\n after`);
         expect(view.state.selection.main.head).toBe(10);
 
         const activationEffect = getActivateInsertedTableEffect(view);

--- a/src/contentScript/__tests__/tableInsertCommand.test.ts
+++ b/src/contentScript/__tests__/tableInsertCommand.test.ts
@@ -1,32 +1,53 @@
-import { describe, expect, it, jest } from '@jest/globals';
-import type { EditorState, TransactionSpec } from '@codemirror/state';
+import { describe, expect, it } from '@jest/globals';
+import type { EditorState, StateEffect, TransactionSpec } from '@codemirror/state';
 import type { EditorView } from '@codemirror/view';
 import { insertTableAndActivate } from '../tableRuntime/operations/structuralOperations';
+import { activateInsertedTableEffect } from '../tableState/insertedTableActivation';
 import { createMarkdownState } from './testMarkdownState';
-
-const activateTableCellMock = jest.fn();
-
-jest.mock('../tableRuntime/activeCell/cellActivation', () => ({
-    activateTableCell: (...args: unknown[]) => activateTableCellMock(...args),
-}));
 
 const DEFAULT_INSERTED_TABLE_MARKDOWN = ['|  |  |', '| --- | --- |', '|  |  |'].join('\n');
 
+interface CapturedDispatch {
+    spec: TransactionSpec;
+    effects: StateEffect<unknown>[];
+}
+
 function createMockView(doc: string, cursorPos: number): EditorView & { state: EditorState } {
+    const dispatches: CapturedDispatch[] = [];
     const view = {
         state: createMarkdownState(doc).update({ selection: { anchor: cursorPos } }).state,
+        get dispatches() {
+            return dispatches;
+        },
         dispatch(spec: TransactionSpec) {
+            const effects: StateEffect<unknown>[] = Array.isArray(spec.effects)
+                ? (spec.effects as StateEffect<unknown>[])
+                : spec.effects
+                  ? [spec.effects as StateEffect<unknown>]
+                  : [];
+            dispatches.push({ spec, effects });
             this.state = this.state.update(spec).state;
         },
     };
 
-    return view as EditorView & { state: EditorState };
+    return view as unknown as EditorView & { state: EditorState };
+}
+
+function getActivateInsertedTableEffect(
+    view: ReturnType<typeof createMockView>
+): { tableFrom: number; target: unknown } | null {
+    for (const { effects } of (view as unknown as { dispatches: CapturedDispatch[] }).dispatches) {
+        for (const effect of effects) {
+            if (effect.is(activateInsertedTableEffect)) {
+                return effect.value;
+            }
+        }
+    }
+    return null;
 }
 
 describe('insertTableAndActivate', () => {
     it('reuses isolated block insertion behavior on a whitespace-only line', () => {
-        activateTableCellMock.mockReset();
-
         const doc = ['before', '', 'after'].join('\n');
         const view = createMockView(doc, 'before\n'.length);
 
@@ -36,44 +57,45 @@ describe('insertTableAndActivate', () => {
             ['before', '', ...DEFAULT_INSERTED_TABLE_MARKDOWN.split('\n'), '', 'after'].join('\n')
         );
         expect(view.state.selection.main.head).toBe(10);
-        expect(activateTableCellMock).toHaveBeenCalledWith(view, 8, {
-            section: 'header',
-            row: 0,
-            col: 0,
+
+        const activationEffect = getActivateInsertedTableEffect(view);
+        expect(activationEffect).toEqual({
+            tableFrom: 8,
+            target: { section: 'header', row: 0, col: 0 },
         });
     });
 
-    it('falls back to the legacy direct insert path mid-line', () => {
-        activateTableCellMock.mockReset();
-
+    it('produces canonical markdown with blank lines when inserting mid-line', () => {
         const doc = 'before after';
         const cursorPos = doc.indexOf(' ');
         const view = createMockView(doc, cursorPos);
 
         insertTableAndActivate(view);
 
-        expect(view.state.doc.toString()).toBe(`before\n${DEFAULT_INSERTED_TABLE_MARKDOWN}\n after`);
-        expect(view.state.selection.main.head).toBe(cursorPos + 3);
-        expect(activateTableCellMock).toHaveBeenCalledWith(view, cursorPos + 1, {
-            section: 'header',
-            row: 0,
-            col: 0,
+        expect(view.state.doc.toString()).toBe(
+            `before\n\n${DEFAULT_INSERTED_TABLE_MARKDOWN}\n\n after`
+        );
+        expect(view.state.selection.main.head).toBe(10);
+
+        const activationEffect = getActivateInsertedTableEffect(view);
+        expect(activationEffect).toEqual({
+            tableFrom: 8,
+            target: { section: 'header', row: 0, col: 0 },
         });
     });
 
     it('keeps empty-document insertion aligned with root paste behavior', () => {
-        activateTableCellMock.mockReset();
-
         const view = createMockView('', 0);
 
         insertTableAndActivate(view);
 
         expect(view.state.doc.toString()).toBe(`\n${DEFAULT_INSERTED_TABLE_MARKDOWN}\n`);
         expect(view.state.selection.main.head).toBe(3);
-        expect(activateTableCellMock).toHaveBeenCalledWith(view, 1, {
-            section: 'header',
-            row: 0,
-            col: 0,
+
+        const activationEffect = getActivateInsertedTableEffect(view);
+        expect(activationEffect).toEqual({
+            tableFrom: 1,
+            target: { section: 'header', row: 0, col: 0 },
         });
     });
 });

--- a/src/contentScript/tableRuntime/activeCell/cellActivation.ts
+++ b/src/contentScript/tableRuntime/activeCell/cellActivation.ts
@@ -11,7 +11,6 @@ import { buildTableContext } from '../../tableModel/tableContext';
 import { createActiveCellFromRanges } from './activeCellFactory';
 import { createResolvedActiveCell } from './resolvedActiveCell';
 import { requestOpenCell } from '../openCellRequest';
-import { requestViewAnimationFrame } from '../../shared/domContext';
 
 export interface ActivateCellOptions {
     /** If true and position is outside any table, clears active cell and focuses main editor (default: false) */
@@ -125,36 +124,34 @@ export function activateCellAtPosition(view: EditorView, pos: number, options?: 
 
 /**
  * Activates a specific cell by table position and coordinates.
- * Waits for widget mount via requestAnimationFrame before activating.
- * Used after table insertion to activate the first cell.
+ * Callers that depend on newly mounted widgets should schedule this after the
+ * relevant DOM update has had a chance to render.
  */
 export function activateTableCell(
     view: EditorView,
     tableFrom: number,
     coords: { section: 'header' | 'body'; row: number; col: number }
 ): void {
-    requestViewAnimationFrame(view, () => {
-        if (!view.dom.isConnected) return;
+    if (!view.dom.isConnected) return;
 
-        // Don't activate cells in source mode (no widgets exist)
-        if (isSourceModeEnabled(view.state)) return;
+    // Don't activate cells in source mode (no widgets exist)
+    if (isSourceModeEnabled(view.state)) return;
 
-        const table = resolveTableAtPos(view.state, tableFrom);
-        if (!table) return;
+    const table = resolveTableAtPos(view.state, tableFrom);
+    if (!table) return;
 
-        const ctx = buildTableContext(table);
-        if (!ctx) return;
+    const ctx = buildTableContext(table);
+    if (!ctx) return;
 
-        const resolvedCell = createResolvedActiveCell({
-            ctx,
-            coords,
-        });
+    const resolvedCell = createResolvedActiveCell({
+        ctx,
+        coords,
+    });
 
-        if (!resolvedCell) return;
+    if (!resolvedCell) return;
 
-        requestOpenCell(view, {
-            target: { resolvedCell },
-            normalizeIfNeeded: true,
-        });
+    requestOpenCell(view, {
+        target: { resolvedCell },
+        normalizeIfNeeded: true,
     });
 }

--- a/src/contentScript/tableRuntime/lifecycle/nestedEditorLifecycle.ts
+++ b/src/contentScript/tableRuntime/lifecycle/nestedEditorLifecycle.ts
@@ -6,7 +6,11 @@ import {
     setActiveCellEffect,
     type ActiveCell,
 } from '../../tableState/activeCellState';
-import { activateInsertedTableEffect } from '../../tableState/insertedTableActivation';
+import {
+    activateInsertedTableEffect,
+    clearInsertedTableActivationEffect,
+    getPendingInsertedTableActivation,
+} from '../../tableState/insertedTableActivation';
 import { isEffectiveRawMode } from '../../tableState/sourceMode';
 import { rebuildAllTableWidgetsEffect, rebuildTableWidgetsEffect } from '../../tableState/tableWidgetEffects';
 import { getResolvedActiveCell, type ResolvedActiveCell } from '../activeCell/resolvedActiveCell';
@@ -197,15 +201,18 @@ export const nestedEditorLifecyclePlugin = ViewPlugin.fromClass(
         }
 
         private scheduleInsertedTableActivation(update: ViewUpdate): void {
-            const activationRequest = getInsertedTableActivationRequest(update);
-            if (!activationRequest) {
+            if (!getInsertedTableActivationRequest(update)) {
                 return;
             }
 
             requestViewAnimationFrame(this.view, () => {
                 if (!this.view.dom.isConnected) return;
 
+                const activationRequest = getPendingInsertedTableActivation(this.view.state);
+                if (!activationRequest) return;
+
                 activateTableCell(this.view, activationRequest.tableFrom, activationRequest.target);
+                this.view.dispatch({ effects: clearInsertedTableActivationEffect.of(undefined) });
             });
         }
 

--- a/src/contentScript/tableRuntime/lifecycle/nestedEditorLifecycle.ts
+++ b/src/contentScript/tableRuntime/lifecycle/nestedEditorLifecycle.ts
@@ -53,16 +53,16 @@ function ensureCursorVisible(view: EditorView): void {
     view.dispatch({ effects: EditorView.scrollIntoView(cursorPos, { y: 'nearest' }) });
 }
 
-function getInsertedTableActivationRequest(update: ViewUpdate) {
+function hasInsertedTableActivationEffect(update: ViewUpdate): boolean {
     for (const tr of update.transactions) {
         for (const effect of tr.effects) {
             if (effect.is(activateInsertedTableEffect)) {
-                return effect.value;
+                return true;
             }
         }
     }
 
-    return null;
+    return false;
 }
 
 function mapActiveCellThroughUpdate(update: ViewUpdate, activeCell: ActiveCell | null): ActiveCell | null {
@@ -201,7 +201,7 @@ export const nestedEditorLifecyclePlugin = ViewPlugin.fromClass(
         }
 
         private scheduleInsertedTableActivation(update: ViewUpdate): void {
-            if (!getInsertedTableActivationRequest(update)) {
+            if (!hasInsertedTableActivationEffect(update)) {
                 return;
             }
 

--- a/src/contentScript/tableRuntime/operations/pasteTableNormalizer.ts
+++ b/src/contentScript/tableRuntime/operations/pasteTableNormalizer.ts
@@ -1,6 +1,6 @@
 import type { EditorState } from '@codemirror/state';
 import { MarkdownTable } from '../../tableModel/MarkdownTable';
-import { buildIsolatedRootTableInsertRewrite } from './rootTableInsertRewrite';
+import { buildIsolatedRootTableInsertRewrite, buildRootTableInsertRewrite } from './rootTableInsertRewrite';
 
 export interface RootTablePasteRewrite {
     changes: {
@@ -62,10 +62,9 @@ export function buildRootTablePasteRewrite(
         return null;
     }
     const canonicalTableText = table.serialize();
-    const rewrite = buildIsolatedRootTableInsertRewrite(state, from, to, canonicalTableText);
-    if (!rewrite) {
-        return null;
-    }
+    const rewrite =
+        buildIsolatedRootTableInsertRewrite(state, from, to, canonicalTableText) ??
+        buildRootTableInsertRewrite(state, from, to, canonicalTableText);
 
     return {
         ...rewrite,

--- a/src/contentScript/tableRuntime/operations/rootTableInsertRewrite.ts
+++ b/src/contentScript/tableRuntime/operations/rootTableInsertRewrite.ts
@@ -50,9 +50,7 @@ export function buildRootTableInsertRewrite(
 
     const prefix = insertsIntoEmptyDocument ? '\n' : '\n'.repeat(computeLeadingNewlines(beforeText));
     const suffix =
-        insertsIntoEmptyDocument || insertsAtDocumentEnd
-            ? '\n'
-            : '\n'.repeat(computeTrailingNewlines(afterText));
+        insertsIntoEmptyDocument || insertsAtDocumentEnd ? '\n' : '\n'.repeat(computeTrailingNewlines(afterText));
     const insert = prefix + tableText + suffix;
     const tableFrom = replaceFrom + prefix.length;
 

--- a/src/contentScript/tableRuntime/operations/rootTableInsertRewrite.ts
+++ b/src/contentScript/tableRuntime/operations/rootTableInsertRewrite.ts
@@ -21,7 +21,23 @@ function hasNonWhitespace(text: string): boolean {
     return text.trim().length > 0;
 }
 
-function buildRootTableInsertRewrite(
+function computeLeadingNewlines(beforeText: string): number {
+    if (!hasNonWhitespace(beforeText)) return 0;
+    const existingBlanks = countTrailingBlankLinesBeforeBoundary(beforeText);
+    if (existingBlanks >= REQUIRED_TABLE_BOUNDARY_BLANK_LINES) return 0;
+    const endsWithNewline = beforeText.endsWith('\n');
+    return (endsWithNewline ? 0 : 1) + (REQUIRED_TABLE_BOUNDARY_BLANK_LINES - existingBlanks);
+}
+
+function computeTrailingNewlines(afterText: string): number {
+    if (!hasNonWhitespace(afterText)) return 0;
+    const existingBlanks = countLeadingBlankLinesAfterBoundary(afterText);
+    if (existingBlanks >= REQUIRED_TABLE_BOUNDARY_BLANK_LINES) return 0;
+    const startsWithNewline = afterText.startsWith('\n');
+    return (startsWithNewline ? 0 : 1) + (REQUIRED_TABLE_BOUNDARY_BLANK_LINES - existingBlanks);
+}
+
+export function buildRootTableInsertRewrite(
     state: EditorState,
     replaceFrom: number,
     replaceTo: number,
@@ -30,18 +46,13 @@ function buildRootTableInsertRewrite(
     const beforeText = state.doc.sliceString(0, replaceFrom);
     const afterText = state.doc.sliceString(replaceTo);
     const insertsIntoEmptyDocument = state.doc.length === 0;
-    const needsLeadingSeparator =
-        insertsIntoEmptyDocument ||
-        (hasNonWhitespace(beforeText) &&
-            countTrailingBlankLinesBeforeBoundary(beforeText) < REQUIRED_TABLE_BOUNDARY_BLANK_LINES);
     const insertsAtDocumentEnd = replaceTo === state.doc.length && state.doc.length > 0;
-    const needsTrailingSeparator =
-        insertsIntoEmptyDocument ||
-        insertsAtDocumentEnd ||
-        (hasNonWhitespace(afterText) &&
-            countLeadingBlankLinesAfterBoundary(afterText) < REQUIRED_TABLE_BOUNDARY_BLANK_LINES);
-    const prefix = needsLeadingSeparator ? '\n' : '';
-    const suffix = needsTrailingSeparator ? '\n' : '';
+
+    const prefix = insertsIntoEmptyDocument ? '\n' : '\n'.repeat(computeLeadingNewlines(beforeText));
+    const suffix =
+        insertsIntoEmptyDocument || insertsAtDocumentEnd
+            ? '\n'
+            : '\n'.repeat(computeTrailingNewlines(afterText));
     const insert = prefix + tableText + suffix;
     const tableFrom = replaceFrom + prefix.length;
 

--- a/src/contentScript/tableRuntime/operations/structuralOperations.ts
+++ b/src/contentScript/tableRuntime/operations/structuralOperations.ts
@@ -2,10 +2,10 @@ import { EditorView } from '@codemirror/view';
 import type { TableAlignment } from '../../tableModel/MarkdownTable';
 import type { StructuralTableCommand } from '../../tableModel/structuralCommandSemantics';
 import type { ResolvedActiveCell } from '../activeCell/resolvedActiveCell';
-import { activateTableCell } from '../activeCell/cellActivation';
 import { focusMainEditorWithoutScroll } from '../../shared/mainEditorFocus';
-import { buildIsolatedRootTableInsertRewrite } from './rootTableInsertRewrite';
+import { buildRootTableInsertRewrite } from './rootTableInsertRewrite';
 import { runStructuralMutationAndReopen, type StructuralReopenOptions } from './runStructuralMutation';
+import { activateInsertedTableEffect } from '../../tableState/insertedTableActivation';
 
 export type CommandColumnAlignment = TableAlignment;
 export type RowInsertOpenOptions = StructuralReopenOptions;
@@ -69,25 +69,19 @@ export function insertRowAtBottom(
 
 export function insertTableAndActivate(view: EditorView): boolean {
     const cursorPos = view.state.selection.main.head;
-    const rewrite = buildIsolatedRootTableInsertRewrite(
-        view.state,
-        cursorPos,
-        cursorPos,
-        DEFAULT_INSERTED_TABLE_MARKDOWN
-    ) ?? {
-        changes: {
-            from: cursorPos,
-            to: cursorPos,
-            insert: `\n${DEFAULT_INSERTED_TABLE_MARKDOWN}\n`,
-        },
-        tableFrom: cursorPos + 1,
-    };
+    const rewrite = buildRootTableInsertRewrite(view.state, cursorPos, cursorPos, DEFAULT_INSERTED_TABLE_MARKDOWN);
 
     view.dispatch({
         changes: rewrite.changes,
         selection: { anchor: rewrite.tableFrom + DEFAULT_INSERTED_TABLE_SELECTION_OFFSET },
+        effects: [
+            activateInsertedTableEffect.of({
+                tableFrom: rewrite.tableFrom,
+                target: { section: 'header', row: 0, col: 0 },
+            }),
+        ],
+        scrollIntoView: false,
     });
 
-    activateTableCell(view, rewrite.tableFrom, { section: 'header', row: 0, col: 0 });
     return true;
 }

--- a/src/contentScript/tableState/insertedTableActivation.ts
+++ b/src/contentScript/tableState/insertedTableActivation.ts
@@ -39,6 +39,8 @@ export const insertedTableActivationField = StateField.define<InsertedTableActiv
     update(value, tr) {
         let nextValue = value;
 
+        // Map only the already-pending request. New activation effects carry
+        // post-change positions from their originating transaction.
         if (tr.docChanged && nextValue) {
             nextValue = mapInsertedTableActivation(nextValue, tr.changes);
         }

--- a/src/contentScript/tableState/insertedTableActivation.ts
+++ b/src/contentScript/tableState/insertedTableActivation.ts
@@ -1,4 +1,4 @@
-import { StateEffect } from '@codemirror/state';
+import { EditorState, StateEffect, StateField, type ChangeDesc } from '@codemirror/state';
 import type { CellCoords } from '../tableModel/types';
 
 export interface InsertedTableActivationRequest {
@@ -6,10 +6,58 @@ export interface InsertedTableActivationRequest {
     target: CellCoords;
 }
 
-export const activateInsertedTableEffect = StateEffect.define<InsertedTableActivationRequest>({
-    map(value, changes) {
-        const tableFrom = changes.mapPos(value.tableFrom, 1);
-        if (!Number.isFinite(tableFrom) || tableFrom < 0) return undefined;
-        return { ...value, tableFrom };
+function mapInsertedTableActivation(
+    value: InsertedTableActivationRequest,
+    changes: ChangeDesc
+): InsertedTableActivationRequest | null {
+    let tableStartDeleted = false;
+    changes.iterChangedRanges((fromA, toA) => {
+        if (fromA <= value.tableFrom && value.tableFrom < toA) {
+            tableStartDeleted = true;
+        }
+    });
+    if (tableStartDeleted) {
+        return null;
+    }
+
+    const tableFrom = changes.mapPos(value.tableFrom, 1);
+    if (!Number.isFinite(tableFrom) || tableFrom < 0) {
+        return null;
+    }
+
+    return { ...value, tableFrom };
+}
+
+export const activateInsertedTableEffect = StateEffect.define<InsertedTableActivationRequest>();
+export const clearInsertedTableActivationEffect = StateEffect.define<void>();
+
+export const insertedTableActivationField = StateField.define<InsertedTableActivationRequest | null>({
+    create() {
+        return null;
+    },
+
+    update(value, tr) {
+        let nextValue = value;
+
+        if (tr.docChanged && nextValue) {
+            nextValue = mapInsertedTableActivation(nextValue, tr.changes);
+        }
+
+        for (const effect of tr.effects) {
+            if (effect.is(activateInsertedTableEffect)) {
+                nextValue = effect.value;
+                continue;
+            }
+
+            if (effect.is(clearInsertedTableActivationEffect)) {
+                nextValue = null;
+            }
+        }
+
+        return nextValue;
     },
 });
+
+export function getPendingInsertedTableActivation(state: EditorState): InsertedTableActivationRequest | null {
+    return state.field(insertedTableActivationField, false) ?? null;
+}

--- a/src/contentScript/tableState/insertedTableActivation.ts
+++ b/src/contentScript/tableState/insertedTableActivation.ts
@@ -6,4 +6,10 @@ export interface InsertedTableActivationRequest {
     target: CellCoords;
 }
 
-export const activateInsertedTableEffect = StateEffect.define<InsertedTableActivationRequest>();
+export const activateInsertedTableEffect = StateEffect.define<InsertedTableActivationRequest>({
+    map(value, changes) {
+        const tableFrom = changes.mapPos(value.tableFrom, 1);
+        if (!Number.isFinite(tableFrom) || tableFrom < 0) return undefined;
+        return { ...value, tableFrom };
+    },
+});

--- a/src/contentScript/tableWidget/tableWidgetExtension.ts
+++ b/src/contentScript/tableWidget/tableWidgetExtension.ts
@@ -15,6 +15,7 @@ import { resolvedActiveCellField } from '../tableRuntime/activeCell/resolvedActi
 import { cellSelectionField } from '../tableState/cellSelectionState';
 import { searchForceSourceModeField } from '../tableState/searchForceSourceMode';
 import { sourceModeField } from '../tableState/sourceMode';
+import { insertedTableActivationField } from '../tableState/insertedTableActivation';
 import { cellSelectionClipboardPlugin } from '../tableRuntime/selection/cellSelectionClipboard';
 import { cellSelectionKeyCapturePlugin } from '../tableRuntime/selection/cellSelectionKeymap';
 import { cellSelectionVisualsPlugin } from './cellSelectionVisuals';
@@ -114,6 +115,7 @@ async function registerTableWidgetExtension(
         activeCellField,
         resolvedActiveCellField,
         openCellRequestField,
+        insertedTableActivationField,
         cellSelectionField,
         createMainEditorActiveCellGuard(() => isNestedEditorOpen(cm6View)),
         openCellRequestKeymap,


### PR DESCRIPTION
Enhance the reliability of table insertion and activation by ensuring mid-line inserts produce canonical GFM recognized by the parser. Refactor the activation process to eliminate unnecessary calls and improve consistency between inserted and pasted tables. Add a mapped state for pending table activation to streamline the activation lifecycle.