### PR TITLE
refactor: TableRuntimeFacts model and policy test fixtures

### DIFF
--- a/src/contentScript/__tests__/runtimeEventClassifier.test.ts
+++ b/src/contentScript/__tests__/runtimeEventClassifier.test.ts
@@ -8,8 +8,7 @@ import { describe, expect, it } from 'vitest';
 import { syncAnnotation } from '../editorBridge/syncAnnotation';
 import { triggerOpenCellRequestEffect } from '../tableRuntime/openCellRequest';
 import {
-    classifyTableRuntimeEvent,
-    createTableRuntimeSnapshot,
+    classifyTableRuntimeFacts,
     type TableRuntimeExternalFacts,
 } from '../tableRuntime/lifecycle/runtimeEventClassifier';
 import { normalizeBeforeEditAnnotation } from '../tableRuntime/lifecycle/tableNormalization';
@@ -79,7 +78,28 @@ function dispatchAndCaptureUpdate(params: {
 }
 
 describe('runtimeEventClassifier', () => {
-    it('creates a runtime snapshot from current state and previous runtime flags', () => {
+    it('distinguishes absent and unresolved active cells', () => {
+        const absentUpdate = dispatchAndCaptureUpdate({
+            dispatch(view) {
+                view.dispatch({ selection: { anchor: 1 } });
+            },
+        });
+        const unresolvedUpdate = dispatchAndCaptureUpdate({
+            activeCell: { ...getHeaderCell(), tableFrom: 999 },
+            dispatch(view) {
+                view.dispatch({ selection: { anchor: 1 } });
+            },
+        });
+
+        expect(classifyTableRuntimeFacts(absentUpdate, DEFAULT_EXTERNAL_FACTS).activeCell).toEqual({
+            status: 'absent',
+        });
+        expect(classifyTableRuntimeFacts(unresolvedUpdate, DEFAULT_EXTERNAL_FACTS).activeCell).toEqual({
+            status: 'unresolved',
+        });
+    });
+
+    it('classifies current state and external runtime flags', () => {
         const externalFacts: TableRuntimeExternalFacts = {
             ...DEFAULT_EXTERNAL_FACTS,
             nestedEditorOpen: true,
@@ -92,9 +112,8 @@ describe('runtimeEventClassifier', () => {
             },
         });
 
-        expect(createTableRuntimeSnapshot(update, externalFacts)).toEqual({
-            hasActiveCell: true,
-            currentActiveCellResolved: true,
+        expect(classifyTableRuntimeFacts(update, externalFacts)).toMatchObject({
+            activeCell: { status: 'resolved', selectionLeftTable: false },
             effectiveRawMode: false,
             nestedEditorOpen: true,
             hadActiveCellBeforeUpdate: true,
@@ -117,14 +136,13 @@ describe('runtimeEventClassifier', () => {
                 });
             },
         });
-        const snapshot = createTableRuntimeSnapshot(update, DEFAULT_EXTERNAL_FACTS);
-        const event = classifyTableRuntimeEvent(update, snapshot);
+        const facts = classifyTableRuntimeFacts(update, DEFAULT_EXTERNAL_FACTS);
 
-        expect(event.isNormalizeBeforeEdit).toBe(true);
-        expect(event.isCellSelectionTransition).toBe(true);
-        expect(event.hasInsertedTableActivation).toBe(false);
-        expect(event.openRequestId).toBe('latest-request');
-        expect(event.rawModeTransition).toEqual({
+        expect(facts.isNormalizeBeforeEdit).toBe(true);
+        expect(facts.isCellSelectionTransition).toBe(true);
+        expect(facts.hasInsertedTableActivation).toBe(false);
+        expect(facts.openRequestId).toBe('latest-request');
+        expect(facts.rawModeTransition).toEqual({
             enteredRawMode: true,
             exitedRawMode: false,
             exitedSourceMode: false,
@@ -143,10 +161,9 @@ describe('runtimeEventClassifier', () => {
                 });
             },
         });
-        const snapshot = createTableRuntimeSnapshot(update, DEFAULT_EXTERNAL_FACTS);
-        const event = classifyTableRuntimeEvent(update, snapshot);
+        const facts = classifyTableRuntimeFacts(update, DEFAULT_EXTERNAL_FACTS);
 
-        expect(event.hasInsertedTableActivation).toBe(true);
+        expect(facts.hasInsertedTableActivation).toBe(true);
     });
 
     it('classifies raw mode exit from the update start state', () => {
@@ -156,10 +173,9 @@ describe('runtimeEventClassifier', () => {
                 view.dispatch({ effects: toggleSourceModeEffect.of(false) });
             },
         });
-        const snapshot = createTableRuntimeSnapshot(update, DEFAULT_EXTERNAL_FACTS);
-        const event = classifyTableRuntimeEvent(update, snapshot);
+        const facts = classifyTableRuntimeFacts(update, DEFAULT_EXTERNAL_FACTS);
 
-        expect(event.rawModeTransition).toEqual({
+        expect(facts.rawModeTransition).toEqual({
             enteredRawMode: false,
             exitedRawMode: true,
             exitedSourceMode: false,
@@ -178,12 +194,11 @@ describe('runtimeEventClassifier', () => {
                 view.dispatch({ selection: { anchor: 4 } });
             },
         });
-        const snapshot = createTableRuntimeSnapshot(update, externalFacts);
-        const event = classifyTableRuntimeEvent(update, snapshot);
+        const facts = classifyTableRuntimeFacts(update, externalFacts);
 
-        expect(event.selectionChanged).toBe(true);
-        expect(event.isSync).toBe(false);
-        expect(event.shouldSyncMainToNested).toBe(true);
+        expect(facts.selectionChanged).toBe(true);
+        expect(facts.isSync).toBe(false);
+        expect(facts.shouldSyncMainToNested).toBe(true);
     });
 
     it('does not request nested sync for sync-annotated selection updates', () => {
@@ -200,11 +215,10 @@ describe('runtimeEventClassifier', () => {
                 });
             },
         });
-        const snapshot = createTableRuntimeSnapshot(update, externalFacts);
-        const event = classifyTableRuntimeEvent(update, snapshot);
+        const facts = classifyTableRuntimeFacts(update, externalFacts);
 
-        expect(event.isSync).toBe(true);
-        expect(event.shouldSyncMainToNested).toBe(false);
+        expect(facts.isSync).toBe(true);
+        expect(facts.shouldSyncMainToNested).toBe(false);
     });
 
     it('detects when selection leaves the resolved active table', () => {
@@ -219,10 +233,9 @@ describe('runtimeEventClassifier', () => {
                 view.dispatch({ selection: { anchor: 0 } });
             },
         });
-        const snapshot = createTableRuntimeSnapshot(update, externalFacts);
-        const event = classifyTableRuntimeEvent(update, snapshot);
+        const facts = classifyTableRuntimeFacts(update, externalFacts);
 
-        expect(event.selectionLeftActiveTable).toBe(true);
+        expect(facts.activeCell).toEqual({ status: 'resolved', selectionLeftTable: true });
     });
 
     it('detects redo edits outside the active cell as reposition events', () => {
@@ -235,10 +248,41 @@ describe('runtimeEventClassifier', () => {
                 });
             },
         });
-        const snapshot = createTableRuntimeSnapshot(update, DEFAULT_EXTERNAL_FACTS);
-        const event = classifyTableRuntimeEvent(update, snapshot);
+        const facts = classifyTableRuntimeFacts(update, DEFAULT_EXTERNAL_FACTS);
 
-        expect(event.docChanged).toBe(true);
-        expect(event.requiresCellReposition).toBe(true);
+        expect(facts.docChanged).toBe(true);
+        expect(facts.requiresCellReposition).toBe(true);
+    });
+
+    it('produces coherent facts when a sync update carries several signals', () => {
+        const update = dispatchAndCaptureUpdate({
+            activeCell: getHeaderCell(),
+            dispatch(view) {
+                view.dispatch({
+                    selection: { anchor: 4 },
+                    effects: activateInsertedTableEffect.of({
+                        tableFrom: 0,
+                        target: { section: 'header', row: 0, col: 0 },
+                    }),
+                    annotations: [syncAnnotation.of(true), cellSelectionTransitionAnnotation.of(true)],
+                });
+            },
+        });
+
+        const facts = classifyTableRuntimeFacts(update, {
+            nestedEditorOpen: true,
+            pendingFullReplaceRebuild: true,
+        });
+
+        expect(facts).toMatchObject({
+            activeCell: { status: 'resolved', selectionLeftTable: false },
+            nestedEditorOpen: true,
+            pendingFullReplaceRebuild: true,
+            selectionChanged: true,
+            isSync: true,
+            isCellSelectionTransition: true,
+            hasInsertedTableActivation: true,
+            shouldSyncMainToNested: false,
+        });
     });
 });

--- a/src/contentScript/__tests__/tableRuntimePolicies.test.ts
+++ b/src/contentScript/__tests__/tableRuntimePolicies.test.ts
@@ -13,9 +13,8 @@ import { rebuildTableWidgetsEffect } from '../tableState/tableWidgetEffects';
 import { sourceModeField, toggleSourceModeEffect } from '../tableState/sourceMode';
 import { searchForceSourceModeField, setSearchForceSourceModeEffect } from '../tableState/searchForceSourceMode';
 import {
-    reduceTableRuntime,
-    type TableRuntimeEvent,
-    type TableRuntimeSnapshot,
+    reduceTableRuntime as reduceTableRuntimePolicy,
+    type TableRuntimeFacts,
 } from '../tableRuntime/lifecycle/lifecyclePolicy';
 import { transactionRequiresTableRebuild } from '../tableRuntime/tableTransactionHelpers';
 import { decideMainEditorGuardTransaction } from '../editorBridge/mainEditorGuardPolicy';
@@ -82,20 +81,13 @@ function requireResolvedActiveCell(state: EditorState) {
     return resolved;
 }
 
-function defaultRuntimeSnapshot(overrides: Partial<TableRuntimeSnapshot> = {}): TableRuntimeSnapshot {
+function defaultRuntimeFacts(overrides: Partial<TableRuntimeFacts> = {}): TableRuntimeFacts {
     return {
-        hasActiveCell: false,
-        currentActiveCellResolved: false,
+        activeCell: { status: 'absent' },
+        hadActiveCellBeforeUpdate: false,
         effectiveRawMode: false,
         nestedEditorOpen: false,
-        hadActiveCellBeforeUpdate: false,
         pendingFullReplaceRebuild: false,
-        ...overrides,
-    };
-}
-
-function defaultRuntimeEvent(overrides: Partial<TableRuntimeEvent> = {}): TableRuntimeEvent {
-    return {
         docChanged: false,
         selectionChanged: false,
         isSync: false,
@@ -110,11 +102,50 @@ function defaultRuntimeEvent(overrides: Partial<TableRuntimeEvent> = {}): TableR
         hasFullDocumentReplace: false,
         hasInsertedTableActivation: false,
         openRequestId: null,
-        selectionLeftActiveTable: false,
         requiresCellReposition: false,
         shouldSyncMainToNested: false,
         ...overrides,
     };
+}
+
+interface RuntimeStateFixture {
+    hasActiveCell?: boolean;
+    currentActiveCellResolved?: boolean;
+    effectiveRawMode?: boolean;
+    nestedEditorOpen?: boolean;
+    hadActiveCellBeforeUpdate?: boolean;
+    pendingFullReplaceRebuild?: boolean;
+}
+
+interface RuntimeEventFixture extends Omit<Partial<TableRuntimeFacts>, 'activeCell'> {
+    selectionLeftActiveTable?: boolean;
+}
+
+function defaultRuntimeSnapshot(overrides: RuntimeStateFixture = {}): RuntimeStateFixture {
+    return overrides;
+}
+
+function defaultRuntimeEvent(overrides: RuntimeEventFixture = {}): RuntimeEventFixture {
+    return overrides;
+}
+
+function reduceTableRuntime(state: RuntimeStateFixture, event: RuntimeEventFixture = {}) {
+    const activeCell = event.selectionLeftActiveTable
+        ? { status: 'resolved' as const, selectionLeftTable: true }
+        : state.currentActiveCellResolved
+          ? { status: 'resolved' as const, selectionLeftTable: false }
+          : state.hasActiveCell
+            ? { status: 'unresolved' as const }
+            : { status: 'absent' as const };
+    const { selectionLeftActiveTable: _selectionLeftActiveTable, ...eventFacts } = event;
+
+    return reduceTableRuntimePolicy(
+        defaultRuntimeFacts({
+            ...state,
+            ...eventFacts,
+            activeCell,
+        })
+    );
 }
 
 describe('tableRuntimePolicies', () => {

--- a/src/contentScript/__tests__/tableRuntimePolicies.test.ts
+++ b/src/contentScript/__tests__/tableRuntimePolicies.test.ts
@@ -12,10 +12,7 @@ import { resolveActiveCell } from '../tableRuntime/activeCell/resolvedActiveCell
 import { rebuildTableWidgetsEffect } from '../tableState/tableWidgetEffects';
 import { sourceModeField, toggleSourceModeEffect } from '../tableState/sourceMode';
 import { searchForceSourceModeField, setSearchForceSourceModeEffect } from '../tableState/searchForceSourceMode';
-import {
-    reduceTableRuntime as reduceTableRuntimePolicy,
-    type TableRuntimeFacts,
-} from '../tableRuntime/lifecycle/lifecyclePolicy';
+import { reduceTableRuntime, type TableRuntimeFacts } from '../tableRuntime/lifecycle/lifecyclePolicy';
 import { transactionRequiresTableRebuild } from '../tableRuntime/tableTransactionHelpers';
 import { decideMainEditorGuardTransaction } from '../editorBridge/mainEditorGuardPolicy';
 import { decideTableDecorationUpdate } from '../tableWidget/tableDecorationPolicy';
@@ -106,46 +103,6 @@ function defaultRuntimeFacts(overrides: Partial<TableRuntimeFacts> = {}): TableR
         shouldSyncMainToNested: false,
         ...overrides,
     };
-}
-
-interface RuntimeStateFixture {
-    hasActiveCell?: boolean;
-    currentActiveCellResolved?: boolean;
-    effectiveRawMode?: boolean;
-    nestedEditorOpen?: boolean;
-    hadActiveCellBeforeUpdate?: boolean;
-    pendingFullReplaceRebuild?: boolean;
-}
-
-interface RuntimeEventFixture extends Omit<Partial<TableRuntimeFacts>, 'activeCell'> {
-    selectionLeftActiveTable?: boolean;
-}
-
-function defaultRuntimeSnapshot(overrides: RuntimeStateFixture = {}): RuntimeStateFixture {
-    return overrides;
-}
-
-function defaultRuntimeEvent(overrides: RuntimeEventFixture = {}): RuntimeEventFixture {
-    return overrides;
-}
-
-function reduceTableRuntime(state: RuntimeStateFixture, event: RuntimeEventFixture = {}) {
-    const activeCell = event.selectionLeftActiveTable
-        ? { status: 'resolved' as const, selectionLeftTable: true }
-        : state.currentActiveCellResolved
-          ? { status: 'resolved' as const, selectionLeftTable: false }
-          : state.hasActiveCell
-            ? { status: 'unresolved' as const }
-            : { status: 'absent' as const };
-    const { selectionLeftActiveTable: _selectionLeftActiveTable, ...eventFacts } = event;
-
-    return reduceTableRuntimePolicy(
-        defaultRuntimeFacts({
-            ...state,
-            ...eventFacts,
-            activeCell,
-        })
-    );
 }
 
 describe('tableRuntimePolicies', () => {
@@ -363,11 +320,9 @@ describe('tableRuntimePolicies', () => {
     });
 
     it('plans raw mode exit as cursor reactivation', () => {
-        const state = defaultRuntimeSnapshot({
-            hasActiveCell: true,
+        const facts = defaultRuntimeFacts({
+            activeCell: { status: 'unresolved' },
             hadActiveCellBeforeUpdate: true,
-        });
-        const event = defaultRuntimeEvent({
             rawModeTransition: {
                 enteredRawMode: false,
                 exitedRawMode: true,
@@ -376,7 +331,7 @@ describe('tableRuntimePolicies', () => {
             },
         });
 
-        expect(reduceTableRuntime(state, event)).toEqual([
+        expect(reduceTableRuntime(facts)).toEqual([
             {
                 type: 'scheduleActivateCellAtCursor',
                 options: {
@@ -390,48 +345,35 @@ describe('tableRuntimePolicies', () => {
     });
 
     it('appends inserted-table activation after explicit open requests', () => {
-        const state = defaultRuntimeSnapshot({
-            hasActiveCell: true,
-            currentActiveCellResolved: true,
+        const facts = defaultRuntimeFacts({
+            activeCell: { status: 'resolved', selectionLeftTable: false },
             nestedEditorOpen: true,
             hadActiveCellBeforeUpdate: true,
+            hasInsertedTableActivation: true,
+            openRequestId: 'explicit-request',
+            requiresCellReposition: true,
         });
 
-        expect(
-            reduceTableRuntime(
-                state,
-                defaultRuntimeEvent({
-                    hasInsertedTableActivation: true,
-                    openRequestId: 'explicit-request',
-                    requiresCellReposition: true,
-                })
-            )
-        ).toEqual([
+        expect(reduceTableRuntime(facts)).toEqual([
             { type: 'openRequestedCell', requestId: 'explicit-request' },
             { type: 'scheduleInsertedTableActivation' },
         ]);
     });
 
     it('appends inserted-table activation after raw-mode exit actions', () => {
-        const state = defaultRuntimeSnapshot({
-            hasActiveCell: true,
+        const facts = defaultRuntimeFacts({
+            activeCell: { status: 'unresolved' },
             hadActiveCellBeforeUpdate: true,
+            hasInsertedTableActivation: true,
+            rawModeTransition: {
+                enteredRawMode: false,
+                exitedRawMode: true,
+                exitedSourceMode: true,
+                exitedSearchForce: false,
+            },
         });
 
-        expect(
-            reduceTableRuntime(
-                state,
-                defaultRuntimeEvent({
-                    hasInsertedTableActivation: true,
-                    rawModeTransition: {
-                        enteredRawMode: false,
-                        exitedRawMode: true,
-                        exitedSourceMode: true,
-                        exitedSearchForce: false,
-                    },
-                })
-            )
-        ).toEqual([
+        expect(reduceTableRuntime(facts)).toEqual([
             {
                 type: 'scheduleActivateCellAtCursor',
                 options: {
@@ -446,9 +388,9 @@ describe('tableRuntimePolicies', () => {
     });
 
     it('plans inserted-table activation when no other lifecycle work is needed', () => {
-        expect(
-            reduceTableRuntime(defaultRuntimeSnapshot(), defaultRuntimeEvent({ hasInsertedTableActivation: true }))
-        ).toEqual([{ type: 'scheduleInsertedTableActivation' }]);
+        expect(reduceTableRuntime(defaultRuntimeFacts({ hasInsertedTableActivation: true }))).toEqual([
+            { type: 'scheduleInsertedTableActivation' },
+        ]);
     });
 
     it('treats normalize-before-edit full table replacement as a controlled requested reopen', () => {
@@ -486,28 +428,21 @@ describe('tableRuntimePolicies', () => {
             ],
             annotations: normalizeBeforeEditAnnotation.of(true),
         });
-        const state = defaultRuntimeSnapshot({
-            hasActiveCell: true,
-            currentActiveCellResolved: true,
+        const facts = defaultRuntimeFacts({
+            activeCell: { status: 'resolved', selectionLeftTable: false },
             hadActiveCellBeforeUpdate: true,
+            docChanged: true,
+            selectionChanged: true,
+            isNormalizeBeforeEdit: true,
+            hasFullDocumentReplace: true,
+            openRequestId: 'normalize-request',
         });
 
         expect(decideTableDecorationUpdate(tr)).toEqual({ type: 'rebuildAllDecorations' });
         expect(decideMainEditorGuardTransaction(tr, { nestedEditorOpen: true })).toEqual({
             type: 'allowTransaction',
         });
-        expect(
-            reduceTableRuntime(
-                state,
-                defaultRuntimeEvent({
-                    docChanged: true,
-                    selectionChanged: true,
-                    isNormalizeBeforeEdit: true,
-                    hasFullDocumentReplace: true,
-                    openRequestId: 'normalize-request',
-                })
-            )
-        ).toEqual([{ type: 'openRequestedCell', requestId: 'normalize-request' }]);
+        expect(reduceTableRuntime(facts)).toEqual([{ type: 'openRequestedCell', requestId: 'normalize-request' }]);
     });
 
     it('does not plan normalization when disabled or already canonical', () => {
@@ -615,81 +550,65 @@ describe('tableRuntimePolicies', () => {
     });
 
     it('does not plan a generic reopen for rebuild-only transactions', () => {
-        const state = defaultRuntimeSnapshot({
-            hasActiveCell: true,
-            currentActiveCellResolved: true,
+        const facts = defaultRuntimeFacts({
+            activeCell: { status: 'resolved', selectionLeftTable: false },
             nestedEditorOpen: true,
             hadActiveCellBeforeUpdate: true,
         });
 
-        expect(reduceTableRuntime(state, defaultRuntimeEvent())).toEqual([]);
+        expect(reduceTableRuntime(facts)).toEqual([]);
     });
 
     it('plans nested editor sync from a single sync fact', () => {
-        const state = defaultRuntimeSnapshot({
-            hasActiveCell: true,
-            currentActiveCellResolved: true,
+        const facts = defaultRuntimeFacts({
+            activeCell: { status: 'resolved', selectionLeftTable: false },
             nestedEditorOpen: true,
             hadActiveCellBeforeUpdate: true,
         });
 
-        expect(reduceTableRuntime(state, defaultRuntimeEvent({ shouldSyncMainToNested: true }))).toContainEqual({
+        expect(reduceTableRuntime({ ...facts, shouldSyncMainToNested: true })).toContainEqual({
             type: 'syncMainToNested',
         });
-        expect(reduceTableRuntime(state, defaultRuntimeEvent({ shouldSyncMainToNested: false }))).toEqual([]);
+        expect(reduceTableRuntime({ ...facts, shouldSyncMainToNested: false })).toEqual([]);
     });
 
     it('prefers an explicit open request over generic branches', () => {
-        const state = defaultRuntimeSnapshot({
-            hasActiveCell: true,
-            currentActiveCellResolved: true,
+        const facts = defaultRuntimeFacts({
+            activeCell: { status: 'resolved', selectionLeftTable: true },
             nestedEditorOpen: true,
             hadActiveCellBeforeUpdate: true,
-        });
-        const event = defaultRuntimeEvent({
             docChanged: true,
             hasFullDocumentReplace: true,
             openRequestId: 'explicit-request',
             requiresCellReposition: true,
             selectionChanged: true,
-            selectionLeftActiveTable: true,
             shouldSyncMainToNested: true,
         });
 
-        expect(reduceTableRuntime(state, event)).toEqual([
-            { type: 'openRequestedCell', requestId: 'explicit-request' },
-        ]);
+        expect(reduceTableRuntime(facts)).toEqual([{ type: 'openRequestedCell', requestId: 'explicit-request' }]);
     });
 
-    it('uses the compact open request id selected by the adapter', () => {
-        const state = defaultRuntimeSnapshot({
-            hasActiveCell: true,
-            currentActiveCellResolved: true,
+    it('uses the classified open request id', () => {
+        const facts = defaultRuntimeFacts({
+            activeCell: { status: 'resolved', selectionLeftTable: false },
             nestedEditorOpen: true,
             hadActiveCellBeforeUpdate: true,
+            openRequestId: 'latest-request',
         });
-        const event = defaultRuntimeEvent({ openRequestId: 'latest-request' });
 
-        expect(reduceTableRuntime(state, event)).toEqual([{ type: 'openRequestedCell', requestId: 'latest-request' }]);
+        expect(reduceTableRuntime(facts)).toEqual([{ type: 'openRequestedCell', requestId: 'latest-request' }]);
     });
 
     it('uses the resolved update range when undo or redo repositions the active cell', () => {
-        const state = defaultRuntimeSnapshot({
-            hasActiveCell: true,
-            currentActiveCellResolved: true,
+        const facts = defaultRuntimeFacts({
+            activeCell: { status: 'resolved', selectionLeftTable: false },
             nestedEditorOpen: true,
             hadActiveCellBeforeUpdate: true,
+            docChanged: true,
+            requiresCellReposition: true,
         });
 
-        expect(
-            reduceTableRuntime(
-                state,
-                defaultRuntimeEvent({
-                    docChanged: true,
-                    requiresCellReposition: true,
-                })
-            )
-        ).toEqual([
+        expect(reduceTableRuntime(facts)).toEqual([
             { type: 'closeNestedEditorUsingResolvedUpdateRange' },
             {
                 type: 'scheduleActivateCellAtCursor',
@@ -704,92 +623,49 @@ describe('tableRuntimePolicies', () => {
     });
 
     it('closes and clears the active cell when selection moves outside the active table', () => {
-        const state = defaultRuntimeSnapshot({
-            hasActiveCell: true,
-            currentActiveCellResolved: true,
+        const facts = defaultRuntimeFacts({
+            activeCell: { status: 'resolved', selectionLeftTable: true },
             nestedEditorOpen: true,
             hadActiveCellBeforeUpdate: true,
+            selectionChanged: true,
         });
 
-        expect(
-            reduceTableRuntime(
-                state,
-                defaultRuntimeEvent({
-                    selectionChanged: true,
-                    selectionLeftActiveTable: true,
-                })
-            )
-        ).toEqual([{ type: 'closeNestedEditor' }, { type: 'clearActiveCell' }]);
+        expect(reduceTableRuntime(facts)).toEqual([{ type: 'closeNestedEditor' }, { type: 'clearActiveCell' }]);
     });
 
     it('suppresses selection-left-table cleanup during raw mode, cell selection, and sync updates', () => {
-        const state = defaultRuntimeSnapshot({
-            hasActiveCell: true,
-            currentActiveCellResolved: true,
+        const facts = defaultRuntimeFacts({
+            activeCell: { status: 'resolved', selectionLeftTable: true },
             nestedEditorOpen: true,
             hadActiveCellBeforeUpdate: true,
-        });
-        const event = defaultRuntimeEvent({
             selectionChanged: true,
-            selectionLeftActiveTable: true,
         });
 
-        expect(reduceTableRuntime(defaultRuntimeSnapshot({ ...state, effectiveRawMode: true }), event)).toEqual([]);
-        expect(
-            reduceTableRuntime(
-                state,
-                defaultRuntimeEvent({
-                    ...event,
-                    isCellSelectionTransition: true,
-                })
-            )
-        ).toEqual([]);
-        expect(
-            reduceTableRuntime(
-                state,
-                defaultRuntimeEvent({
-                    ...event,
-                    isSync: true,
-                })
-            )
-        ).toEqual([]);
+        expect(reduceTableRuntime({ ...facts, effectiveRawMode: true })).toEqual([]);
+        expect(reduceTableRuntime({ ...facts, isCellSelectionTransition: true })).toEqual([]);
+        expect(reduceTableRuntime({ ...facts, isSync: true })).toEqual([]);
     });
 
     it('does not clear the active cell when selection leaves the table after the nested editor already closed', () => {
-        const state = defaultRuntimeSnapshot({
-            hasActiveCell: true,
-            currentActiveCellResolved: true,
+        const facts = defaultRuntimeFacts({
+            activeCell: { status: 'resolved', selectionLeftTable: true },
             nestedEditorOpen: false,
             hadActiveCellBeforeUpdate: true,
+            selectionChanged: true,
         });
 
-        expect(
-            reduceTableRuntime(
-                state,
-                defaultRuntimeEvent({
-                    selectionChanged: true,
-                    selectionLeftActiveTable: true,
-                })
-            )
-        ).toEqual([]);
+        expect(reduceTableRuntime(facts)).toEqual([]);
     });
 
     it('plans stale active cell cleanup when the nested editor is gone', () => {
-        const state = defaultRuntimeSnapshot({
-            hasActiveCell: true,
-            currentActiveCellResolved: true,
+        const facts = defaultRuntimeFacts({
+            activeCell: { status: 'resolved', selectionLeftTable: false },
             nestedEditorOpen: false,
             hadActiveCellBeforeUpdate: true,
+            docChanged: true,
         });
 
-        expect(
-            reduceTableRuntime(
-                state,
-                defaultRuntimeEvent({
-                    docChanged: true,
-                })
-            )
-        ).toContainEqual({
+        expect(reduceTableRuntime(facts)).toContainEqual({
             type: 'clearActiveCell',
         });
     });
@@ -814,21 +690,14 @@ describe('tableRuntimePolicies', () => {
     });
 
     it('clears stale active cell when the resolver cannot find the table', () => {
-        const state = defaultRuntimeSnapshot({
-            hasActiveCell: true,
-            currentActiveCellResolved: false,
+        const facts = defaultRuntimeFacts({
+            activeCell: { status: 'unresolved' },
             nestedEditorOpen: false,
             hadActiveCellBeforeUpdate: true,
+            docChanged: true,
         });
 
-        expect(
-            reduceTableRuntime(
-                state,
-                defaultRuntimeEvent({
-                    docChanged: true,
-                })
-            )
-        ).toContainEqual({
+        expect(reduceTableRuntime(facts)).toContainEqual({
             type: 'clearActiveCell',
         });
     });

--- a/src/contentScript/tableRuntime/lifecycle/lifecyclePolicy.ts
+++ b/src/contentScript/tableRuntime/lifecycle/lifecyclePolicy.ts
@@ -1,13 +1,19 @@
-export interface TableRuntimeSnapshot {
-    hasActiveCell: boolean;
-    currentActiveCellResolved: boolean;
-    effectiveRawMode: boolean;
-    nestedEditorOpen: boolean;
-    hadActiveCellBeforeUpdate: boolean;
-    pendingFullReplaceRebuild: boolean;
-}
+export type ActiveCellFacts =
+    | { status: 'absent' }
+    | { status: 'unresolved' }
+    | { status: 'resolved'; selectionLeftTable: boolean };
 
-export interface TableRuntimeEvent {
+export interface TableRuntimeFacts {
+    // Post-update editor state
+    activeCell: ActiveCellFacts;
+    hadActiveCellBeforeUpdate: boolean;
+    effectiveRawMode: boolean;
+
+    // External facts supplied by the lifecycle plugin
+    nestedEditorOpen: boolean;
+    pendingFullReplaceRebuild: boolean;
+
+    // Transaction facts
     docChanged: boolean;
     selectionChanged: boolean;
     isSync: boolean;
@@ -15,13 +21,12 @@ export interface TableRuntimeEvent {
     isCellSelectionTransition: boolean;
     rawModeTransition: RawModeTransitionFacts;
     hasFullDocumentReplace: boolean;
+
+    // Requests
     hasInsertedTableActivation: boolean;
     openRequestId: string | null;
-    /**
-     * True only when the current active cell resolved and either main
-     * selection endpoint is outside that resolved table.
-     */
-    selectionLeftActiveTable: boolean;
+
+    // Derived policy inputs
     requiresCellReposition: boolean;
     shouldSyncMainToNested: boolean;
 }
@@ -56,19 +61,19 @@ export type TableRuntimeAction =
     | { type: 'scheduleRebuildAllAfterFullReplace' }
     | { type: 'scheduleInsertedTableActivation' };
 
-export function reduceTableRuntime(snapshot: TableRuntimeSnapshot, event: TableRuntimeEvent): TableRuntimeAction[] {
-    const actions = reduceCoreTableRuntime(snapshot, event);
-    if (event.hasInsertedTableActivation) {
+export function reduceTableRuntime(facts: TableRuntimeFacts): TableRuntimeAction[] {
+    const actions = reduceCoreTableRuntime(facts);
+    if (facts.hasInsertedTableActivation) {
         return [...actions, { type: 'scheduleInsertedTableActivation' }];
     }
 
     return actions;
 }
 
-function reduceCoreTableRuntime(snapshot: TableRuntimeSnapshot, event: TableRuntimeEvent): TableRuntimeAction[] {
+function reduceCoreTableRuntime(facts: TableRuntimeFacts): TableRuntimeAction[] {
     const actions: TableRuntimeAction[] = [];
 
-    if (event.openRequestId) {
+    if (facts.openRequestId) {
         // Command-driven structural mutations and direct cell activations
         // route through the explicit open path. The session controller still
         // closes the previous editor before mounting the next one, but doing
@@ -76,21 +81,21 @@ function reduceCoreTableRuntime(snapshot: TableRuntimeSnapshot, event: TableRunt
         // dismiss and reopen the IME when switching cells by tap.
         actions.push({
             type: 'openRequestedCell',
-            requestId: event.openRequestId,
+            requestId: facts.openRequestId,
         });
         return actions;
     }
 
     if (
-        snapshot.hadActiveCellBeforeUpdate &&
-        event.hasFullDocumentReplace &&
-        !event.isNormalizeBeforeEdit &&
-        !snapshot.pendingFullReplaceRebuild
+        facts.hadActiveCellBeforeUpdate &&
+        facts.hasFullDocumentReplace &&
+        !facts.isNormalizeBeforeEdit &&
+        !facts.pendingFullReplaceRebuild
     ) {
         actions.push({ type: 'scheduleRebuildAllAfterFullReplace' });
     }
 
-    if (event.rawModeTransition.exitedSourceMode || event.rawModeTransition.exitedSearchForce) {
+    if (facts.rawModeTransition.exitedSourceMode || facts.rawModeTransition.exitedSearchForce) {
         actions.push({
             type: 'scheduleActivateCellAtCursor',
             options: getActivateCellAtCursorOptions('rawModeExit'),
@@ -98,16 +103,20 @@ function reduceCoreTableRuntime(snapshot: TableRuntimeSnapshot, event: TableRunt
         return actions;
     }
 
-    if (event.rawModeTransition.enteredRawMode && !event.isCellSelectionTransition) {
+    if (facts.rawModeTransition.enteredRawMode && !facts.isCellSelectionTransition) {
         actions.push({ type: 'scheduleEnsureCursorVisible', mode: 'enteredRawMode' });
     }
 
-    if (event.rawModeTransition.exitedRawMode && !snapshot.hasActiveCell && !event.isCellSelectionTransition) {
+    if (
+        facts.rawModeTransition.exitedRawMode &&
+        facts.activeCell.status === 'absent' &&
+        !facts.isCellSelectionTransition
+    ) {
         actions.push({ type: 'scheduleEnsureCursorVisible', mode: 'exitedRawModeWithoutActiveCell' });
     }
 
-    if (event.requiresCellReposition) {
-        if (snapshot.nestedEditorOpen) {
+    if (facts.requiresCellReposition) {
+        if (facts.nestedEditorOpen) {
             actions.push({ type: 'closeNestedEditorUsingResolvedUpdateRange' });
         }
         actions.push({
@@ -117,42 +126,46 @@ function reduceCoreTableRuntime(snapshot: TableRuntimeSnapshot, event: TableRunt
         return actions;
     }
 
-    if (shouldClearActiveCellWhenSelectionLeavesTable(snapshot, event)) {
-        if (snapshot.nestedEditorOpen) {
+    if (shouldClearActiveCellWhenSelectionLeavesTable(facts)) {
+        if (facts.nestedEditorOpen) {
             actions.push({ type: 'closeNestedEditor' });
         }
         actions.push({ type: 'clearActiveCell' });
         return actions;
     }
 
-    if (!snapshot.hasActiveCell && snapshot.hadActiveCellBeforeUpdate) {
+    if (facts.activeCell.status === 'absent' && facts.hadActiveCellBeforeUpdate) {
         actions.push({ type: 'closeNestedEditor' });
     }
 
-    if (event.shouldSyncMainToNested) {
+    if (facts.shouldSyncMainToNested) {
         actions.push({ type: 'syncMainToNested' });
     }
 
-    if (event.docChanged && snapshot.hasActiveCell && !snapshot.currentActiveCellResolved && !event.isSync) {
+    if (facts.docChanged && facts.activeCell.status === 'unresolved' && !facts.isSync) {
         actions.push({ type: 'clearActiveCell' });
     }
 
-    if (event.docChanged && snapshot.currentActiveCellResolved && !snapshot.nestedEditorOpen && !event.isSync) {
+    if (facts.docChanged && facts.activeCell.status === 'resolved' && !facts.nestedEditorOpen && !facts.isSync) {
         actions.push({ type: 'clearActiveCell' });
     }
 
     return actions;
 }
 
-function shouldClearActiveCellWhenSelectionLeavesTable(state: TableRuntimeSnapshot, event: TableRuntimeEvent): boolean {
+function shouldClearActiveCellWhenSelectionLeavesTable(facts: TableRuntimeFacts): boolean {
     return (
-        event.selectionChanged &&
-        !event.isSync &&
-        !event.isCellSelectionTransition &&
-        !state.effectiveRawMode &&
-        state.nestedEditorOpen &&
-        event.selectionLeftActiveTable
+        facts.selectionChanged &&
+        !facts.isSync &&
+        !facts.isCellSelectionTransition &&
+        !facts.effectiveRawMode &&
+        facts.nestedEditorOpen &&
+        selectionLeftActiveTable(facts)
     );
+}
+
+function selectionLeftActiveTable(facts: TableRuntimeFacts): boolean {
+    return facts.activeCell.status === 'resolved' && facts.activeCell.selectionLeftTable;
 }
 
 function getActivateCellAtCursorOptions(reason: ActivateCellAtCursorReason): ActivateCellAtCursorOptions {

--- a/src/contentScript/tableRuntime/lifecycle/nestedEditorLifecycle.ts
+++ b/src/contentScript/tableRuntime/lifecycle/nestedEditorLifecycle.ts
@@ -25,7 +25,7 @@ import { clearOpenCellRequestEffect, getOpenCellRequestById } from '../openCellR
 import { planNormalizeTableBeforeOpen } from './tableNormalization';
 import { hostEditorConfigFacet } from '../../services/hostEditorConfig';
 import { reduceTableRuntime, type ActivateCellAtCursorOptions, type TableRuntimeAction } from './lifecyclePolicy';
-import { classifyTableRuntimeEvent, createTableRuntimeSnapshot } from './runtimeEventClassifier';
+import { classifyTableRuntimeFacts } from './runtimeEventClassifier';
 import { requestViewAnimationFrame } from '../../shared/domContext';
 
 // ============================================================================
@@ -80,13 +80,11 @@ export const nestedEditorLifecyclePlugin = ViewPlugin.fromClass(
         }
 
         update(update: ViewUpdate): void {
-            const externalRuntimeFacts = {
+            const facts = classifyTableRuntimeFacts(update, {
                 nestedEditorOpen: isNestedEditorOpen(this.view),
                 pendingFullReplaceRebuild: this.pendingFullReplaceRebuild,
-            };
-            const snapshot = createTableRuntimeSnapshot(update, externalRuntimeFacts);
-            const event = classifyTableRuntimeEvent(update, snapshot);
-            const actions = reduceTableRuntime(snapshot, event);
+            });
+            const actions = reduceTableRuntime(facts);
 
             this.executeActions(actions, update);
         }

--- a/src/contentScript/tableRuntime/lifecycle/runtimeEventClassifier.ts
+++ b/src/contentScript/tableRuntime/lifecycle/runtimeEventClassifier.ts
@@ -14,47 +14,38 @@ import { isFullDocumentReplace } from '../../shared/transactionUtils';
 import { transactionRequiresTableRebuild } from '../tableTransactionHelpers';
 import { triggerOpenCellRequestEffect } from '../openCellRequest';
 import { normalizeBeforeEditAnnotation } from './tableNormalization';
-import type { RawModeTransitionFacts, TableRuntimeEvent, TableRuntimeSnapshot } from './lifecyclePolicy';
+import type { ActiveCellFacts, RawModeTransitionFacts, TableRuntimeFacts } from './lifecyclePolicy';
 
 export interface TableRuntimeExternalFacts {
     nestedEditorOpen: boolean;
     pendingFullReplaceRebuild: boolean;
 }
 
-export function createTableRuntimeSnapshot(
+export function classifyTableRuntimeFacts(
     update: ViewUpdate,
     externalFacts: TableRuntimeExternalFacts
-): TableRuntimeSnapshot {
-    const activeCell = getActiveCell(update.state);
-    const prevActiveCell = getActiveCell(update.startState);
-    const resolvedActiveCell = getResolvedActiveCell(update.state);
+): TableRuntimeFacts {
+    const activeCellBefore = getActiveCell(update.startState);
+    const activeCellAfter = getActiveCell(update.state);
+    const resolvedCellBefore = getResolvedActiveCell(update.startState);
+    const resolvedCellAfter = getResolvedActiveCell(update.state);
     const effectiveRawMode = isEffectiveRawMode(update.state);
-
-    return {
-        hasActiveCell: Boolean(activeCell),
-        currentActiveCellResolved: Boolean(resolvedActiveCell),
-        effectiveRawMode,
-        nestedEditorOpen: externalFacts.nestedEditorOpen,
-        hadActiveCellBeforeUpdate: Boolean(prevActiveCell),
-        pendingFullReplaceRebuild: externalFacts.pendingFullReplaceRebuild,
-    };
-}
-
-export function classifyTableRuntimeEvent(update: ViewUpdate, snapshot: TableRuntimeSnapshot): TableRuntimeEvent {
-    const activeCell = getActiveCell(update.state);
-    const prevActiveCell = getActiveCell(update.startState);
-    const resolvedActiveCell = getResolvedActiveCell(update.state);
-    const resolvedPrevActiveCell = getResolvedActiveCell(update.startState);
-    const isSync = update.transactions.some((tr) => Boolean(tr.annotation(syncAnnotation)));
-    const shouldSyncDoc = update.docChanged && Boolean(resolvedActiveCell) && snapshot.nestedEditorOpen && !isSync;
+    const isSync = hasSyncAnnotation(update);
+    const activeCell = getActiveCellFacts(update, activeCellAfter, resolvedCellAfter);
+    const shouldSyncDoc = update.docChanged && Boolean(resolvedCellAfter) && externalFacts.nestedEditorOpen && !isSync;
     const shouldSyncSelection =
         update.selectionSet &&
-        isSameActiveCell(prevActiveCell, activeCell) &&
-        Boolean(resolvedActiveCell) &&
-        snapshot.nestedEditorOpen &&
+        isSameActiveCell(activeCellBefore, activeCellAfter) &&
+        Boolean(resolvedCellAfter) &&
+        externalFacts.nestedEditorOpen &&
         !isSync;
 
     return {
+        activeCell,
+        hadActiveCellBeforeUpdate: Boolean(activeCellBefore),
+        effectiveRawMode,
+        nestedEditorOpen: externalFacts.nestedEditorOpen,
+        pendingFullReplaceRebuild: externalFacts.pendingFullReplaceRebuild,
         docChanged: update.docChanged,
         selectionChanged: update.selectionSet,
         isSync,
@@ -66,15 +57,35 @@ export function classifyTableRuntimeEvent(update: ViewUpdate, snapshot: TableRun
         hasFullDocumentReplace: update.transactions.some((tr) => isFullDocumentReplace(tr)),
         hasInsertedTableActivation: hasInsertedTableActivationEffect(update),
         openRequestId: extractOpenRequestId(update),
-        selectionLeftActiveTable: isSelectionOutsideResolvedTable(update, resolvedActiveCell),
         requiresCellReposition: updateRequiresCellReposition({
             update,
-            effectiveRawMode: snapshot.effectiveRawMode,
-            hadActiveCellBeforeUpdate: snapshot.hadActiveCellBeforeUpdate,
-            resolvedPrevActiveCell,
+            effectiveRawMode,
+            hadActiveCellBeforeUpdate: Boolean(activeCellBefore),
+            resolvedActiveCellBefore: resolvedCellBefore,
             isSync,
         }),
         shouldSyncMainToNested: shouldSyncDoc || shouldSyncSelection,
+    };
+}
+
+function hasSyncAnnotation(update: ViewUpdate): boolean {
+    return update.transactions.some((tr) => Boolean(tr.annotation(syncAnnotation)));
+}
+
+function getActiveCellFacts(
+    update: ViewUpdate,
+    activeCell: ReturnType<typeof getActiveCell>,
+    resolvedActiveCell: ResolvedActiveCell | null
+): ActiveCellFacts {
+    if (!activeCell) {
+        return { status: 'absent' };
+    }
+    if (!resolvedActiveCell) {
+        return { status: 'unresolved' };
+    }
+    return {
+        status: 'resolved',
+        selectionLeftTable: isSelectionOutsideResolvedTable(update, resolvedActiveCell),
     };
 }
 
@@ -153,16 +164,16 @@ function updateRequiresCellReposition(params: {
     update: ViewUpdate;
     effectiveRawMode: boolean;
     hadActiveCellBeforeUpdate: boolean;
-    resolvedPrevActiveCell: ResolvedActiveCell | null;
+    resolvedActiveCellBefore: ResolvedActiveCell | null;
     isSync: boolean;
 }): boolean {
     if (!params.update.docChanged || params.isSync || params.effectiveRawMode) {
         return false;
     }
 
-    if (params.hadActiveCellBeforeUpdate && params.resolvedPrevActiveCell) {
+    if (params.hadActiveCellBeforeUpdate && params.resolvedActiveCellBefore) {
         return params.update.transactions.some((tr) =>
-            transactionRequiresTableRebuild(tr, params.resolvedPrevActiveCell)
+            transactionRequiresTableRebuild(tr, params.resolvedActiveCellBefore)
         );
     }
 


### PR DESCRIPTION
Unify the classifier into a single TableRuntimeFacts model (removing the unnecessary snapshot vs events disctinction) for better clarity and maintainability. Update policy test fixtures to align with the new model structure.