### PR TITLE
fix: only re-render cell content when we can resolve a current valid cell range

### DIFF
--- a/src/contentScript/__tests__/nestedEditorControllerRenderer.test.ts
+++ b/src/contentScript/__tests__/nestedEditorControllerRenderer.test.ts
@@ -55,4 +55,66 @@ describe('nestedEditorController markdown rendering', () => {
 
         view.destroy();
     });
+
+    it('does not render stale offsets when the open table was deleted before closing', () => {
+        const tableText = [
+            '| my new | table test | new col |',
+            '| --- | --- | --- |',
+            '| abc 123 | aaaad | abd t |',
+            '| abc 123 | **aaaad** | abc **test** |',
+            '| abd `code` | aaaa `bbb` | ls \\| grep |',
+        ].join('\n');
+        const intro = 'abc 123\n\n\n\n';
+        const middle = '**rootTableInsertRewrite.ts** - Mid-line inserts now produce canonical GFM.\n\n';
+        const insertedTableFrom = intro.length;
+        const insertedTableWithSpacing = `${tableText}\n\n`;
+        const doc = `${intro}${insertedTableWithSpacing}${middle}${tableText}`;
+        const renderer: MarkdownRenderService = {
+            getCached: jest.fn(() => undefined),
+            renderAsync: jest.fn(),
+            clear: jest.fn(),
+        };
+        let state = createMarkdownState(doc, [
+            activeCellField,
+            markdownRenderServiceFacet.of(renderer),
+            nestedEditorPlugin,
+        ]);
+        state = state.update({
+            effects: setActiveCellEffect.of({
+                tableFrom: insertedTableFrom,
+                section: 'header',
+                row: 0,
+                col: 0,
+            }),
+        }).state;
+
+        const parent = document.createElement('div');
+        document.body.appendChild(parent);
+        const view = new EditorView({ parent, state });
+        const cellElement = document.createElement('th');
+        cellElement.textContent = 'my new';
+        parent.appendChild(cellElement);
+
+        expect(
+            openNestedEditor({
+                mainView: view,
+                cellElement,
+                featureSettings: { autoMatchingBraces: true },
+            })
+        ).toBe(true);
+
+        view.dispatch({
+            changes: {
+                from: insertedTableFrom,
+                to: insertedTableFrom + insertedTableWithSpacing.length,
+                insert: '',
+            },
+        });
+        closeNestedEditor(view);
+
+        expect(renderer.getCached).not.toHaveBeenCalledWith(expect.stringContaining('rootTableInsertRewrite'));
+        expect(cellElement.querySelector('div')?.innerHTML).toBe('my new');
+
+        view.destroy();
+    });
 });

--- a/src/contentScript/nestedEditor/nestedEditorController.ts
+++ b/src/contentScript/nestedEditor/nestedEditorController.ts
@@ -241,10 +241,11 @@ class NestedEditorController {
             this.cellElement.classList.remove(CLASS_CELL_ACTIVE);
         }
 
-        const { contentFrom, contentTo } = this.resolveCellRangeForClose(params, session, mainView);
+        const cellRange = this.resolveCellRangeForClose(params, session, mainView);
 
-        if (this.contentEl && mainView) {
+        if (this.contentEl && mainView && cellRange) {
             const renderer = mainView.state.facet(markdownRenderServiceFacet);
+            const { contentFrom, contentTo } = cellRange;
             const cellText = mainView.state.doc.sliceString(contentFrom, contentTo).trim();
             const { displayText, cacheKey } = buildRenderableContent(cellText);
             const cached = renderer.getCached(cacheKey);
@@ -287,7 +288,7 @@ class NestedEditorController {
         params: { contentFrom?: number; contentTo?: number } | undefined,
         session: NestedEditorSession | null,
         mainView: EditorView | null
-    ): { contentFrom: number; contentTo: number } {
+    ): { contentFrom: number; contentTo: number } | null {
         if (params?.contentFrom != null && params?.contentTo != null) {
             return { contentFrom: params.contentFrom, contentTo: params.contentTo };
         }
@@ -299,10 +300,7 @@ class NestedEditorController {
             }
         }
 
-        return {
-            contentFrom: session?.resolvedCell.contentFrom ?? 0,
-            contentTo: session?.resolvedCell.contentTo ?? 0,
-        };
+        return null;
     }
 
     isOpen(): boolean {


### PR DESCRIPTION
## Summary

- Fixes stale cell content rendered after undo: when a pasted table was deleted (via undo), `resolveCellRangeForClose` fell back to stale session offsets that now pointed into different document content, causing the wrong text to appear in the first cell of the remaining table.
- `resolveCellRangeForClose` now re-resolves the cell from the current document state via `resolveActiveCell`; if resolution fails (table was deleted), it returns `null` and the close path skips re-rendering entirely.
- Added a regression test that directly exercises the bug scenario: open a nested editor on a pasted table's cell, delete the pasted table, close the editor, and assert the remaining table's cell retains correct content.

## Repro

1. Note with content: text, blank lines, then a GFM table
2. Copy the table, paste it in the blank space between the text and the table
3. Ctrl+Z to undo — the first header cell of the original table briefly shows wrong content (content from the wrong doc offset)
4. Clicking in/out of the cell corrects it

## Test plan

- [x] Run `npm test` — new regression test passes, existing tests unaffected
- [x] Manual repro: paste a table above an existing table, undo — original table cells show correct content
- [x] Open a nested editor normally, close it — cell re-renders correctly as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)