### PR TITLE
Refactor markdown renderer to use promises

### DIFF
--- a/docs/Architecture/Markdown-Rendering.md
+++ b/docs/Architecture/Markdown-Rendering.md
@@ -10,7 +10,7 @@ Table cells render Markdown through Joplin's `renderMarkup` command. The decisio
 - Main plugin executes Joplin’s `renderMarkup` and returns HTML.
 - The content script runs `sanitizeHtml()` → `postProcessHtml()` before using the HTML.
 
-The renderer is created during content-script startup and installed through `markdownRenderServiceFacet`, so widgets and runtime code read the service from `view.state` instead of importing module-level mutable state.
+The renderer exposes `render(text): Promise<string>` plus cache helpers. It is created during content-script startup and installed through `markdownRenderServiceFacet`, so widgets and runtime code read the service from `view.state` instead of importing module-level mutable state.
 
 ### Cache + De-dupe
 

--- a/src/contentScript/__tests__/markdownRenderer.test.ts
+++ b/src/contentScript/__tests__/markdownRenderer.test.ts
@@ -3,6 +3,7 @@
 import { describe, expect, it, jest } from '@jest/globals';
 import type { RenderMarkupResult } from '../../contentScriptBridge/contentScriptMessages';
 import { createMarkdownRenderer, type RenderMarkupFn } from '../services/markdownRenderer';
+import { deferred } from './testUtils';
 
 jest.mock('../../logger', () => ({
     logger: {
@@ -11,21 +12,6 @@ jest.mock('../../logger', () => ({
         warn: jest.fn(),
     },
 }));
-
-function deferred<T>(): {
-    promise: Promise<T>;
-    resolve: (value: T) => void;
-    reject: (reason?: unknown) => void;
-} {
-    let resolve!: (value: T) => void;
-    let reject!: (reason?: unknown) => void;
-    const promise = new Promise<T>((promiseResolve, promiseReject) => {
-        resolve = promiseResolve;
-        reject = promiseReject;
-    });
-
-    return { promise, resolve, reject };
-}
 
 describe('createMarkdownRenderer', () => {
     it('sanitizes, post-processes, and caches rendered HTML', async () => {

--- a/src/contentScript/__tests__/markdownRenderer.test.ts
+++ b/src/contentScript/__tests__/markdownRenderer.test.ts
@@ -27,12 +27,6 @@ function deferred<T>(): {
     return { promise, resolve, reject };
 }
 
-function render(renderer: ReturnType<typeof createMarkdownRenderer>, markdown: string): Promise<string> {
-    return new Promise((resolve) => {
-        renderer.renderAsync(markdown, resolve);
-    });
-}
-
 describe('createMarkdownRenderer', () => {
     it('sanitizes, post-processes, and caches rendered HTML', async () => {
         const renderMarkup = jest.fn<RenderMarkupFn>(async (_markdown, id) => ({
@@ -41,8 +35,8 @@ describe('createMarkdownRenderer', () => {
         }));
         const renderer = createMarkdownRenderer(renderMarkup);
 
-        const first = await render(renderer, '**ok**');
-        const second = await render(renderer, '**ok**');
+        const first = await renderer.render('**ok**');
+        const second = await renderer.render('**ok**');
 
         expect(first).toContain('<strong>ok</strong>');
         expect(first).not.toContain('joplin-source');
@@ -56,8 +50,8 @@ describe('createMarkdownRenderer', () => {
         const renderMarkup = jest.fn<RenderMarkupFn>(() => pending.promise);
         const renderer = createMarkdownRenderer(renderMarkup);
 
-        const first = render(renderer, '`x`');
-        const second = render(renderer, '`x`');
+        const first = renderer.render('`x`');
+        const second = renderer.render('`x`');
         pending.resolve({ id: 'render-1', html: '<p><code>x</code></p>' });
 
         await expect(first).resolves.toContain('<code>x</code>');
@@ -73,7 +67,7 @@ describe('createMarkdownRenderer', () => {
         const renderer = createMarkdownRenderer(renderMarkup);
 
         for (let index = 0; index < 501; index++) {
-            await render(renderer, `value-${index}`);
+            await renderer.render(`value-${index}`);
         }
 
         expect(renderer.getCached('value-0')).toBeUndefined();
@@ -88,8 +82,8 @@ describe('createMarkdownRenderer', () => {
             .mockResolvedValueOnce({ id: 'render-2', html: '<img src=x onerror=alert(1)>', error: true });
         const renderer = createMarkdownRenderer(renderMarkup);
 
-        await expect(render(renderer, '<b>unsafe</b>')).resolves.toBe('&lt;b&gt;unsafe&lt;/b&gt;');
-        await expect(render(renderer, '<i>bad</i>')).resolves.toBe('&lt;i&gt;bad&lt;/i&gt;');
+        await expect(renderer.render('<b>unsafe</b>')).resolves.toBe('&lt;b&gt;unsafe&lt;/b&gt;');
+        await expect(renderer.render('<i>bad</i>')).resolves.toBe('&lt;i&gt;bad&lt;/i&gt;');
     });
 
     it('clear removes cached entries and pending request state', async () => {
@@ -101,9 +95,9 @@ describe('createMarkdownRenderer', () => {
             .mockReturnValueOnce(second.promise);
         const renderer = createMarkdownRenderer(renderMarkup);
 
-        const staleRender = render(renderer, '**x**');
+        const staleRender = renderer.render('**x**');
         renderer.clear();
-        const currentRender = render(renderer, '**x**');
+        const currentRender = renderer.render('**x**');
 
         first.resolve({ id: 'render-1', html: '<p>stale</p>' });
         second.resolve({ id: 'render-2', html: '<p>current</p>' });

--- a/src/contentScript/__tests__/nestedEditorControllerRenderer.test.ts
+++ b/src/contentScript/__tests__/nestedEditorControllerRenderer.test.ts
@@ -16,7 +16,7 @@ describe('nestedEditorController markdown rendering', () => {
         const tableText = ['| H1 |', '| --- |', '| **body** |'].join('\n');
         const renderer: MarkdownRenderService = {
             getCached: jest.fn(() => '<p><strong>cached</strong></p>'),
-            renderAsync: jest.fn(),
+            render: jest.fn(async () => ''),
             clear: jest.fn(),
         };
         let state = createMarkdownState(tableText, [
@@ -71,7 +71,7 @@ describe('nestedEditorController markdown rendering', () => {
         const doc = `${intro}${insertedTableWithSpacing}${middle}${tableText}`;
         const renderer: MarkdownRenderService = {
             getCached: jest.fn(() => undefined),
-            renderAsync: jest.fn(),
+            render: jest.fn(async () => ''),
             clear: jest.fn(),
         };
         let state = createMarkdownState(doc, [

--- a/src/contentScript/__tests__/tableWidgetMarkdownRenderer.test.ts
+++ b/src/contentScript/__tests__/tableWidgetMarkdownRenderer.test.ts
@@ -7,22 +7,11 @@ import { markdownRenderServiceFacet, type MarkdownRenderService } from '../servi
 import { MarkdownTable } from '../tableModel/MarkdownTable';
 import { computeMarkdownTableCellRanges } from '../tableModel/markdownTableCellRanges';
 import { TableWidget } from '../tableWidget/TableWidget';
+import { deferred } from './testUtils';
 
 class ResizeObserverMock {
     observe = jest.fn();
     disconnect = jest.fn();
-}
-
-function deferred<T>(): {
-    promise: Promise<T>;
-    resolve: (value: T) => void;
-} {
-    let resolve!: (value: T) => void;
-    const promise = new Promise<T>((promiseResolve) => {
-        resolve = promiseResolve;
-    });
-
-    return { promise, resolve };
 }
 
 describe('TableWidget markdown rendering', () => {

--- a/src/contentScript/__tests__/tableWidgetMarkdownRenderer.test.ts
+++ b/src/contentScript/__tests__/tableWidgetMarkdownRenderer.test.ts
@@ -13,6 +13,18 @@ class ResizeObserverMock {
     disconnect = jest.fn();
 }
 
+function deferred<T>(): {
+    promise: Promise<T>;
+    resolve: (value: T) => void;
+} {
+    let resolve!: (value: T) => void;
+    const promise = new Promise<T>((promiseResolve) => {
+        resolve = promiseResolve;
+    });
+
+    return { promise, resolve };
+}
+
 describe('TableWidget markdown rendering', () => {
     const originalResizeObserver = window.ResizeObserver;
 
@@ -24,8 +36,8 @@ describe('TableWidget markdown rendering', () => {
         window.ResizeObserver = originalResizeObserver;
     });
 
-    it('uses the markdown renderer supplied by the editor state facet', () => {
-        const renderCallbacks: Array<(html: string) => void> = [];
+    it('uses the markdown renderer supplied by the editor state facet', async () => {
+        const rendered = deferred<string>();
         const tableText = ['| H1 |', '| --- |', '| **body** |'].join('\n');
         const table = MarkdownTable.parse(tableText);
         const cellRanges = computeMarkdownTableCellRanges(tableText);
@@ -35,9 +47,7 @@ describe('TableWidget markdown rendering', () => {
 
         const renderer: MarkdownRenderService = {
             getCached: jest.fn(() => undefined),
-            renderAsync: jest.fn((_text: string, callback: (html: string) => void) => {
-                renderCallbacks.push(callback);
-            }),
+            render: jest.fn(() => rendered.promise),
             clear: jest.fn(),
         };
         const state = EditorState.create({
@@ -52,9 +62,11 @@ describe('TableWidget markdown rendering', () => {
         const widget = new TableWidget(table, cellRanges, tableText, 0, tableText.length, 'hash');
         const dom = widget.toDOM(view);
         document.body.appendChild(dom);
-        renderCallbacks[0]?.('<p><strong>rendered</strong></p>');
+        rendered.resolve('<p><strong>rendered</strong></p>');
+        await rendered.promise;
+        await Promise.resolve();
 
-        expect(renderer.renderAsync).toHaveBeenCalledWith('**body**', expect.any(Function));
+        expect(renderer.render).toHaveBeenCalledWith('**body**');
         expect(dom.querySelector('tbody td div')?.innerHTML).toBe('<p><strong>rendered</strong></p>');
         dom.remove();
     });

--- a/src/contentScript/__tests__/tableWidgetMarkdownRenderer.test.ts
+++ b/src/contentScript/__tests__/tableWidgetMarkdownRenderer.test.ts
@@ -53,6 +53,8 @@ describe('TableWidget markdown rendering', () => {
         document.body.appendChild(dom);
         rendered.resolve('<p><strong>rendered</strong></p>');
         await rendered.promise;
+        // The widget attaches its DOM update in a .then() on the same promise.
+        // Let that chained microtask run before asserting the rendered HTML.
         await Promise.resolve();
 
         expect(renderer.render).toHaveBeenCalledWith('**body**');

--- a/src/contentScript/__tests__/testUtils.ts
+++ b/src/contentScript/__tests__/testUtils.ts
@@ -1,0 +1,14 @@
+export function deferred<T>(): {
+    promise: Promise<T>;
+    resolve: (value: T) => void;
+    reject: (reason?: unknown) => void;
+} {
+    let resolve!: (value: T) => void;
+    let reject!: (reason?: unknown) => void;
+    const promise = new Promise<T>((promiseResolve, promiseReject) => {
+        resolve = promiseResolve;
+        reject = promiseReject;
+    });
+
+    return { promise, resolve, reject };
+}

--- a/src/contentScript/nestedEditor/nestedEditorController.ts
+++ b/src/contentScript/nestedEditor/nestedEditorController.ts
@@ -29,6 +29,7 @@ import { markdownRenderServiceFacet } from '../services/markdownRenderer';
 import type { NestedEditorHostConfig } from '../../contentScriptBridge/hostEditorConfigBridge';
 import { createNestedEditorFeatureExtensions } from './nestedEditorFeatureConfig';
 import { requestViewAnimationFrame } from '../shared/domContext';
+import { logger } from '../../logger';
 
 const SYNTAX_TREE_PARSE_TIMEOUT = 50;
 
@@ -256,11 +257,16 @@ class NestedEditorController {
                 this.contentEl.innerHTML = escapeHtmlPreservingBr(displayText);
                 if (containsMarkdown(cacheKey)) {
                     const contentEl = this.contentEl;
-                    void renderer.render(cacheKey).then((html) => {
-                        if (contentEl.isConnected) {
-                            contentEl.innerHTML = html;
-                        }
-                    });
+                    void renderer
+                        .render(cacheKey)
+                        .then((html) => {
+                            if (contentEl.isConnected) {
+                                contentEl.innerHTML = html;
+                            }
+                        })
+                        .catch((error) => {
+                            logger.error('Failed to render nested editor markdown:', error);
+                        });
                 }
             }
         }

--- a/src/contentScript/nestedEditor/nestedEditorController.ts
+++ b/src/contentScript/nestedEditor/nestedEditorController.ts
@@ -256,7 +256,7 @@ class NestedEditorController {
                 this.contentEl.innerHTML = escapeHtmlPreservingBr(displayText);
                 if (containsMarkdown(cacheKey)) {
                     const contentEl = this.contentEl;
-                    renderer.renderAsync(cacheKey, (html) => {
+                    void renderer.render(cacheKey).then((html) => {
                         if (contentEl.isConnected) {
                             contentEl.innerHTML = html;
                         }

--- a/src/contentScript/services/markdownRenderer.ts
+++ b/src/contentScript/services/markdownRenderer.ts
@@ -17,7 +17,7 @@ export type RenderMarkupFn = (markdown: string, id: string) => Promise<RenderMar
  * Allows decoupling widgets/editors from the specific caching/rendering implementation.
  */
 export interface MarkdownRenderService {
-    renderAsync(text: string, callback: (html: string) => void): void;
+    render(text: string): Promise<string>;
     getCached(text: string): string | undefined;
     clear(): void;
 }
@@ -31,9 +31,9 @@ const MAX_CACHE_SIZE = 500;
  * It returns escaped fallback HTML so callers can safely assign the result to innerHTML.
  */
 const fallbackMarkdownRenderer: MarkdownRenderService = {
-    renderAsync(text, callback) {
+    render(text) {
         logger.warn('Markdown renderer service missing, returning escaped markdown');
-        callback(escapeHtmlPreservingBr(text));
+        return Promise.resolve(escapeHtmlPreservingBr(text));
     },
     getCached() {
         return undefined;
@@ -61,21 +61,12 @@ class DefaultMarkdownRenderer implements MarkdownRenderService {
 
     constructor(private readonly renderMarkup: RenderMarkupFn) {}
 
-    renderAsync(text: string, callback: (html: string) => void): void {
-        const cached = this.renderCache.get(text);
-        if (cached !== undefined) {
-            callback(cached);
-            return;
-        }
-        this.renderMarkdown(text).then(callback);
-    }
-
     getCached(text: string): string | undefined {
         return this.renderCache.get(text);
     }
 
     clear(): void {
-        // In-flight requests still resolve for existing callbacks, but their results are not cached.
+        // In-flight requests still resolve for existing callers, but their results are not cached.
         this.renderCache.clear();
         this.pendingRequests.clear();
         this.generation++;
@@ -103,7 +94,7 @@ class DefaultMarkdownRenderer implements MarkdownRenderService {
      * Render markdown to HTML asynchronously.
      * Returns cached result if available, otherwise sends request to main plugin.
      */
-    private async renderMarkdown(markdown: string): Promise<string> {
+    async render(markdown: string): Promise<string> {
         const cached = this.renderCache.get(markdown);
         if (cached !== undefined) {
             return cached;

--- a/src/contentScript/tableWidget/TableWidget.ts
+++ b/src/contentScript/tableWidget/TableWidget.ts
@@ -230,7 +230,7 @@ export class TableWidget extends WidgetType {
         // Check if content likely contains markdown (optimization)
         if (containsMarkdown(cacheKey)) {
             // Request async rendering and update when ready
-            renderer.renderAsync(cacheKey, (html) => {
+            void renderer.render(cacheKey).then((html) => {
                 // Only update if the wrapper is still in the DOM.
                 // Note: Height re-measurement is handled automatically by ResizeObserver.
                 if (contentWrapper.isConnected) {

--- a/src/contentScript/tableWidget/TableWidget.ts
+++ b/src/contentScript/tableWidget/TableWidget.ts
@@ -19,6 +19,7 @@ import {
 import { estimateTableHeight } from './tableHeightEstimation';
 import { buildRenderableContent, containsMarkdown, escapeHtmlPreservingBr } from '../shared/cellContentUtils';
 import { getViewDocument, getViewWindow } from '../shared/domContext';
+import { logger } from '../../logger';
 
 /** Associates widget DOM elements with their EditorView for cleanup during destroy. */
 const widgetViews = new WeakMap<HTMLElement, EditorView>();
@@ -230,13 +231,18 @@ export class TableWidget extends WidgetType {
         // Check if content likely contains markdown (optimization)
         if (containsMarkdown(cacheKey)) {
             // Request async rendering and update when ready
-            void renderer.render(cacheKey).then((html) => {
-                // Only update if the wrapper is still in the DOM.
-                // Note: Height re-measurement is handled automatically by ResizeObserver.
-                if (contentWrapper.isConnected) {
-                    contentWrapper.innerHTML = html;
-                }
-            });
+            void renderer
+                .render(cacheKey)
+                .then((html) => {
+                    // Only update if the wrapper is still in the DOM.
+                    // Note: Height re-measurement is handled automatically by ResizeObserver.
+                    if (contentWrapper.isConnected) {
+                        contentWrapper.innerHTML = html;
+                    }
+                })
+                .catch((error) => {
+                    logger.error('Failed to render table cell markdown:', error);
+                });
         }
     }
 


### PR DESCRIPTION
Transition the markdown rendering service from a callback-based approach to a promise-based one, improving error handling and addressing duplicated test helpers. Additionally, add comments for clarity.