### PR TITLE
refactor: classifier and policy boundary

### DIFF
--- a/src/contentScript/__tests__/runtimeEventClassifier.test.ts
+++ b/src/contentScript/__tests__/runtimeEventClassifier.test.ts
@@ -116,7 +116,8 @@ describe('runtimeEventClassifier', () => {
             activeCell: { status: 'resolved', selectionLeftActiveTable: false },
             effectiveRawMode: false,
             nestedEditorOpen: true,
-            hadActiveCellBeforeUpdate: true,
+            activeCellBefore: 'resolved',
+            activeCellIdentityUnchanged: true,
             pendingFullReplaceRebuild: true,
         });
     });
@@ -183,7 +184,7 @@ describe('runtimeEventClassifier', () => {
         });
     });
 
-    it('classifies same-cell selection updates as nested sync work', () => {
+    it('classifies same-cell selection facts needed for nested sync work', () => {
         const externalFacts: TableRuntimeExternalFacts = {
             ...DEFAULT_EXTERNAL_FACTS,
             nestedEditorOpen: true,
@@ -198,10 +199,10 @@ describe('runtimeEventClassifier', () => {
 
         expect(facts.selectionChanged).toBe(true);
         expect(facts.isSync).toBe(false);
-        expect(facts.shouldSyncMainToNested).toBe(true);
+        expect(facts.activeCellIdentityUnchanged).toBe(true);
     });
 
-    it('does not request nested sync for sync-annotated selection updates', () => {
+    it('classifies sync-annotated selection updates as sync updates', () => {
         const externalFacts: TableRuntimeExternalFacts = {
             ...DEFAULT_EXTERNAL_FACTS,
             nestedEditorOpen: true,
@@ -218,7 +219,7 @@ describe('runtimeEventClassifier', () => {
         const facts = classifyTableRuntimeFacts(update, externalFacts);
 
         expect(facts.isSync).toBe(true);
-        expect(facts.shouldSyncMainToNested).toBe(false);
+        expect(facts.activeCellIdentityUnchanged).toBe(true);
     });
 
     it('detects when selection leaves the resolved active table', () => {
@@ -251,7 +252,9 @@ describe('runtimeEventClassifier', () => {
         const facts = classifyTableRuntimeFacts(update, DEFAULT_EXTERNAL_FACTS);
 
         expect(facts.docChanged).toBe(true);
-        expect(facts.requiresCellReposition).toBe(true);
+        expect(facts.activeCellBefore).toBe('resolved');
+        expect(facts.rebuildTouchesPreviousActiveTable).toBe(true);
+        expect(facts.isUndoRedoInsideTable).toBe(false);
     });
 
     it('produces coherent facts when a sync update carries several signals', () => {
@@ -282,7 +285,7 @@ describe('runtimeEventClassifier', () => {
             isSync: true,
             isCellSelectionTransition: true,
             hasInsertedTableActivation: true,
-            shouldSyncMainToNested: false,
+            activeCellIdentityUnchanged: true,
         });
     });
 });

--- a/src/contentScript/__tests__/runtimeEventClassifier.test.ts
+++ b/src/contentScript/__tests__/runtimeEventClassifier.test.ts
@@ -257,6 +257,22 @@ describe('runtimeEventClassifier', () => {
         expect(facts.isUndoRedoInsideTable).toBe(false);
     });
 
+    it('classifies undo or redo inside a table independently of policy gates', () => {
+        const update = dispatchAndCaptureUpdate({
+            dispatch(view) {
+                view.dispatch({
+                    changes: { from: 3, to: 3, insert: 'x' },
+                    annotations: [Transaction.userEvent.of('undo'), syncAnnotation.of(true)],
+                });
+            },
+        });
+        const facts = classifyTableRuntimeFacts(update, DEFAULT_EXTERNAL_FACTS);
+
+        expect(facts.docChanged).toBe(true);
+        expect(facts.isSync).toBe(true);
+        expect(facts.isUndoRedoInsideTable).toBe(true);
+    });
+
     it('produces coherent facts when a sync update carries several signals', () => {
         const update = dispatchAndCaptureUpdate({
             activeCell: getHeaderCell(),

--- a/src/contentScript/__tests__/tableRuntimePolicies.test.ts
+++ b/src/contentScript/__tests__/tableRuntimePolicies.test.ts
@@ -81,7 +81,8 @@ function requireResolvedActiveCell(state: EditorState) {
 function defaultRuntimeFacts(overrides: Partial<TableRuntimeFacts> = {}): TableRuntimeFacts {
     return {
         activeCell: { status: 'absent' },
-        hadActiveCellBeforeUpdate: false,
+        activeCellBefore: 'absent',
+        activeCellIdentityUnchanged: false,
         effectiveRawMode: false,
         nestedEditorOpen: false,
         pendingFullReplaceRebuild: false,
@@ -97,10 +98,10 @@ function defaultRuntimeFacts(overrides: Partial<TableRuntimeFacts> = {}): TableR
             exitedSearchForce: false,
         },
         hasFullDocumentReplace: false,
+        rebuildTouchesPreviousActiveTable: false,
+        isUndoRedoInsideTable: false,
         hasInsertedTableActivation: false,
         openRequestId: null,
-        requiresCellReposition: false,
-        shouldSyncMainToNested: false,
         ...overrides,
     };
 }
@@ -322,7 +323,7 @@ describe('tableRuntimePolicies', () => {
     it('plans raw mode exit as cursor reactivation', () => {
         const facts = defaultRuntimeFacts({
             activeCell: { status: 'unresolved' },
-            hadActiveCellBeforeUpdate: true,
+            activeCellBefore: 'resolved',
             rawModeTransition: {
                 enteredRawMode: false,
                 exitedRawMode: true,
@@ -348,10 +349,10 @@ describe('tableRuntimePolicies', () => {
         const facts = defaultRuntimeFacts({
             activeCell: { status: 'resolved', selectionLeftActiveTable: false },
             nestedEditorOpen: true,
-            hadActiveCellBeforeUpdate: true,
+            activeCellBefore: 'resolved',
             hasInsertedTableActivation: true,
             openRequestId: 'explicit-request',
-            requiresCellReposition: true,
+            rebuildTouchesPreviousActiveTable: true,
         });
 
         expect(reduceTableRuntime(facts)).toEqual([
@@ -363,7 +364,7 @@ describe('tableRuntimePolicies', () => {
     it('appends inserted-table activation after raw-mode exit actions', () => {
         const facts = defaultRuntimeFacts({
             activeCell: { status: 'unresolved' },
-            hadActiveCellBeforeUpdate: true,
+            activeCellBefore: 'resolved',
             hasInsertedTableActivation: true,
             rawModeTransition: {
                 enteredRawMode: false,
@@ -430,7 +431,7 @@ describe('tableRuntimePolicies', () => {
         });
         const facts = defaultRuntimeFacts({
             activeCell: { status: 'resolved', selectionLeftActiveTable: false },
-            hadActiveCellBeforeUpdate: true,
+            activeCellBefore: 'resolved',
             docChanged: true,
             selectionChanged: true,
             isNormalizeBeforeEdit: true,
@@ -553,36 +554,38 @@ describe('tableRuntimePolicies', () => {
         const facts = defaultRuntimeFacts({
             activeCell: { status: 'resolved', selectionLeftActiveTable: false },
             nestedEditorOpen: true,
-            hadActiveCellBeforeUpdate: true,
+            activeCellBefore: 'resolved',
         });
 
         expect(reduceTableRuntime(facts)).toEqual([]);
     });
 
-    it('plans nested editor sync from a single sync fact', () => {
+    it('plans nested editor sync from document changes or same-cell selection changes', () => {
         const facts = defaultRuntimeFacts({
             activeCell: { status: 'resolved', selectionLeftActiveTable: false },
             nestedEditorOpen: true,
-            hadActiveCellBeforeUpdate: true,
+            activeCellBefore: 'resolved',
         });
 
-        expect(reduceTableRuntime({ ...facts, shouldSyncMainToNested: true })).toContainEqual({
+        expect(reduceTableRuntime({ ...facts, docChanged: true })).toContainEqual({
             type: 'syncMainToNested',
         });
-        expect(reduceTableRuntime({ ...facts, shouldSyncMainToNested: false })).toEqual([]);
+        expect(
+            reduceTableRuntime({ ...facts, selectionChanged: true, activeCellIdentityUnchanged: true })
+        ).toContainEqual({ type: 'syncMainToNested' });
+        expect(reduceTableRuntime({ ...facts, selectionChanged: true })).toEqual([]);
     });
 
     it('prefers an explicit open request over generic branches', () => {
         const facts = defaultRuntimeFacts({
             activeCell: { status: 'resolved', selectionLeftActiveTable: true },
             nestedEditorOpen: true,
-            hadActiveCellBeforeUpdate: true,
+            activeCellBefore: 'resolved',
             docChanged: true,
             hasFullDocumentReplace: true,
             openRequestId: 'explicit-request',
-            requiresCellReposition: true,
+            rebuildTouchesPreviousActiveTable: true,
             selectionChanged: true,
-            shouldSyncMainToNested: true,
         });
 
         expect(reduceTableRuntime(facts)).toEqual([{ type: 'openRequestedCell', requestId: 'explicit-request' }]);
@@ -592,7 +595,7 @@ describe('tableRuntimePolicies', () => {
         const facts = defaultRuntimeFacts({
             activeCell: { status: 'resolved', selectionLeftActiveTable: false },
             nestedEditorOpen: true,
-            hadActiveCellBeforeUpdate: true,
+            activeCellBefore: 'resolved',
             openRequestId: 'latest-request',
         });
 
@@ -603,9 +606,9 @@ describe('tableRuntimePolicies', () => {
         const facts = defaultRuntimeFacts({
             activeCell: { status: 'resolved', selectionLeftActiveTable: false },
             nestedEditorOpen: true,
-            hadActiveCellBeforeUpdate: true,
+            activeCellBefore: 'resolved',
             docChanged: true,
-            requiresCellReposition: true,
+            rebuildTouchesPreviousActiveTable: true,
         });
 
         expect(reduceTableRuntime(facts)).toEqual([
@@ -622,11 +625,30 @@ describe('tableRuntimePolicies', () => {
         ]);
     });
 
+    it('repositions after undo or redo inside a table without a resolved previous active cell', () => {
+        const facts = defaultRuntimeFacts({
+            docChanged: true,
+            isUndoRedoInsideTable: true,
+        });
+
+        expect(reduceTableRuntime(facts)).toEqual([
+            {
+                type: 'scheduleActivateCellAtCursor',
+                options: {
+                    clearIfOutside: true,
+                    ensureCursorVisibleIfNotActivated: false,
+                    normalizeIfNeeded: false,
+                    preserveMainSelection: false,
+                },
+            },
+        ]);
+    });
+
     it('closes and clears the active cell when selection moves outside the active table', () => {
         const facts = defaultRuntimeFacts({
             activeCell: { status: 'resolved', selectionLeftActiveTable: true },
             nestedEditorOpen: true,
-            hadActiveCellBeforeUpdate: true,
+            activeCellBefore: 'resolved',
             selectionChanged: true,
         });
 
@@ -640,7 +662,7 @@ describe('tableRuntimePolicies', () => {
         const facts = defaultRuntimeFacts({
             activeCell: { status: 'absent' },
             nestedEditorOpen: true,
-            hadActiveCellBeforeUpdate: true,
+            activeCellBefore: 'resolved',
         });
 
         expect(reduceTableRuntime(facts)).toEqual([{ type: 'closeNestedEditor', reason: 'activeCellRemoved' }]);
@@ -650,7 +672,7 @@ describe('tableRuntimePolicies', () => {
         const facts = defaultRuntimeFacts({
             activeCell: { status: 'resolved', selectionLeftActiveTable: true },
             nestedEditorOpen: true,
-            hadActiveCellBeforeUpdate: true,
+            activeCellBefore: 'resolved',
             selectionChanged: true,
         });
 
@@ -663,7 +685,7 @@ describe('tableRuntimePolicies', () => {
         const facts = defaultRuntimeFacts({
             activeCell: { status: 'resolved', selectionLeftActiveTable: true },
             nestedEditorOpen: false,
-            hadActiveCellBeforeUpdate: true,
+            activeCellBefore: 'resolved',
             selectionChanged: true,
         });
 
@@ -674,7 +696,7 @@ describe('tableRuntimePolicies', () => {
         const facts = defaultRuntimeFacts({
             activeCell: { status: 'resolved', selectionLeftActiveTable: false },
             nestedEditorOpen: false,
-            hadActiveCellBeforeUpdate: true,
+            activeCellBefore: 'resolved',
             docChanged: true,
         });
 
@@ -706,7 +728,7 @@ describe('tableRuntimePolicies', () => {
         const facts = defaultRuntimeFacts({
             activeCell: { status: 'unresolved' },
             nestedEditorOpen: false,
-            hadActiveCellBeforeUpdate: true,
+            activeCellBefore: 'resolved',
             docChanged: true,
         });
 

--- a/src/contentScript/nestedEditor/nestedEditorController.ts
+++ b/src/contentScript/nestedEditor/nestedEditorController.ts
@@ -16,6 +16,7 @@ import {
 } from '../editorBridge/cellTextCodec';
 import { forceRootDomSelection } from '../editorBridge/rootDomSelection';
 import { syncAnnotation } from '../editorBridge/syncAnnotation';
+import { hasSyncAnnotation } from '../shared/transactionUtils';
 import { ensureCellWrapper } from './mounting';
 import {
     getResolvedActiveCell,
@@ -338,7 +339,7 @@ class NestedEditorController {
             return;
         }
 
-        const isSync = update.transactions.some((tr) => Boolean(tr.annotation(syncAnnotation)));
+        const isSync = hasSyncAnnotation(update.transactions);
         if (isSync || this.session.applyingRootToLocal) {
             return;
         }

--- a/src/contentScript/shared/transactionUtils.ts
+++ b/src/contentScript/shared/transactionUtils.ts
@@ -1,4 +1,9 @@
 import { Transaction } from '@codemirror/state';
+import { syncAnnotation } from '../editorBridge/syncAnnotation';
+
+export function hasSyncAnnotation(transactions: readonly Transaction[]): boolean {
+    return transactions.some((tr) => Boolean(tr.annotation(syncAnnotation)));
+}
 
 /**
  * Detects a full document replacement transaction (e.g., external sync update).

--- a/src/contentScript/tableRuntime/lifecycle/lifecyclePolicy.ts
+++ b/src/contentScript/tableRuntime/lifecycle/lifecyclePolicy.ts
@@ -1,12 +1,17 @@
 export type ActiveCellFacts =
     | { status: 'absent' }
     | { status: 'unresolved' }
-    | { status: 'resolved'; selectionLeftActiveTable: boolean };
+    | {
+          status: 'resolved';
+          // True when either main-selection endpoint is outside the resolved table.
+          selectionLeftActiveTable: boolean;
+      };
 
 export interface TableRuntimeFacts {
     // Post-update editor state
     activeCell: ActiveCellFacts;
-    hadActiveCellBeforeUpdate: boolean;
+    activeCellBefore: ActiveCellFacts['status'];
+    activeCellIdentityUnchanged: boolean;
     effectiveRawMode: boolean;
 
     // External facts supplied by the lifecycle plugin
@@ -21,14 +26,12 @@ export interface TableRuntimeFacts {
     isCellSelectionTransition: boolean;
     rawModeTransition: RawModeTransitionFacts;
     hasFullDocumentReplace: boolean;
+    rebuildTouchesPreviousActiveTable: boolean;
+    isUndoRedoInsideTable: boolean;
 
     // Requests
     hasInsertedTableActivation: boolean;
     openRequestId: string | null;
-
-    // Derived policy inputs
-    requiresCellReposition: boolean;
-    shouldSyncMainToNested: boolean;
 }
 
 export interface RawModeTransitionFacts {
@@ -88,7 +91,7 @@ function reduceCoreTableRuntime(facts: TableRuntimeFacts): TableRuntimeAction[] 
     }
 
     if (
-        facts.hadActiveCellBeforeUpdate &&
+        facts.activeCellBefore !== 'absent' &&
         facts.hasFullDocumentReplace &&
         !facts.isNormalizeBeforeEdit &&
         !facts.pendingFullReplaceRebuild
@@ -116,7 +119,7 @@ function reduceCoreTableRuntime(facts: TableRuntimeFacts): TableRuntimeAction[] 
         actions.push({ type: 'scheduleEnsureCursorVisible', mode: 'exitedRawModeWithoutActiveCell' });
     }
 
-    if (facts.requiresCellReposition) {
+    if (requiresCellReposition(facts)) {
         if (facts.nestedEditorOpen) {
             actions.push({ type: 'closeNestedEditor', reason: 'cellReposition' });
         }
@@ -135,11 +138,11 @@ function reduceCoreTableRuntime(facts: TableRuntimeFacts): TableRuntimeAction[] 
         return actions;
     }
 
-    if (facts.activeCell.status === 'absent' && facts.hadActiveCellBeforeUpdate) {
+    if (facts.activeCell.status === 'absent' && facts.activeCellBefore !== 'absent') {
         actions.push({ type: 'closeNestedEditor', reason: 'activeCellRemoved' });
     }
 
-    if (facts.shouldSyncMainToNested) {
+    if (shouldSyncMainToNested(facts)) {
         actions.push({ type: 'syncMainToNested' });
     }
 
@@ -152,6 +155,25 @@ function reduceCoreTableRuntime(facts: TableRuntimeFacts): TableRuntimeAction[] 
     }
 
     return actions;
+}
+
+function shouldSyncMainToNested(facts: TableRuntimeFacts): boolean {
+    return (
+        facts.nestedEditorOpen &&
+        !facts.isSync &&
+        facts.activeCell.status === 'resolved' &&
+        (facts.docChanged || (facts.selectionChanged && facts.activeCellIdentityUnchanged))
+    );
+}
+
+function requiresCellReposition(facts: TableRuntimeFacts): boolean {
+    if (!facts.docChanged || facts.isSync || facts.effectiveRawMode) {
+        return false;
+    }
+
+    return facts.activeCellBefore === 'resolved'
+        ? facts.rebuildTouchesPreviousActiveTable
+        : facts.isUndoRedoInsideTable;
 }
 
 function shouldClearActiveCellWhenSelectionLeavesTable(facts: TableRuntimeFacts): boolean {

--- a/src/contentScript/tableRuntime/lifecycle/runtimeEventClassifier.ts
+++ b/src/contentScript/tableRuntime/lifecycle/runtimeEventClassifier.ts
@@ -1,7 +1,5 @@
 import { type ViewUpdate } from '@codemirror/view';
 import { getActiveCell, isSameActiveCell } from '../../tableState/activeCellState';
-import { cellSelectionTransitionAnnotation } from '../../tableState/cellSelectionState';
-import { syncAnnotation } from '../../editorBridge/syncAnnotation';
 import {
     exitSearchForceSourceModeEffect,
     setSearchForceSourceModeEffect,
@@ -10,10 +8,14 @@ import { exitSourceModeEffect, isEffectiveRawMode, toggleSourceModeEffect } from
 import { activateInsertedTableEffect } from '../../tableState/insertedTableActivation';
 import { getResolvedActiveCell, type ResolvedActiveCell } from '../activeCell/resolvedActiveCell';
 import { findTableRanges } from '../tableResolution';
-import { isFullDocumentReplace } from '../../shared/transactionUtils';
+import { hasSyncAnnotation } from '../../shared/transactionUtils';
 import { transactionRequiresTableRebuild } from '../tableTransactionHelpers';
 import { triggerOpenCellRequestEffect } from '../openCellRequest';
-import { normalizeBeforeEditAnnotation } from './tableNormalization';
+import {
+    hasCellSelectionTransitionAnnotation,
+    hasFullDocumentReplace,
+    hasNormalizeBeforeEditAnnotation,
+} from './transactionFactPredicates';
 import type { ActiveCellFacts, RawModeTransitionFacts, TableRuntimeFacts } from './lifecyclePolicy';
 
 export interface TableRuntimeExternalFacts {
@@ -30,46 +32,44 @@ export function classifyTableRuntimeFacts(
     const resolvedCellBefore = getResolvedActiveCell(update.startState);
     const resolvedCellAfter = getResolvedActiveCell(update.state);
     const effectiveRawMode = isEffectiveRawMode(update.state);
-    const isSync = hasSyncAnnotation(update);
+    const activeCellBeforeStatus = getActiveCellStatus(activeCellBefore, resolvedCellBefore);
+    const isSync = hasSyncAnnotation(update.transactions);
     const activeCell = getActiveCellFacts(update, activeCellAfter, resolvedCellAfter);
-    const shouldSyncDoc = update.docChanged && Boolean(resolvedCellAfter) && externalFacts.nestedEditorOpen && !isSync;
-    const shouldSyncSelection =
-        update.selectionSet &&
-        isSameActiveCell(activeCellBefore, activeCellAfter) &&
-        Boolean(resolvedCellAfter) &&
-        externalFacts.nestedEditorOpen &&
-        !isSync;
+    const isUndoRedoInsideTable =
+        update.docChanged && !isSync && !effectiveRawMode && isUndoRedo(update) && cursorInsideAnyTable(update);
 
     return {
         activeCell,
-        hadActiveCellBeforeUpdate: Boolean(activeCellBefore),
+        activeCellBefore: activeCellBeforeStatus,
+        activeCellIdentityUnchanged: isSameActiveCell(activeCellBefore, activeCellAfter),
         effectiveRawMode,
         nestedEditorOpen: externalFacts.nestedEditorOpen,
         pendingFullReplaceRebuild: externalFacts.pendingFullReplaceRebuild,
         docChanged: update.docChanged,
         selectionChanged: update.selectionSet,
         isSync,
-        isNormalizeBeforeEdit: update.transactions.some((tr) => Boolean(tr.annotation(normalizeBeforeEditAnnotation))),
-        isCellSelectionTransition: update.transactions.some((tr) =>
-            Boolean(tr.annotation(cellSelectionTransitionAnnotation))
-        ),
+        isNormalizeBeforeEdit: hasNormalizeBeforeEditAnnotation(update.transactions),
+        isCellSelectionTransition: hasCellSelectionTransitionAnnotation(update.transactions),
         rawModeTransition: scanRawModeTransitionFacts(update),
-        hasFullDocumentReplace: update.transactions.some((tr) => isFullDocumentReplace(tr)),
+        hasFullDocumentReplace: hasFullDocumentReplace(update.transactions),
         hasInsertedTableActivation: hasInsertedTableActivationEffect(update),
         openRequestId: extractOpenRequestId(update),
-        requiresCellReposition: updateRequiresCellReposition({
-            update,
-            effectiveRawMode,
-            hadActiveCellBeforeUpdate: Boolean(activeCellBefore),
-            resolvedActiveCellBefore: resolvedCellBefore,
-            isSync,
-        }),
-        shouldSyncMainToNested: shouldSyncDoc || shouldSyncSelection,
+        rebuildTouchesPreviousActiveTable:
+            update.docChanged && activeCellBeforeStatus === 'resolved'
+                ? update.transactions.some((tr) => transactionRequiresTableRebuild(tr, resolvedCellBefore))
+                : false,
+        isUndoRedoInsideTable,
     };
 }
 
-function hasSyncAnnotation(update: ViewUpdate): boolean {
-    return update.transactions.some((tr) => Boolean(tr.annotation(syncAnnotation)));
+function getActiveCellStatus(
+    activeCell: ReturnType<typeof getActiveCell>,
+    resolvedActiveCell: ResolvedActiveCell | null
+): ActiveCellFacts['status'] {
+    if (!activeCell) {
+        return 'absent';
+    }
+    return resolvedActiveCell ? 'resolved' : 'unresolved';
 }
 
 function getActiveCellFacts(
@@ -77,11 +77,9 @@ function getActiveCellFacts(
     activeCell: ReturnType<typeof getActiveCell>,
     resolvedActiveCell: ResolvedActiveCell | null
 ): ActiveCellFacts {
-    if (!activeCell) {
-        return { status: 'absent' };
-    }
-    if (!resolvedActiveCell) {
-        return { status: 'unresolved' };
+    const status = getActiveCellStatus(activeCell, resolvedActiveCell);
+    if (status !== 'resolved') {
+        return { status };
     }
     return {
         status: 'resolved',
@@ -160,23 +158,6 @@ function cursorInsideAnyTable(update: ViewUpdate): boolean {
     return findTableRanges(update.state).some((table) => cursorPos >= table.from && cursorPos <= table.to);
 }
 
-function updateRequiresCellReposition(params: {
-    update: ViewUpdate;
-    effectiveRawMode: boolean;
-    hadActiveCellBeforeUpdate: boolean;
-    resolvedActiveCellBefore: ResolvedActiveCell | null;
-    isSync: boolean;
-}): boolean {
-    if (!params.update.docChanged || params.isSync || params.effectiveRawMode) {
-        return false;
-    }
-
-    if (params.hadActiveCellBeforeUpdate && params.resolvedActiveCellBefore) {
-        return params.update.transactions.some((tr) =>
-            transactionRequiresTableRebuild(tr, params.resolvedActiveCellBefore)
-        );
-    }
-
-    const isUndoRedo = params.update.transactions.some((tr) => tr.isUserEvent('undo') || tr.isUserEvent('redo'));
-    return isUndoRedo && cursorInsideAnyTable(params.update);
+function isUndoRedo(update: ViewUpdate): boolean {
+    return update.transactions.some((tr) => tr.isUserEvent('undo') || tr.isUserEvent('redo'));
 }

--- a/src/contentScript/tableRuntime/lifecycle/runtimeEventClassifier.ts
+++ b/src/contentScript/tableRuntime/lifecycle/runtimeEventClassifier.ts
@@ -35,8 +35,7 @@ export function classifyTableRuntimeFacts(
     const activeCellBeforeStatus = getActiveCellStatus(activeCellBefore, resolvedCellBefore);
     const isSync = hasSyncAnnotation(update.transactions);
     const activeCell = getActiveCellFacts(update, activeCellAfter, resolvedCellAfter);
-    const isUndoRedoInsideTable =
-        update.docChanged && !isSync && !effectiveRawMode && isUndoRedo(update) && cursorInsideAnyTable(update);
+    const isUndoRedoInsideTable = isUndoRedo(update) && cursorInsideAnyTable(update);
 
     return {
         activeCell,

--- a/src/contentScript/tableRuntime/lifecycle/transactionFactPredicates.ts
+++ b/src/contentScript/tableRuntime/lifecycle/transactionFactPredicates.ts
@@ -1,0 +1,16 @@
+import { type Transaction } from '@codemirror/state';
+import { isFullDocumentReplace } from '../../shared/transactionUtils';
+import { cellSelectionTransitionAnnotation } from '../../tableState/cellSelectionState';
+import { normalizeBeforeEditAnnotation } from './tableNormalization';
+
+export function hasNormalizeBeforeEditAnnotation(transactions: readonly Transaction[]): boolean {
+    return transactions.some((tr) => Boolean(tr.annotation(normalizeBeforeEditAnnotation)));
+}
+
+export function hasCellSelectionTransitionAnnotation(transactions: readonly Transaction[]): boolean {
+    return transactions.some((tr) => Boolean(tr.annotation(cellSelectionTransitionAnnotation)));
+}
+
+export function hasFullDocumentReplace(transactions: readonly Transaction[]): boolean {
+    return transactions.some((tr) => isFullDocumentReplace(tr));
+}


### PR DESCRIPTION
Enhance the classifier and policy boundary by deriving decisions from primitive facts and consolidating sync-annotation detection. Update tests to cover new logic and ensure accurate classification of selection updates. Fix an issue with duplicated gate handling.