### PR TITLE
refactor: close-action vocabulary

### DIFF
--- a/src/contentScript/__tests__/runtimeEventClassifier.test.ts
+++ b/src/contentScript/__tests__/runtimeEventClassifier.test.ts
@@ -113,7 +113,7 @@ describe('runtimeEventClassifier', () => {
         });
 
         expect(classifyTableRuntimeFacts(update, externalFacts)).toMatchObject({
-            activeCell: { status: 'resolved', selectionLeftTable: false },
+            activeCell: { status: 'resolved', selectionLeftActiveTable: false },
             effectiveRawMode: false,
             nestedEditorOpen: true,
             hadActiveCellBeforeUpdate: true,
@@ -235,7 +235,7 @@ describe('runtimeEventClassifier', () => {
         });
         const facts = classifyTableRuntimeFacts(update, externalFacts);
 
-        expect(facts.activeCell).toEqual({ status: 'resolved', selectionLeftTable: true });
+        expect(facts.activeCell).toEqual({ status: 'resolved', selectionLeftActiveTable: true });
     });
 
     it('detects redo edits outside the active cell as reposition events', () => {
@@ -275,7 +275,7 @@ describe('runtimeEventClassifier', () => {
         });
 
         expect(facts).toMatchObject({
-            activeCell: { status: 'resolved', selectionLeftTable: false },
+            activeCell: { status: 'resolved', selectionLeftActiveTable: false },
             nestedEditorOpen: true,
             pendingFullReplaceRebuild: true,
             selectionChanged: true,

--- a/src/contentScript/__tests__/tableRuntimePolicies.test.ts
+++ b/src/contentScript/__tests__/tableRuntimePolicies.test.ts
@@ -346,7 +346,7 @@ describe('tableRuntimePolicies', () => {
 
     it('appends inserted-table activation after explicit open requests', () => {
         const facts = defaultRuntimeFacts({
-            activeCell: { status: 'resolved', selectionLeftTable: false },
+            activeCell: { status: 'resolved', selectionLeftActiveTable: false },
             nestedEditorOpen: true,
             hadActiveCellBeforeUpdate: true,
             hasInsertedTableActivation: true,
@@ -429,7 +429,7 @@ describe('tableRuntimePolicies', () => {
             annotations: normalizeBeforeEditAnnotation.of(true),
         });
         const facts = defaultRuntimeFacts({
-            activeCell: { status: 'resolved', selectionLeftTable: false },
+            activeCell: { status: 'resolved', selectionLeftActiveTable: false },
             hadActiveCellBeforeUpdate: true,
             docChanged: true,
             selectionChanged: true,
@@ -551,7 +551,7 @@ describe('tableRuntimePolicies', () => {
 
     it('does not plan a generic reopen for rebuild-only transactions', () => {
         const facts = defaultRuntimeFacts({
-            activeCell: { status: 'resolved', selectionLeftTable: false },
+            activeCell: { status: 'resolved', selectionLeftActiveTable: false },
             nestedEditorOpen: true,
             hadActiveCellBeforeUpdate: true,
         });
@@ -561,7 +561,7 @@ describe('tableRuntimePolicies', () => {
 
     it('plans nested editor sync from a single sync fact', () => {
         const facts = defaultRuntimeFacts({
-            activeCell: { status: 'resolved', selectionLeftTable: false },
+            activeCell: { status: 'resolved', selectionLeftActiveTable: false },
             nestedEditorOpen: true,
             hadActiveCellBeforeUpdate: true,
         });
@@ -574,7 +574,7 @@ describe('tableRuntimePolicies', () => {
 
     it('prefers an explicit open request over generic branches', () => {
         const facts = defaultRuntimeFacts({
-            activeCell: { status: 'resolved', selectionLeftTable: true },
+            activeCell: { status: 'resolved', selectionLeftActiveTable: true },
             nestedEditorOpen: true,
             hadActiveCellBeforeUpdate: true,
             docChanged: true,
@@ -590,7 +590,7 @@ describe('tableRuntimePolicies', () => {
 
     it('uses the classified open request id', () => {
         const facts = defaultRuntimeFacts({
-            activeCell: { status: 'resolved', selectionLeftTable: false },
+            activeCell: { status: 'resolved', selectionLeftActiveTable: false },
             nestedEditorOpen: true,
             hadActiveCellBeforeUpdate: true,
             openRequestId: 'latest-request',
@@ -601,7 +601,7 @@ describe('tableRuntimePolicies', () => {
 
     it('uses the resolved update range when undo or redo repositions the active cell', () => {
         const facts = defaultRuntimeFacts({
-            activeCell: { status: 'resolved', selectionLeftTable: false },
+            activeCell: { status: 'resolved', selectionLeftActiveTable: false },
             nestedEditorOpen: true,
             hadActiveCellBeforeUpdate: true,
             docChanged: true,
@@ -609,7 +609,7 @@ describe('tableRuntimePolicies', () => {
         });
 
         expect(reduceTableRuntime(facts)).toEqual([
-            { type: 'closeNestedEditorUsingResolvedUpdateRange' },
+            { type: 'closeNestedEditor', reason: 'cellReposition' },
             {
                 type: 'scheduleActivateCellAtCursor',
                 options: {
@@ -624,18 +624,31 @@ describe('tableRuntimePolicies', () => {
 
     it('closes and clears the active cell when selection moves outside the active table', () => {
         const facts = defaultRuntimeFacts({
-            activeCell: { status: 'resolved', selectionLeftTable: true },
+            activeCell: { status: 'resolved', selectionLeftActiveTable: true },
             nestedEditorOpen: true,
             hadActiveCellBeforeUpdate: true,
             selectionChanged: true,
         });
 
-        expect(reduceTableRuntime(facts)).toEqual([{ type: 'closeNestedEditor' }, { type: 'clearActiveCell' }]);
+        expect(reduceTableRuntime(facts)).toEqual([
+            { type: 'closeNestedEditor', reason: 'selectionLeftActiveTable' },
+            { type: 'clearActiveCell' },
+        ]);
+    });
+
+    it('closes the nested editor when the active cell disappears', () => {
+        const facts = defaultRuntimeFacts({
+            activeCell: { status: 'absent' },
+            nestedEditorOpen: true,
+            hadActiveCellBeforeUpdate: true,
+        });
+
+        expect(reduceTableRuntime(facts)).toEqual([{ type: 'closeNestedEditor', reason: 'activeCellRemoved' }]);
     });
 
     it('suppresses selection-left-table cleanup during raw mode, cell selection, and sync updates', () => {
         const facts = defaultRuntimeFacts({
-            activeCell: { status: 'resolved', selectionLeftTable: true },
+            activeCell: { status: 'resolved', selectionLeftActiveTable: true },
             nestedEditorOpen: true,
             hadActiveCellBeforeUpdate: true,
             selectionChanged: true,
@@ -648,7 +661,7 @@ describe('tableRuntimePolicies', () => {
 
     it('does not clear the active cell when selection leaves the table after the nested editor already closed', () => {
         const facts = defaultRuntimeFacts({
-            activeCell: { status: 'resolved', selectionLeftTable: true },
+            activeCell: { status: 'resolved', selectionLeftActiveTable: true },
             nestedEditorOpen: false,
             hadActiveCellBeforeUpdate: true,
             selectionChanged: true,
@@ -659,7 +672,7 @@ describe('tableRuntimePolicies', () => {
 
     it('plans stale active cell cleanup when the nested editor is gone', () => {
         const facts = defaultRuntimeFacts({
-            activeCell: { status: 'resolved', selectionLeftTable: false },
+            activeCell: { status: 'resolved', selectionLeftActiveTable: false },
             nestedEditorOpen: false,
             hadActiveCellBeforeUpdate: true,
             docChanged: true,

--- a/src/contentScript/tableRuntime/lifecycle/lifecyclePolicy.ts
+++ b/src/contentScript/tableRuntime/lifecycle/lifecyclePolicy.ts
@@ -1,7 +1,7 @@
 export type ActiveCellFacts =
     | { status: 'absent' }
     | { status: 'unresolved' }
-    | { status: 'resolved'; selectionLeftTable: boolean };
+    | { status: 'resolved'; selectionLeftActiveTable: boolean };
 
 export interface TableRuntimeFacts {
     // Post-update editor state
@@ -47,10 +47,11 @@ export interface ActivateCellAtCursorOptions {
     preserveMainSelection: boolean;
 }
 
+export type NestedEditorCloseReason = 'cellReposition' | 'selectionLeftActiveTable' | 'activeCellRemoved';
+
 export type TableRuntimeAction =
     | { type: 'openRequestedCell'; requestId: string }
-    | { type: 'closeNestedEditor' }
-    | { type: 'closeNestedEditorUsingResolvedUpdateRange' }
+    | { type: 'closeNestedEditor'; reason: NestedEditorCloseReason }
     | { type: 'syncMainToNested' }
     | { type: 'clearActiveCell' }
     | {
@@ -117,7 +118,7 @@ function reduceCoreTableRuntime(facts: TableRuntimeFacts): TableRuntimeAction[] 
 
     if (facts.requiresCellReposition) {
         if (facts.nestedEditorOpen) {
-            actions.push({ type: 'closeNestedEditorUsingResolvedUpdateRange' });
+            actions.push({ type: 'closeNestedEditor', reason: 'cellReposition' });
         }
         actions.push({
             type: 'scheduleActivateCellAtCursor',
@@ -128,14 +129,14 @@ function reduceCoreTableRuntime(facts: TableRuntimeFacts): TableRuntimeAction[] 
 
     if (shouldClearActiveCellWhenSelectionLeavesTable(facts)) {
         if (facts.nestedEditorOpen) {
-            actions.push({ type: 'closeNestedEditor' });
+            actions.push({ type: 'closeNestedEditor', reason: 'selectionLeftActiveTable' });
         }
         actions.push({ type: 'clearActiveCell' });
         return actions;
     }
 
     if (facts.activeCell.status === 'absent' && facts.hadActiveCellBeforeUpdate) {
-        actions.push({ type: 'closeNestedEditor' });
+        actions.push({ type: 'closeNestedEditor', reason: 'activeCellRemoved' });
     }
 
     if (facts.shouldSyncMainToNested) {
@@ -160,12 +161,9 @@ function shouldClearActiveCellWhenSelectionLeavesTable(facts: TableRuntimeFacts)
         !facts.isCellSelectionTransition &&
         !facts.effectiveRawMode &&
         facts.nestedEditorOpen &&
-        selectionLeftActiveTable(facts)
+        facts.activeCell.status === 'resolved' &&
+        facts.activeCell.selectionLeftActiveTable
     );
-}
-
-function selectionLeftActiveTable(facts: TableRuntimeFacts): boolean {
-    return facts.activeCell.status === 'resolved' && facts.activeCell.selectionLeftTable;
 }
 
 function getActivateCellAtCursorOptions(reason: ActivateCellAtCursorReason): ActivateCellAtCursorOptions {

--- a/src/contentScript/tableRuntime/lifecycle/nestedEditorLifecycle.ts
+++ b/src/contentScript/tableRuntime/lifecycle/nestedEditorLifecycle.ts
@@ -117,10 +117,11 @@ export const nestedEditorLifecyclePlugin = ViewPlugin.fromClass(
                         this.scheduleEnsureCursorVisible(action.mode);
                         break;
                     case 'closeNestedEditor':
-                        closeNestedEditor(this.view);
-                        break;
-                    case 'closeNestedEditorUsingResolvedUpdateRange':
-                        closeNestedEditor(this.view, snapshotResolvedCellRange(update.state) ?? undefined);
+                        if (action.reason === 'cellReposition') {
+                            closeNestedEditor(this.view, snapshotResolvedCellRange(update.state) ?? undefined);
+                        } else {
+                            closeNestedEditor(this.view);
+                        }
                         break;
                     case 'openRequestedCell':
                         this.scheduleOpenRequestedCell(action.requestId);

--- a/src/contentScript/tableRuntime/lifecycle/runtimeEventClassifier.ts
+++ b/src/contentScript/tableRuntime/lifecycle/runtimeEventClassifier.ts
@@ -85,7 +85,7 @@ function getActiveCellFacts(
     }
     return {
         status: 'resolved',
-        selectionLeftTable: isSelectionOutsideResolvedTable(update, resolvedActiveCell),
+        selectionLeftActiveTable: isSelectionOutsideResolvedTable(update, resolvedActiveCell),
     };
 }
 


### PR DESCRIPTION
- Replaced the old resolved-range close action with `closeNestedEditor` reasons.
- Added `cellReposition`, `selectionLeftActiveTable`, and `activeCellRemoved`.
- Preserved resolved-range closing only for reposition; other reasons use normal session-anchored closing.
- Renamed the fact to `selectionLeftActiveTable` and inlined the redundant policy helper.
- Updated policy/classifier tests, including an explicit active-cell-removal reason assertion.