### PR TITLE
Enable spellcheck in nested editor

### DIFF
--- a/docs/Architecture/Nested-Editor-Architecture.md
+++ b/docs/Architecture/Nested-Editor-Architecture.md
@@ -115,5 +115,6 @@ Nested editor requires its own extensions for parity with main editor:
 - **Inline Code**: Styled border around backticked code.
 - **Mark**: `==text==` highlighting.
 - **Insert**: `++text++` underline.
-- **Editor Features**: Close-bracket behavior is sourced from a one-time content-script-startup snapshot of the Joplin
-  `editor.autoMatchingBraces` setting fetched through the plugin process.
+- **Editor Features**: Close-bracket behavior and native spellcheck are sourced from a one-time
+  content-script-startup snapshot of the Joplin `editor.autoMatchingBraces` and `spellChecker.enabled` settings
+  fetched through the plugin process. Spellcheck adds a `spellcheck="true"` content attribute to the nested editor.

--- a/src/__tests__/contentScriptMessageHandler.test.ts
+++ b/src/__tests__/contentScriptMessageHandler.test.ts
@@ -55,7 +55,7 @@ describe('contentScriptMessageHandler', () => {
     });
 
     it('reads the host editor config', async () => {
-        globalValues.mockResolvedValueOnce([true]);
+        globalValues.mockResolvedValueOnce([true, true]);
         values.mockResolvedValueOnce({
             'floatingToolbar.showMoveButtons': false,
             'floatingToolbar.showClearButtons': true,
@@ -67,7 +67,7 @@ describe('contentScriptMessageHandler', () => {
             type: 'getHostEditorConfig',
         });
 
-        expect(globalValues).toHaveBeenCalledWith(['editor.autoMatchingBraces']);
+        expect(globalValues).toHaveBeenCalledWith(['editor.autoMatchingBraces', 'spellChecker.enabled']);
         expect(values).toHaveBeenCalledWith([
             'floatingToolbar.showMoveButtons',
             'floatingToolbar.showClearButtons',
@@ -77,6 +77,7 @@ describe('contentScriptMessageHandler', () => {
         expect(result).toEqual({
             nestedEditor: {
                 autoMatchingBraces: true,
+                spellcheck: true,
             },
             toolbar: {
                 showMoveButtons: false,

--- a/src/__tests__/hostEditorConfigBridge.test.ts
+++ b/src/__tests__/hostEditorConfigBridge.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import type { HostEditorConfigDeps } from '../contentScriptBridge/hostEditorConfigBridge';
 import {
     AUTO_MATCHING_BRACES_SETTING_KEY,
+    SPELLCHECK_ENABLED_SETTING_KEY,
     defaultHostEditorConfig,
     readHostEditorConfig,
     TOOLBAR_SHOW_ALIGNMENT_BUTTONS_SETTING_KEY,
@@ -33,7 +34,7 @@ describe('hostEditorConfigBridge', () => {
     });
 
     it('reads and normalizes the combined host editor config', async () => {
-        globalValuesMock.mockResolvedValue([true]);
+        globalValuesMock.mockResolvedValue([true, true]);
         valuesMock.mockResolvedValue({
             [TOOLBAR_SHOW_MOVE_BUTTONS_SETTING_KEY]: false,
             [TOOLBAR_SHOW_CLEAR_BUTTONS_SETTING_KEY]: true,
@@ -43,7 +44,10 @@ describe('hostEditorConfigBridge', () => {
 
         const result = await readHostEditorConfig(deps);
 
-        expect(globalValuesMock).toHaveBeenCalledWith([AUTO_MATCHING_BRACES_SETTING_KEY]);
+        expect(globalValuesMock).toHaveBeenCalledWith([
+            AUTO_MATCHING_BRACES_SETTING_KEY,
+            SPELLCHECK_ENABLED_SETTING_KEY,
+        ]);
         expect(valuesMock).toHaveBeenCalledWith([
             TOOLBAR_SHOW_MOVE_BUTTONS_SETTING_KEY,
             TOOLBAR_SHOW_CLEAR_BUTTONS_SETTING_KEY,
@@ -53,6 +57,7 @@ describe('hostEditorConfigBridge', () => {
         expect(result).toEqual({
             nestedEditor: {
                 autoMatchingBraces: true,
+                spellcheck: true,
             },
             toolbar: {
                 showMoveButtons: false,
@@ -64,7 +69,7 @@ describe('hostEditorConfigBridge', () => {
     });
 
     it('uses defaults for missing and non-boolean values', async () => {
-        globalValuesMock.mockResolvedValue(['true']);
+        globalValuesMock.mockResolvedValue(['true', 'true']);
         valuesMock.mockResolvedValue({
             [TOOLBAR_SHOW_MOVE_BUTTONS_SETTING_KEY]: false,
             [TOOLBAR_SHOW_CLEAR_BUTTONS_SETTING_KEY]: 'true',
@@ -73,6 +78,7 @@ describe('hostEditorConfigBridge', () => {
         await expect(readHostEditorConfig(deps)).resolves.toEqual({
             nestedEditor: {
                 autoMatchingBraces: false,
+                spellcheck: false,
             },
             toolbar: {
                 showMoveButtons: false,
@@ -104,12 +110,13 @@ describe('hostEditorConfigBridge', () => {
     });
 
     it('defaults only the toolbar config when plugin settings fail', async () => {
-        globalValuesMock.mockResolvedValue([true]);
+        globalValuesMock.mockResolvedValue([true, true]);
         valuesMock.mockRejectedValue(new Error('plugin boom'));
 
         await expect(readHostEditorConfig(deps)).resolves.toEqual({
             nestedEditor: {
                 autoMatchingBraces: true,
+                spellcheck: true,
             },
             toolbar: defaultHostEditorConfig().toolbar,
         });

--- a/src/contentScript/__tests__/hostEditorConfig.test.ts
+++ b/src/contentScript/__tests__/hostEditorConfig.test.ts
@@ -17,6 +17,7 @@ describe('hostEditorConfig', () => {
     const validConfig: HostEditorConfig = {
         nestedEditor: {
             autoMatchingBraces: true,
+            spellcheck: true,
         },
         toolbar: {
             showMoveButtons: false,

--- a/src/contentScript/__tests__/nestedEditorControllerRenderer.test.ts
+++ b/src/contentScript/__tests__/nestedEditorControllerRenderer.test.ts
@@ -44,7 +44,7 @@ describe('nestedEditorController markdown rendering', () => {
             openNestedEditor({
                 mainView: view,
                 cellElement,
-                featureSettings: { autoMatchingBraces: true },
+                featureSettings: { autoMatchingBraces: true, spellcheck: false },
             })
         ).toBe(true);
 
@@ -99,7 +99,7 @@ describe('nestedEditorController markdown rendering', () => {
             openNestedEditor({
                 mainView: view,
                 cellElement,
-                featureSettings: { autoMatchingBraces: true },
+                featureSettings: { autoMatchingBraces: true, spellcheck: false },
             })
         ).toBe(true);
 

--- a/src/contentScript/__tests__/nestedEditorFeatureConfig.test.ts
+++ b/src/contentScript/__tests__/nestedEditorFeatureConfig.test.ts
@@ -1,15 +1,24 @@
 import { EditorState } from '@codemirror/state';
+import { EditorView } from '@codemirror/view';
 import { describe, expect, it } from '@jest/globals';
 import { createNestedEditorFeatureExtensions } from '../nestedEditor/nestedEditorFeatureConfig';
 
 describe('nestedEditorFeatureConfig', () => {
     it('returns valid close-bracket extensions when auto matching braces is enabled', () => {
-        const extensions = createNestedEditorFeatureExtensions({ autoMatchingBraces: true });
+        const extensions = createNestedEditorFeatureExtensions({ autoMatchingBraces: true, spellcheck: false });
         expect(extensions.length).toBeGreaterThan(0);
         expect(() => EditorState.create({ extensions })).not.toThrow();
     });
 
-    it('returns no extensions when auto matching braces is disabled', () => {
-        expect(createNestedEditorFeatureExtensions({ autoMatchingBraces: false })).toHaveLength(0);
+    it('returns no extensions when all features are disabled', () => {
+        expect(
+            createNestedEditorFeatureExtensions({ autoMatchingBraces: false, spellcheck: false })
+        ).toHaveLength(0);
+    });
+
+    it('enables the spellcheck content attribute when spellcheck is enabled', () => {
+        const extensions = createNestedEditorFeatureExtensions({ autoMatchingBraces: false, spellcheck: true });
+        const state = EditorState.create({ extensions });
+        expect(state.facet(EditorView.contentAttributes)).toContainEqual({ spellcheck: 'true' });
     });
 });

--- a/src/contentScript/__tests__/nestedEditorLifecycle.test.ts
+++ b/src/contentScript/__tests__/nestedEditorLifecycle.test.ts
@@ -40,6 +40,7 @@ const activateTableCellMock = jest.fn();
 const findCellElementMock: jest.Mock = jest.fn(() => document.createElement('td'));
 const DEFAULT_FEATURE_SETTINGS = {
     autoMatchingBraces: true,
+    spellcheck: false,
 } satisfies HostEditorConfig['nestedEditor'];
 const TEST_HOST_CONFIG = {
     nestedEditor: DEFAULT_FEATURE_SETTINGS,

--- a/src/contentScript/__tests__/nestedEditorNavigation.test.ts
+++ b/src/contentScript/__tests__/nestedEditorNavigation.test.ts
@@ -15,6 +15,10 @@ const markdownExtension = markdown({
 });
 
 describe('nested editor navigation', () => {
+    afterEach(() => {
+        document.body.innerHTML = '';
+    });
+
     it('flushes pending nested-editor text before Tab inserts a new row from the last cell', () => {
         const parent = document.createElement('div');
         document.body.appendChild(parent);
@@ -82,6 +86,73 @@ describe('nested editor navigation', () => {
             row: 1,
             col: 0,
         });
+
+        mainView.destroy();
+    });
+
+    it('mirrors right-click position to the main editor without moving the nested selection', () => {
+        const parent = document.createElement('div');
+        document.body.appendChild(parent);
+
+        const mainView = new EditorView({
+            parent,
+            extensions: [markdownExtension, activeCellField, resolvedActiveCellField, nestedEditorPlugin],
+            doc: ['| H1 | H2 |', '| --- | --- |', '| misspelled | other |'].join('\n'),
+        });
+
+        mainView.dispatch({
+            effects: setActiveCellEffect.of({
+                tableFrom: 0,
+                section: 'body',
+                row: 0,
+                col: 0,
+            }),
+        });
+
+        const cellElement = document.createElement('td');
+        document.body.appendChild(cellElement);
+
+        openNestedEditor({
+            mainView,
+            cellElement,
+            featureSettings: defaultHostEditorConfig().nestedEditor,
+        });
+
+        const controller = (mainView.plugin(nestedEditorPlugin) as { controller: unknown } | null)?.controller as
+            | {
+                  session: {
+                      resolvedCell: { editableFrom: number };
+                      editor: EditorView;
+                  } | null;
+                  syncSelectionToMain: (nestedView: EditorView, event?: MouseEvent) => void;
+              }
+            | undefined;
+
+        const nestedView = controller?.session?.editor;
+        if (!controller?.session || !nestedView) {
+            throw new Error('Expected nested editor session to be open');
+        }
+
+        const initialNestedSelection = nestedView.state.selection.main;
+        const clickedLocalPos = 4;
+        const nestedDispatchSpy = jest.spyOn(nestedView, 'dispatch');
+        jest.spyOn(nestedView, 'posAtCoords').mockReturnValue(clickedLocalPos);
+
+        controller.syncSelectionToMain(
+            nestedView,
+            new MouseEvent('contextmenu', {
+                bubbles: true,
+                cancelable: true,
+                button: 2,
+                clientX: 24,
+                clientY: 12,
+            })
+        );
+
+        expect(nestedDispatchSpy).not.toHaveBeenCalled();
+        expect(nestedView.state.selection.main).toEqual(initialNestedSelection);
+        expect(mainView.state.selection.main.anchor).toBe(controller.session.resolvedCell.editableFrom + clickedLocalPos);
+        expect(mainView.state.selection.main.head).toBe(controller.session.resolvedCell.editableFrom + clickedLocalPos);
 
         mainView.destroy();
     });

--- a/src/contentScript/__tests__/nestedEditorUndoRegression.test.ts
+++ b/src/contentScript/__tests__/nestedEditorUndoRegression.test.ts
@@ -52,6 +52,7 @@ if (!Range.prototype.getClientRects) {
 const TEST_HOST_CONFIG = {
     nestedEditor: {
         autoMatchingBraces: true,
+        spellcheck: false,
     },
     toolbar: {
         showMoveButtons: true,

--- a/src/contentScript/nestedEditor/domHandlers.ts
+++ b/src/contentScript/nestedEditor/domHandlers.ts
@@ -250,6 +250,10 @@ export function createNestedEditorDomHandlers(
             },
             mousedown: (e, view) => {
                 const mouseEvent = e as MouseEvent;
+                // Mirror the right-click position to the main editor so context-menu plugins that
+                // read the main cursor (e.g. link actions) target the clicked location. This only
+                // moves the main editor's selection, never the nested editor's, so Chromium's
+                // native selection of a misspelled word survives and spelling suggestions appear.
                 if (mouseEvent.button === 2) {
                     options.syncSelectionToMain(view, mouseEvent);
                 }

--- a/src/contentScript/nestedEditor/nestedEditorController.ts
+++ b/src/contentScript/nestedEditor/nestedEditorController.ts
@@ -406,25 +406,27 @@ class NestedEditorController {
             return;
         }
 
+        let localSelection: LocalSelection = {
+            anchor: nestedView.state.selection.main.anchor,
+            head: nestedView.state.selection.main.head,
+        };
+
+        // For a right-click with no active selection, derive the cursor position from the click
+        // coordinates so the main editor — and any context-menu plugins that read it (e.g. link
+        // actions) — point at the clicked location. We mirror this position to the main editor
+        // WITHOUT moving the nested editor's own selection: collapsing it here would override
+        // Chromium's native selection of a misspelled word on right-click and suppress the host's
+        // spelling suggestions. The browser positions the nested caret natively on right-click.
         if (event && nestedView.state.selection.main.empty) {
             const clickedPos = nestedView.posAtCoords({ x: event.clientX, y: event.clientY });
             if (clickedPos != null) {
                 const clamped = Math.max(0, Math.min(nestedView.state.doc.length, clickedPos));
-                if (clamped !== nestedView.state.selection.main.head) {
-                    nestedView.dispatch({
-                        selection: EditorSelection.single(clamped, clamped),
-                        annotations: Transaction.addToHistory.of(false),
-                        scrollIntoView: false,
-                    });
-                }
+                localSelection = { anchor: clamped, head: clamped };
             }
         }
 
-        this.session.local.selection = {
-            anchor: nestedView.state.selection.main.anchor,
-            head: nestedView.state.selection.main.head,
-        };
-        const rootSelection = toRootSelection(this.session.local.selection, this.session.local.text);
+        this.session.local.selection = localSelection;
+        const rootSelection = toRootSelection(localSelection, this.session.local.text);
         mirrorLocalSelectionToMain({
             nestedView,
             mainView: this.mainView,

--- a/src/contentScript/nestedEditor/nestedEditorFeatureConfig.ts
+++ b/src/contentScript/nestedEditor/nestedEditorFeatureConfig.ts
@@ -1,12 +1,18 @@
 import { closeBrackets, closeBracketsKeymap } from '@codemirror/autocomplete';
 import type { Extension } from '@codemirror/state';
-import { keymap } from '@codemirror/view';
+import { EditorView, keymap } from '@codemirror/view';
 import type { NestedEditorHostConfig } from '../../contentScriptBridge/hostEditorConfigBridge';
 
 export function createNestedEditorFeatureExtensions(featureSettings: NestedEditorHostConfig): Extension[] {
-    if (!featureSettings.autoMatchingBraces) {
-        return [];
+    const extensions: Extension[] = [];
+
+    if (featureSettings.autoMatchingBraces) {
+        extensions.push(closeBrackets(), keymap.of(closeBracketsKeymap));
     }
 
-    return [closeBrackets(), keymap.of(closeBracketsKeymap)];
+    if (featureSettings.spellcheck) {
+        extensions.push(EditorView.contentAttributes.of({ spellcheck: 'true' }));
+    }
+
+    return extensions;
 }

--- a/src/contentScriptBridge/hostEditorConfigBridge.ts
+++ b/src/contentScriptBridge/hostEditorConfigBridge.ts
@@ -1,6 +1,7 @@
 import { logger } from '../logger';
 
 export const AUTO_MATCHING_BRACES_SETTING_KEY = 'editor.autoMatchingBraces';
+export const SPELLCHECK_ENABLED_SETTING_KEY = 'spellChecker.enabled';
 export const TOOLBAR_SHOW_MOVE_BUTTONS_SETTING_KEY = 'floatingToolbar.showMoveButtons';
 export const TOOLBAR_SHOW_CLEAR_BUTTONS_SETTING_KEY = 'floatingToolbar.showClearButtons';
 export const TOOLBAR_SHOW_ALIGNMENT_BUTTONS_SETTING_KEY = 'floatingToolbar.showAlignmentButtons';
@@ -9,6 +10,7 @@ export const TOOLBAR_SHOW_DELETE_TABLE_BUTTON_SETTING_KEY = 'floatingToolbar.sho
 export interface HostEditorConfig {
     nestedEditor: {
         autoMatchingBraces: boolean;
+        spellcheck: boolean;
     };
     toolbar: {
         showMoveButtons: boolean;
@@ -36,6 +38,7 @@ export function defaultHostEditorConfig(): HostEditorConfig {
     return {
         nestedEditor: {
             autoMatchingBraces: false,
+            spellcheck: false,
         },
         toolbar: {
             showMoveButtons: true,
@@ -59,6 +62,7 @@ export function isHostEditorConfig(value: unknown): value is HostEditorConfig {
         typeof nestedEditor === 'object' &&
         nestedEditor !== null &&
         typeof nestedEditor.autoMatchingBraces === 'boolean' &&
+        typeof nestedEditor.spellcheck === 'boolean' &&
         typeof toolbar === 'object' &&
         toolbar !== null &&
         typeof toolbar.showMoveButtons === 'boolean' &&
@@ -78,11 +82,15 @@ async function readNestedEditorConfig(deps: HostEditorConfigDeps): Promise<Neste
     const defaults = defaultHostEditorConfig().nestedEditor;
 
     try {
-        const [autoMatchingBraces] = await deps.settings.globalValues([AUTO_MATCHING_BRACES_SETTING_KEY]);
+        const [autoMatchingBraces, spellcheck] = await deps.settings.globalValues([
+            AUTO_MATCHING_BRACES_SETTING_KEY,
+            SPELLCHECK_ENABLED_SETTING_KEY,
+        ]);
 
         return {
             autoMatchingBraces:
                 typeof autoMatchingBraces === 'boolean' ? autoMatchingBraces : defaults.autoMatchingBraces,
+            spellcheck: typeof spellcheck === 'boolean' ? spellcheck : defaults.spellcheck,
         };
     } catch (error) {
         logger.warn('Failed to read nested editor host config, using defaults', error);


### PR DESCRIPTION
Introduce spellcheck functionality in the nested editor when enabled in the main editor. Fix a bug where misspelled words were not selected on right-click. Include tests to verify the new behavior.