### PR TITLE
Refactor MarkdownTable row and rectangle APIs

### DIFF
--- a/src/contentScript/__tests__/MarkdownTable.test.ts
+++ b/src/contentScript/__tests__/MarkdownTable.test.ts
@@ -66,6 +66,7 @@ describe('MarkdownTable', () => {
         expect(table.updateColumnAlignment(0, null)).toBe(table);
         expect(table.clearRow('body', 2)).toBe(table);
         expect(table.clearColumn(9)).toBe(table);
+        expect(table.clearRect({ minRow: -1, maxRow: 0, minCol: 0, maxCol: 1 })).toBe(table);
         expect(table.moveRow('header', 0, 'up')).toBe(table);
     });
 
@@ -90,6 +91,10 @@ describe('MarkdownTable', () => {
         const movedHeaderDown = table.moveRow('header', 0, 'down');
         expect(movedHeaderDown.headerCells).toEqual(['A1', 'A2']);
         expect(movedHeaderDown.bodyRows[0]).toEqual(['H1', 'H2']);
+
+        const movedFirstBodyUp = table.moveRow('body', 0, 'up');
+        expect(movedFirstBodyUp.headerCells).toEqual(['A1', 'A2']);
+        expect(movedFirstBodyUp.bodyRows[0]).toEqual(['H1', 'H2']);
     });
 
     it('swapColumns preserves alignments', () => {
@@ -178,6 +183,14 @@ describe('MarkdownTable', () => {
             table.isRectEmpty({
                 minRow: 1,
                 maxRow: 2,
+                minCol: 0,
+                maxCol: 1,
+            })
+        ).toBe(false);
+        expect(
+            table.isRectEmpty({
+                minRow: -1,
+                maxRow: 1,
                 minCol: 0,
                 maxCol: 1,
             })

--- a/src/contentScript/__tests__/markdownTableOperations.test.ts
+++ b/src/contentScript/__tests__/markdownTableOperations.test.ts
@@ -129,7 +129,7 @@ describe('markdownTableOperations', () => {
     describe('swapRows', () => {
         it('should swap two adjacent body rows', () => {
             const table = parseTable(basicTable);
-            const next = table.swapRows(0, 1);
+            const next = table.swapRows(1, 2);
 
             expect(next.headerCells).toEqual(['Header 1', 'Header 2']);
             expect(next.bodyRows.length).toBe(2);
@@ -137,9 +137,9 @@ describe('markdownTableOperations', () => {
             expect(next.bodyRows[1]).toEqual(['Row 1 Col 1', 'Row 1 Col 2']);
         });
 
-        it('should swap header with first body row (row index -1 with 0)', () => {
+        it('should swap header with first body row', () => {
             const table = parseTable(basicTable);
-            const next = table.swapRows(-1, 0);
+            const next = table.swapRows(0, 1);
 
             expect(next.headerCells).toEqual(['Row 1 Col 1', 'Row 1 Col 2']);
             expect(next.alignments).toEqual(['left', 'right']);
@@ -155,16 +155,23 @@ describe('markdownTableOperations', () => {
             expect(next).toBe(table);
         });
 
-        it('should return same table for invalid negative index (not -1)', () => {
+        it('should return same table for a negative index', () => {
             const table = parseTable(basicTable);
-            const next = table.swapRows(-2, 0);
+            const next = table.swapRows(-1, 0);
+
+            expect(next).toBe(table);
+        });
+
+        it('should return same table when swapping a row with itself', () => {
+            const table = parseTable(basicTable);
+            const next = table.swapRows(1, 1);
 
             expect(next).toBe(table);
         });
 
         it('should handle swapping in a table with different column counts', () => {
             const table = parseTable(['| H1 | H2 |', '| --- | --- |', '| A | B | C |', '| D | E |'].join('\n'));
-            const next = table.swapRows(0, 1);
+            const next = table.swapRows(1, 2);
 
             expect(next.bodyRows[0]).toEqual(['D', 'E', '']);
             expect(next.bodyRows[1]).toEqual(['A', 'B', 'C']);

--- a/src/contentScript/tableModel/MarkdownTable.ts
+++ b/src/contentScript/tableModel/MarkdownTable.ts
@@ -188,6 +188,26 @@ export class MarkdownTable {
         return 1 + this.rowsData.length;
     }
 
+    private getUnifiedRow(rowIndex: number): readonly string[] | null {
+        if (rowIndex === 0) {
+            return this.headersData;
+        }
+
+        const bodyRowIndex = rowIndex - 1;
+        return bodyRowIndex >= 0 && bodyRowIndex < this.rowsData.length ? this.rowsData[bodyRowIndex] : null;
+    }
+
+    private isValidRect(rect: TableRect): boolean {
+        return (
+            rect.minRow >= 0 &&
+            rect.minCol >= 0 &&
+            rect.maxRow < this.rowCount &&
+            rect.maxCol < this.columnCount &&
+            rect.minRow <= rect.maxRow &&
+            rect.minCol <= rect.maxCol
+        );
+    }
+
     serialize(): string {
         const joinRow = (cells: readonly string[]) => {
             return '| ' + cells.join(' | ') + ' |';
@@ -357,14 +377,7 @@ export class MarkdownTable {
     }
 
     clearRect(rect: TableRect): MarkdownTable {
-        if (
-            rect.minRow < 0 ||
-            rect.minCol < 0 ||
-            rect.maxRow >= this.rowCount ||
-            rect.maxCol >= this.columnCount ||
-            rect.minRow > rect.maxRow ||
-            rect.minCol > rect.maxCol
-        ) {
+        if (!this.isValidRect(rect)) {
             return this;
         }
 
@@ -388,21 +401,18 @@ export class MarkdownTable {
     }
 
     isRectEmpty(rect: TableRect): boolean {
-        if (
-            rect.minRow < 0 ||
-            rect.minCol < 0 ||
-            rect.maxRow >= this.rowCount ||
-            rect.maxCol >= this.columnCount ||
-            rect.minRow > rect.maxRow ||
-            rect.minCol > rect.maxCol
-        ) {
+        if (!this.isValidRect(rect)) {
             return false;
         }
 
-        const rows = cloneUnifiedRows(this.headersData, this.rowsData);
         for (let row = rect.minRow; row <= rect.maxRow; row++) {
+            const rowCells = this.getUnifiedRow(row);
+            if (!rowCells) {
+                return false;
+            }
+
             for (let col = rect.minCol; col <= rect.maxCol; col++) {
-                if (rows[row][col] !== '') {
+                if (rowCells[col] !== '') {
                     return false;
                 }
             }
@@ -593,16 +603,23 @@ export class MarkdownTable {
             return this;
         }
 
-        const currentRowIndex = section === 'header' ? -1 : rowIndex;
+        if (section === 'header' && rowIndex !== 0) {
+            return this;
+        }
+        if (section === 'body' && (rowIndex < 0 || rowIndex >= this.rowsData.length)) {
+            return this;
+        }
+
+        const currentRowIndex = section === 'header' ? 0 : rowIndex + 1;
         let targetRowIndex: number;
 
         if (direction === 'up') {
-            if (currentRowIndex === -1) {
+            if (currentRowIndex === 0) {
                 return this;
             }
             targetRowIndex = currentRowIndex - 1;
         } else {
-            if (currentRowIndex === this.rowsData.length - 1) {
+            if (currentRowIndex === this.rowCount - 1) {
                 return this;
             }
             targetRowIndex = currentRowIndex + 1;
@@ -612,19 +629,17 @@ export class MarkdownTable {
     }
 
     /**
-     * Swaps rows using the legacy row indexing convention: `-1` addresses the header
-     * and `0..n-1` address body rows.
+     * Swaps rows using unified row indexes: `0` addresses the header and `1..n`
+     * address body rows.
      */
     swapRows(row1: number, row2: number): MarkdownTable {
         const allRows = [[...this.headersData], ...cloneRows(this.rowsData)];
-        const idx1 = row1 + 1;
-        const idx2 = row2 + 1;
 
-        if (idx1 < 0 || idx1 >= allRows.length || idx2 < 0 || idx2 >= allRows.length || idx1 === idx2) {
+        if (row1 < 0 || row1 >= allRows.length || row2 < 0 || row2 >= allRows.length || row1 === row2) {
             return this;
         }
 
-        [allRows[idx1], allRows[idx2]] = [allRows[idx2], allRows[idx1]];
+        [allRows[row1], allRows[row2]] = [allRows[row2], allRows[row1]];
 
         return MarkdownTable.create({
             headerCells: allRows[0],

--- a/src/contentScript/tableModel/MarkdownTable.ts
+++ b/src/contentScript/tableModel/MarkdownTable.ts
@@ -1,7 +1,7 @@
 import { computeMarkdownTableCellRanges, isSeparatorRow } from './markdownTableCellRanges';
 import { scanMarkdownTableRow } from './markdownTableRowScanner';
 import { normalizeBrTags } from '../shared/cellTextNormalization';
-import type { CellCoords, TableRect, TableSection } from './types';
+import { toUnifiedRowIndex, type CellCoords, type TableRect, type TableSection } from './types';
 
 export type TableAlignment = 'left' | 'center' | 'right' | null;
 export interface MarkdownTableParts {
@@ -102,10 +102,6 @@ function createEmptyRow(columnCount: number): string[] {
 
 function cloneUnifiedRows(headers: readonly string[], rows: readonly (readonly string[])[]): string[][] {
     return [[...headers], ...cloneRows(rows)];
-}
-
-function toUnifiedRow(coords: CellCoords): number {
-    return coords.section === 'header' ? 0 : coords.row + 1;
 }
 
 function createFromUnifiedRows(
@@ -406,10 +402,7 @@ export class MarkdownTable {
         }
 
         for (let row = rect.minRow; row <= rect.maxRow; row++) {
-            const rowCells = this.getUnifiedRow(row);
-            if (!rowCells) {
-                return false;
-            }
+            const rowCells = this.getUnifiedRow(row)!;
 
             for (let col = rect.minCol; col <= rect.maxCol; col++) {
                 if (rowCells[col] !== '') {
@@ -458,7 +451,7 @@ export class MarkdownTable {
     pasteFragmentAt(anchor: CellCoords, fragment: ClipboardTableFragment): PasteRectResult | null {
         const pastedRowCount = fragment.cells.length;
         const pastedColCount = fragment.cells[0]?.length ?? 0;
-        const anchorRow = toUnifiedRow(anchor);
+        const anchorRow = toUnifiedRowIndex(anchor.section, anchor.row);
 
         if (
             anchor.col < 0 ||
@@ -610,7 +603,7 @@ export class MarkdownTable {
             return this;
         }
 
-        const currentRowIndex = section === 'header' ? 0 : rowIndex + 1;
+        const currentRowIndex = toUnifiedRowIndex(section, rowIndex);
         let targetRowIndex: number;
 
         if (direction === 'up') {
@@ -633,11 +626,11 @@ export class MarkdownTable {
      * address body rows.
      */
     swapRows(row1: number, row2: number): MarkdownTable {
-        const allRows = [[...this.headersData], ...cloneRows(this.rowsData)];
-
-        if (row1 < 0 || row1 >= allRows.length || row2 < 0 || row2 >= allRows.length || row1 === row2) {
+        if (row1 < 0 || row1 >= this.rowCount || row2 < 0 || row2 >= this.rowCount || row1 === row2) {
             return this;
         }
+
+        const allRows = [[...this.headersData], ...cloneRows(this.rowsData)];
 
         [allRows[row1], allRows[row2]] = [allRows[row2], allRows[row1]];
 

--- a/src/contentScript/tableModel/types.ts
+++ b/src/contentScript/tableModel/types.ts
@@ -31,6 +31,10 @@ export interface TableRect {
     maxCol: number;
 }
 
+export function toUnifiedRowIndex(section: TableSection, row: number): number {
+    return section === 'header' ? 0 : row + 1;
+}
+
 /**
  * Branded type for table identity.
  * Currently based on the table's starting document position (tableFrom),

--- a/src/contentScript/tableState/cellSelectionState.ts
+++ b/src/contentScript/tableState/cellSelectionState.ts
@@ -1,6 +1,6 @@
 import { Annotation, EditorState, StateEffect, StateField } from '@codemirror/state';
 import { setActiveCellEffect } from './activeCellState';
-import type { CellCoords, TableRect } from '../tableModel/types';
+import { toUnifiedRowIndex, type CellCoords, type TableRect } from '../tableModel/types';
 
 export interface CellSelection {
     tableFrom: number;
@@ -16,7 +16,7 @@ export const setCellSelectionEffect = StateEffect.define<CellSelection>();
 export const clearCellSelectionEffect = StateEffect.define<void>();
 
 export function toUnifiedRow(coords: CellCoords): number {
-    return coords.section === 'header' ? 0 : coords.row + 1;
+    return toUnifiedRowIndex(coords.section, coords.row);
 }
 
 export function fromUnifiedRow(row: number, col: number): CellCoords {


### PR DESCRIPTION
Refactor the MarkdownTable to use a unified row indexing model and consolidating rectangle validation.