### PR TITLE
fix: compatibility with extra markdown editor settings link tooltip

### DIFF
--- a/src/contentScript/__tests__/tableWidgetMarkdownRenderer.test.ts
+++ b/src/contentScript/__tests__/tableWidgetMarkdownRenderer.test.ts
@@ -58,4 +58,42 @@ describe('TableWidget markdown rendering', () => {
         expect(dom.querySelector('tbody td div')?.innerHTML).toBe('<p><strong>rendered</strong></p>');
         dom.remove();
     });
+
+    it('resolves coordinates from widget-relative positions when the table starts after document offset 0', () => {
+        const tableText = ['| H1 | H2 |', '| --- | --- |', '| body 1 | body 2 |'].join('\n');
+        const table = MarkdownTable.parse(tableText);
+        const cellRanges = computeMarkdownTableCellRanges(tableText);
+        if (!table || !cellRanges) {
+            throw new Error('Expected test table to parse');
+        }
+
+        const state = EditorState.create({
+            extensions: [
+                markdownRenderServiceFacet.of({
+                    getCached: jest.fn(() => ''),
+                    renderAsync: jest.fn(),
+                    clear: jest.fn(),
+                }),
+            ],
+        });
+        const view = {
+            state,
+            dom: document.createElement('div'),
+            requestMeasure: jest.fn(),
+        } as unknown as EditorView;
+
+        const tableFrom = 50;
+        const widget = new TableWidget(table, cellRanges, tableText, tableFrom, tableFrom + tableText.length, 'hash');
+        const dom = widget.toDOM(view);
+        const targetCell = dom.querySelector('tbody td:nth-child(2)') as HTMLElement | null;
+        if (!targetCell) {
+            throw new Error('Expected second body cell to render');
+        }
+
+        const rect = { top: 10, bottom: 20, left: 30, right: 40 } as DOMRect;
+        jest.spyOn(targetCell, 'getBoundingClientRect').mockReturnValue(rect);
+
+        expect(widget.coordsAt(dom, cellRanges.rows[0][1].from, 1)).toBe(rect);
+        expect(widget.coordsAt(dom, tableFrom + cellRanges.rows[0][1].from, 1)).toBeNull();
+    });
 });

--- a/src/contentScript/tableModel/markdownTableCellRanges.ts
+++ b/src/contentScript/tableModel/markdownTableCellRanges.ts
@@ -203,7 +203,7 @@ export function computeMarkdownTableCellRanges(text: string): TableCellRanges | 
  * This is the inverse of resolveCellDocRange - given a position, find which cell contains it.
  *
  * @param ranges - The computed cell ranges for the table
- * @param relativePos - Position relative to the table start (i.e., pos - tableFrom)
+ * @param relativePos - Position relative to the start of the table text
  * @returns Cell coordinates if position is within a cell, null otherwise
  */
 export function findCellForPos(ranges: TableCellRanges, relativePos: number): CellCoords | null {

--- a/src/contentScript/tableWidget/TableWidget.ts
+++ b/src/contentScript/tableWidget/TableWidget.ts
@@ -255,7 +255,7 @@ export class TableWidget extends WidgetType {
     }
 
     /**
-     * Returns the bounding rectangle of the cell containing the given document position.
+     * Returns the bounding rectangle of the cell containing the given widget-relative position.
      * This helps CodeMirror scroll precisely to specific cells rather than just the table bounds.
      */
     coordsAt(
@@ -263,8 +263,7 @@ export class TableWidget extends WidgetType {
         pos: number,
         _side: number
     ): { top: number; bottom: number; left: number; right: number } | null {
-        const relativePos = pos - this.tableFrom;
-        const coords = findCellForPos(this.cellRanges, relativePos);
+        const coords = findCellForPos(this.cellRanges, pos);
         if (!coords) {
             return null;
         }

--- a/src/contentScript/tableWidget/TableWidget.ts
+++ b/src/contentScript/tableWidget/TableWidget.ts
@@ -257,6 +257,9 @@ export class TableWidget extends WidgetType {
     /**
      * Returns the bounding rectangle of the cell containing the given widget-relative position.
      * This helps CodeMirror scroll precisely to specific cells rather than just the table bounds.
+     *
+     * CodeMirror subtracts the widget's document start offset before calling this, so `pos` is
+     * already relative to the widget — do not subtract `tableFrom` here.
      */
     coordsAt(
         dom: HTMLElement,


### PR DESCRIPTION
Improve compatibility with the extra markdown editor settings link tooltip by fixing the coordinates calculation, ensuring the tooltip displays correctly above or below the edited cell. Update comments for clarity.