### PR TITLE
refactor: point-based table resolution and fix related bugs

### DIFF
--- a/src/contentScript/__tests__/activeCellResolver.test.ts
+++ b/src/contentScript/__tests__/activeCellResolver.test.ts
@@ -74,6 +74,30 @@ describe('resolvedActiveCell', () => {
         expect(resolveActiveCell(tr.state, getActiveCell(tr.state))).toBeNull();
     });
 
+    it('returns null for an anchor outside the document', () => {
+        const doc = ['| H1 | H2 |', '| --- | --- |', '| a1 | a2 |'].join('\n');
+        const state = createState(doc);
+
+        for (const tableFrom of [-1, doc.length + 1, doc.length + 10]) {
+            expect(resolveActiveCell(state, { tableFrom, section: 'header', row: 0, col: 0 })).toBeNull();
+        }
+    });
+
+    it('resolves an in-document anchor that no longer points at the table start', () => {
+        const doc = ['| H1 | H2 |', '| --- | --- |', '| a1 | a2 |'].join('\n');
+        const state = createState(doc);
+
+        const resolved = resolveActiveCell(state, {
+            tableFrom: doc.indexOf('a1'),
+            section: 'header',
+            row: 0,
+            col: 0,
+        });
+
+        expect(resolved?.tableFrom).toBe(0);
+        expect(state.doc.sliceString(resolved!.contentFrom, resolved!.contentTo)).toBe('H1');
+    });
+
     it('returns null when the logical cell no longer exists in the anchored table', () => {
         const startDoc = ['| H1 | H2 |', '| --- | --- |', '| a1 | a2 |', '| b1 | b2 |'].join('\n');
         const state = createState(startDoc, {

--- a/src/contentScript/__tests__/activeCellState.test.ts
+++ b/src/contentScript/__tests__/activeCellState.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { EditorState } from '@codemirror/state';
+import { activeCellField, getActiveCell, setActiveCellEffect, type ActiveCell } from '../tableState/activeCellState';
+
+const DOC = ['| H1 | H2 |', '| --- | --- |', '| a1 | a2 |'].join('\n');
+
+function headerCell(tableFrom: number): ActiveCell {
+    return { tableFrom, section: 'header', row: 0, col: 0 };
+}
+
+function createState(activeCell: ActiveCell) {
+    const state = EditorState.create({ doc: DOC, extensions: [activeCellField] });
+    return state.update({ effects: setActiveCellEffect.of(activeCell) }).state;
+}
+
+describe('activeCellField', () => {
+    it('maps tableFrom through document changes', () => {
+        const state = createState(headerCell(0));
+
+        const tr = state.update({ changes: { from: 0, to: 0, insert: 'before\n' } });
+
+        expect(getActiveCell(tr.state)?.tableFrom).toBe('before\n'.length);
+    });
+
+    it('drops an anchor pointing past the end of the pre-change document', () => {
+        const state = createState(headerCell(DOC.length + 10));
+
+        const tr = state.update({ changes: { from: 0, to: 0, insert: 'x' } });
+
+        expect(getActiveCell(tr.state)).toBeNull();
+        expect(tr.state.doc.toString()).toBe(`x${DOC}`);
+    });
+
+    it('drops a negative anchor', () => {
+        const state = createState(headerCell(-1));
+
+        const tr = state.update({ changes: { from: 0, to: 0, insert: 'x' } });
+
+        expect(getActiveCell(tr.state)).toBeNull();
+    });
+
+    it('keeps an out-of-range anchor untouched when the document does not change', () => {
+        const state = createState(headerCell(DOC.length + 10));
+
+        const tr = state.update({ selection: { anchor: 1 } });
+
+        expect(getActiveCell(tr.state)?.tableFrom).toBe(DOC.length + 10);
+    });
+});

--- a/src/contentScript/__tests__/cellActivationBoundaries.test.ts
+++ b/src/contentScript/__tests__/cellActivationBoundaries.test.ts
@@ -1,0 +1,53 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { describe, expect, it } from 'vitest';
+import { EditorView } from '@codemirror/view';
+import { activateCellAtPosition } from '../tableRuntime/activeCell/cellActivation';
+import { activeCellField } from '../tableState/activeCellState';
+import { sourceModeField } from '../tableState/sourceMode';
+import { createMarkdownState } from './testMarkdownState';
+
+const TABLE = ['| H1 | H2 |', '| --- | --- |', '| a1 | a2 |'].join('\n');
+
+function withView<T>(doc: string, run: (view: EditorView) => T): T {
+    const parent = document.createElement('div');
+    document.body.appendChild(parent);
+    const view = new EditorView({
+        parent,
+        state: createMarkdownState(doc, [activeCellField, sourceModeField]),
+    });
+
+    try {
+        return run(view);
+    } finally {
+        view.destroy();
+        parent.remove();
+    }
+}
+
+describe('activateCellAtPosition table boundaries', () => {
+    it('activates a cell for a position inside the table', () => {
+        expect(withView(TABLE, (view) => activateCellAtPosition(view, TABLE.indexOf('a1')))).toBe(true);
+    });
+
+    it('activates a cell for a position at the very end of the table', () => {
+        expect(withView(TABLE, (view) => activateCellAtPosition(view, TABLE.length))).toBe(true);
+    });
+
+    it('does not activate a cell for text that Lezer folds into the table node', () => {
+        // Lezer extends a `Table` node over following non-blank lines until a blank line.
+        // Without a containment check against the trimmed range, this position resolves to
+        // the table above and activates one of its cells.
+        const doc = `${TABLE}\ntrailing text`;
+
+        expect(withView(doc, (view) => activateCellAtPosition(view, doc.indexOf('trailing')))).toBe(false);
+    });
+
+    it('does not activate a cell for a position in a separate paragraph', () => {
+        const doc = `${TABLE}\n\nparagraph`;
+
+        expect(withView(doc, (view) => activateCellAtPosition(view, doc.indexOf('paragraph')))).toBe(false);
+    });
+});

--- a/src/contentScript/__tests__/mainEditorGuard.test.ts
+++ b/src/contentScript/__tests__/mainEditorGuard.test.ts
@@ -335,10 +335,15 @@ describe('createMainEditorActiveCellGuard', () => {
     });
 
     it('clears stale active cell when the resolver cannot find the anchored table', () => {
-        const doc = TABLE_DOC;
+        // The anchor must stay inside the document so `activeCellField` keeps it through the
+        // change; an out-of-document anchor is dropped by the field itself and never reaches
+        // the guard. Anchoring into a paragraph is what an active cell looks like after the
+        // table it pointed at is gone.
+        const doc = `${TABLE_DOC}\n\nparagraph`;
         const state = createActiveHeaderState({
+            doc,
             activeCell: headerCell({
-                tableFrom: doc.length + 10,
+                tableFrom: doc.indexOf('paragraph'),
             }),
         });
 

--- a/src/contentScript/__tests__/nestedEditorLifecycle.test.ts
+++ b/src/contentScript/__tests__/nestedEditorLifecycle.test.ts
@@ -650,6 +650,33 @@ describe('nestedEditorLifecycle', () => {
         view.destroy();
     });
 
+    it('rejects a stale active-cell anchor when exiting source mode', () => {
+        const doc = CANONICAL_DOC;
+        let state = createLifecycleState({
+            doc,
+            activeCell: headerCell({ tableFrom: doc.length + 1 }),
+        });
+        state = state.update({ effects: toggleSourceModeEffect.of(true) }).state;
+        const parent = document.createElement('div');
+        document.body.appendChild(parent);
+        const view = new EditorView({ parent, state });
+
+        expect(() =>
+            view.dispatch({
+                effects: [toggleSourceModeEffect.of(false), exitSourceModeEffect.of(undefined)],
+            })
+        ).not.toThrow();
+        flushAnimationFrames();
+
+        expect(activateCellAtPositionMock).toHaveBeenCalledWith(
+            view,
+            view.state.selection.main.head,
+            expect.objectContaining({ preferredActiveCell: null })
+        );
+
+        view.destroy();
+    });
+
     it('closes and clears the active cell when main-editor selection leaves the active table', () => {
         nestedEditorControllerMock.isNestedEditorOpen.mockReturnValue(true);
 

--- a/src/contentScript/__tests__/openCellRequest.test.ts
+++ b/src/contentScript/__tests__/openCellRequest.test.ts
@@ -38,11 +38,14 @@ describe('openCellRequestField', () => {
             extensions: [activeCellField, openCellRequestField],
         });
 
-    const beginRequest = (state: EditorState, params?: { requestId?: string; suppressKeys?: boolean }) =>
+    const beginRequest = (
+        state: EditorState,
+        params?: { requestId?: string; suppressKeys?: boolean; activeCell?: ActiveCell }
+    ) =>
         state.update({
             effects: beginOpenCellRequestEffect.of({
                 requestId: params?.requestId ?? 'request-1',
-                activeCell,
+                activeCell: params?.activeCell ?? activeCell,
                 normalizeIfNeeded: true,
                 suppressKeys: params?.suppressKeys ?? true,
             }),
@@ -99,6 +102,28 @@ describe('openCellRequestField', () => {
         const mapped = state.update({
             changes: { from: 0, to: 1, insert: '' },
         }).state;
+
+        expect(getPendingOpenCellRequest(mapped)).toBeNull();
+    });
+
+    it('drops a request anchored past the end of the pre-change document', () => {
+        const base = createState();
+        const state = beginRequest(base, {
+            activeCell: { ...activeCell, tableFrom: base.doc.length + 10 },
+        });
+
+        // Mapping such an anchor is what `ChangeDesc.mapPos` throws on, so the anchor has to
+        // be rejected before it gets there rather than after.
+        expect(() => state.update({ changes: { from: 0, to: 0, insert: 'x' } })).not.toThrow();
+        expect(getPendingOpenCellRequest(state.update({ changes: { from: 0, to: 0, insert: 'x' } }).state)).toBeNull();
+    });
+
+    it('drops a request with a negative anchor', () => {
+        const state = beginRequest(createState(), {
+            activeCell: { ...activeCell, tableFrom: -1 },
+        });
+
+        const mapped = state.update({ changes: { from: 0, to: 0, insert: 'x' } }).state;
 
         expect(getPendingOpenCellRequest(mapped)).toBeNull();
     });

--- a/src/contentScript/__tests__/runtimeEventClassifier.test.ts
+++ b/src/contentScript/__tests__/runtimeEventClassifier.test.ts
@@ -80,12 +80,16 @@ function dispatchAndCaptureUpdate(params: {
 describe('runtimeEventClassifier', () => {
     it('distinguishes absent and unresolved active cells', () => {
         const absentUpdate = dispatchAndCaptureUpdate({
+            doc: DOC_WITH_SURROUNDING_TEXT,
             dispatch(view) {
                 view.dispatch({ selection: { anchor: 1 } });
             },
         });
+        // Anchored inside the document but outside any table, so the cell is present
+        // yet unresolvable — independent of how out-of-document anchors are handled.
         const unresolvedUpdate = dispatchAndCaptureUpdate({
-            activeCell: { ...getHeaderCell(), tableFrom: 999 },
+            doc: DOC_WITH_SURROUNDING_TEXT,
+            activeCell: getHeaderCell(DOC_WITH_SURROUNDING_TEXT.indexOf('after')),
             dispatch(view) {
                 view.dispatch({ selection: { anchor: 1 } });
             },

--- a/src/contentScript/__tests__/tableResolution.test.ts
+++ b/src/contentScript/__tests__/tableResolution.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { resolveContainingTableAtPos } from '../tableRuntime/tableResolution';
+import { createMarkdownState } from './testMarkdownState';
+
+const TABLE = ['| a | b |', '| --- | --- |', '| c | d |'].join('\n');
+
+describe('resolveContainingTableAtPos', () => {
+    it('resolves a position inside a table', () => {
+        const state = createMarkdownState(TABLE);
+
+        expect(resolveContainingTableAtPos(state, TABLE.indexOf('c'))).toEqual({
+            from: 0,
+            to: TABLE.length,
+            text: TABLE,
+        });
+    });
+
+    it('includes a position exactly at the end of a table node', () => {
+        const state = createMarkdownState(TABLE);
+
+        expect(resolveContainingTableAtPos(state, TABLE.length)).toEqual({
+            from: 0,
+            to: TABLE.length,
+            text: TABLE,
+        });
+    });
+
+    it('includes the trimmed table end before trailing non-table text', () => {
+        const state = createMarkdownState(`${TABLE}\ntrailing text`);
+
+        expect(resolveContainingTableAtPos(state, TABLE.length)?.to).toBe(TABLE.length);
+    });
+
+    it("rejects trailing text included in Lezer's table node", () => {
+        const state = createMarkdownState(`${TABLE}\ntrailing text`);
+        const trailingTextPos = TABLE.length + 1;
+
+        expect(resolveContainingTableAtPos(state, trailingTextPos)).toBeNull();
+    });
+
+    it('returns null outside a table', () => {
+        const prefix = 'before\n\n';
+        const state = createMarkdownState(`${prefix}${TABLE}`);
+
+        expect(resolveContainingTableAtPos(state, 0)).toBeNull();
+    });
+});

--- a/src/contentScript/__tests__/tableResolution.test.ts
+++ b/src/contentScript/__tests__/tableResolution.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { resolveContainingTableAtPos } from '../tableRuntime/tableResolution';
+import { findTableRanges, resolveContainingTableAtPos } from '../tableRuntime/tableResolution';
 import { createMarkdownState } from './testMarkdownState';
 
 const TABLE = ['| a | b |', '| --- | --- |', '| c | d |'].join('\n');
@@ -81,4 +81,49 @@ describe('resolveContainingTableAtPos', () => {
             expect(resolveContainingTableAtPos(state, TABLE.length + 1)).toBeNull();
         });
     });
+
+    /**
+     * Regression coverage for a cursor escaping the table widget after undo.
+     *
+     * Undo can restore the cursor to a table's very last offset. The lifecycle classifier
+     * decided "the cursor is inside a table" from `findTableRanges` containment and scheduled
+     * an activation, but activation resolved the table from the cursor position and got null
+     * there — so nothing was activated and the caret rendered outside the widget. The two
+     * resolvers disagreeing about one position was the whole bug, so pin their agreement
+     * across every offset rather than at hand-picked ones.
+     */
+    describe('agrees with findTableRanges at every document offset', () => {
+        const cases: Record<string, string> = {
+            'a lone table': TABLE,
+            'two tables': TWO_TABLES,
+            'a table with trailing non-table text': `${TABLE}\ntrailing text`,
+            'a table between paragraphs': `before\n\n${TABLE}\n\nafter`,
+            'a document with no table': 'just a paragraph\n\nand another',
+            'a table after a list': `- item\n\n${TABLE}`,
+        };
+
+        for (const [name, doc] of Object.entries(cases)) {
+            it(`agrees for ${name}`, () => {
+                const state = createMarkdownState(doc);
+                const ranges = findTableRanges(state);
+
+                const disagreements: string[] = [];
+                for (let pos = 0; pos <= doc.length; pos++) {
+                    const fromPoint = resolveContainingTableAtPos(state, pos);
+                    const fromScan = ranges.find((table) => pos >= table.from && pos <= table.to) ?? null;
+                    if (fromPoint?.from !== fromScan?.from || fromPoint?.to !== fromScan?.to) {
+                        disagreements.push(
+                            `pos ${pos}: point=${describeRange(fromPoint)} scan=${describeRange(fromScan)}`
+                        );
+                    }
+                }
+
+                expect(disagreements).toEqual([]);
+            });
+        }
+    });
 });
+
+function describeRange(table: { from: number; to: number } | null): string {
+    return table ? `${table.from}-${table.to}` : 'null';
+}

--- a/src/contentScript/__tests__/tableResolution.test.ts
+++ b/src/contentScript/__tests__/tableResolution.test.ts
@@ -3,6 +3,9 @@ import { resolveContainingTableAtPos } from '../tableRuntime/tableResolution';
 import { createMarkdownState } from './testMarkdownState';
 
 const TABLE = ['| a | b |', '| --- | --- |', '| c | d |'].join('\n');
+const SECOND_TABLE = ['| e | f |', '| --- | --- |', '| g | h |'].join('\n');
+const TWO_TABLES = `${TABLE}\n\n${SECOND_TABLE}`;
+const SECOND_TABLE_FROM = TABLE.length + '\n\n'.length;
 
 describe('resolveContainingTableAtPos', () => {
     it('resolves a position inside a table', () => {
@@ -43,5 +46,39 @@ describe('resolveContainingTableAtPos', () => {
         const state = createMarkdownState(`${prefix}${TABLE}`);
 
         expect(resolveContainingTableAtPos(state, 0)).toBeNull();
+    });
+
+    describe('with a second table following', () => {
+        it('resolves the preceding table at its end rather than the table below', () => {
+            const state = createMarkdownState(TWO_TABLES);
+
+            expect(resolveContainingTableAtPos(state, TABLE.length)).toEqual({
+                from: 0,
+                to: TABLE.length,
+                text: TABLE,
+            });
+        });
+
+        it('resolves the second table at its start', () => {
+            const state = createMarkdownState(TWO_TABLES);
+
+            expect(resolveContainingTableAtPos(state, SECOND_TABLE_FROM)).toEqual({
+                from: SECOND_TABLE_FROM,
+                to: SECOND_TABLE_FROM + SECOND_TABLE.length,
+                text: SECOND_TABLE,
+            });
+        });
+
+        it('resolves the second table for a position inside it', () => {
+            const state = createMarkdownState(TWO_TABLES);
+
+            expect(resolveContainingTableAtPos(state, TWO_TABLES.indexOf('g'))?.from).toBe(SECOND_TABLE_FROM);
+        });
+
+        it('returns null on the blank line separating the two tables', () => {
+            const state = createMarkdownState(TWO_TABLES);
+
+            expect(resolveContainingTableAtPos(state, TABLE.length + 1)).toBeNull();
+        });
     });
 });

--- a/src/contentScript/tableRuntime/activeCell/cellActivation.ts
+++ b/src/contentScript/tableRuntime/activeCell/cellActivation.ts
@@ -5,7 +5,7 @@
 import { EditorView } from '@codemirror/view';
 import { clearActiveCellEffect, getActiveCell, type ActiveCell } from '../../tableState/activeCellState';
 import { isSourceModeEnabled } from '../../tableState/sourceMode';
-import { resolveTableAtPos } from '../tableResolution';
+import { resolveContainingTableAtPos } from '../tableResolution';
 import { findCellForPos } from '../../tableModel/markdownTableCellRanges';
 import { buildTableContext } from '../../tableModel/tableContext';
 import { createActiveCellFromRanges } from './activeCellFactory';
@@ -55,7 +55,7 @@ export function activateCellAtPosition(view: EditorView, pos: number, options?: 
         return false;
     }
 
-    const table = resolveTableAtPos(view.state, pos);
+    const table = resolveContainingTableAtPos(view.state, pos);
 
     if (!table) {
         // Position is outside any table
@@ -137,7 +137,7 @@ export function activateTableCell(
     // Don't activate cells in source mode (no widgets exist)
     if (isSourceModeEnabled(view.state)) return;
 
-    const table = resolveTableAtPos(view.state, tableFrom);
+    const table = resolveContainingTableAtPos(view.state, tableFrom);
     if (!table) return;
 
     const ctx = buildTableContext(table);

--- a/src/contentScript/tableRuntime/activeCell/resolvedActiveCell.ts
+++ b/src/contentScript/tableRuntime/activeCell/resolvedActiveCell.ts
@@ -3,7 +3,6 @@ import { StateField } from '@codemirror/state';
 import { activeCellField, getActiveCell, type ActiveCell } from '../../tableState/activeCellState';
 import type { TableContext } from '../../tableModel/tableContext';
 import type { CellCoords } from '../../tableModel/types';
-import { clamp } from '../../shared/numberUtils';
 import { resolveCellDocRange, resolveTableContextAtPos } from '../tableResolution';
 
 export interface ResolvedActiveCell {
@@ -55,12 +54,21 @@ export function resolveCellWithinResolvedTable(
     });
 }
 
-function clampDocPos(state: EditorState, pos: number): number {
-    return clamp(pos, 0, state.doc.length);
-}
-
+/**
+ * An anchor outside the document cannot identify a table. Rejecting it outright keeps
+ * resolution honest: clamping such an anchor to a document edge would resolve it against
+ * whatever happens to sit there, yielding a confident answer for an anchor we know is bad.
+ *
+ * Note this only covers anchors outside the document. An in-range anchor that no longer
+ * points at a table start still resolves to the table containing it, which nested-editor
+ * sessions rely on to recover from document drift.
+ */
 function resolveAnchoredActiveCell(state: EditorState, activeCell: ActiveCell): ResolvedActiveCell | null {
-    const ctx = resolveTableContextAtPos(state, clampDocPos(state, activeCell.tableFrom));
+    if (activeCell.tableFrom < 0 || activeCell.tableFrom > state.doc.length) {
+        return null;
+    }
+
+    const ctx = resolveTableContextAtPos(state, activeCell.tableFrom);
     if (!ctx) {
         return null;
     }

--- a/src/contentScript/tableRuntime/lifecycle/nestedEditorLifecycle.ts
+++ b/src/contentScript/tableRuntime/lifecycle/nestedEditorLifecycle.ts
@@ -3,7 +3,7 @@ import {
     clearActiveCellEffect,
     getActiveCell,
     isSameActiveCell,
-    type ActiveCell,
+    mapActiveCellThroughChanges,
 } from '../../tableState/activeCellState';
 import {
     clearInsertedTableActivationEffect,
@@ -43,22 +43,6 @@ function ensureCursorVisible(view: EditorView): void {
     if (!cursorAbove && !cursorBelow) return;
 
     view.dispatch({ effects: EditorView.scrollIntoView(cursorPos, { y: 'nearest' }) });
-}
-
-function mapActiveCellThroughUpdate(update: ViewUpdate, activeCell: ActiveCell | null): ActiveCell | null {
-    if (!activeCell) {
-        return null;
-    }
-
-    const mappedTableFrom = update.changes.mapPos(activeCell.tableFrom, 1);
-    if (!Number.isFinite(mappedTableFrom) || mappedTableFrom < 0) {
-        return null;
-    }
-
-    return {
-        ...activeCell,
-        tableFrom: mappedTableFrom,
-    };
 }
 
 interface OpenRequestExecutionGuardResult {
@@ -150,7 +134,7 @@ export const nestedEditorLifecyclePlugin = ViewPlugin.fromClass(
 
         private scheduleActivateCellAtCursor(update: ViewUpdate, activateOptions: ActivateCellAtCursorOptions): void {
             const cursorPos = update.state.selection.main.head;
-            const preferredActiveCell = mapActiveCellThroughUpdate(update, getActiveCell(update.startState));
+            const preferredActiveCell = mapActiveCellThroughChanges(getActiveCell(update.startState), update.changes);
 
             requestViewAnimationFrame(this.view, () => {
                 if (!this.view.dom.isConnected) return;

--- a/src/contentScript/tableRuntime/lifecycle/runtimeEventClassifier.ts
+++ b/src/contentScript/tableRuntime/lifecycle/runtimeEventClassifier.ts
@@ -7,7 +7,7 @@ import {
 import { exitSourceModeEffect, isEffectiveRawMode, toggleSourceModeEffect } from '../../tableState/sourceMode';
 import { activateInsertedTableEffect } from '../../tableState/insertedTableActivation';
 import { getResolvedActiveCell, type ResolvedActiveCell } from '../activeCell/resolvedActiveCell';
-import { findTableRanges } from '../tableResolution';
+import { resolveContainingTableAtPos } from '../tableResolution';
 import { hasSyncAnnotation } from '../../shared/transactionUtils';
 import { transactionRequiresTableRebuild } from '../tableTransactionHelpers';
 import { triggerOpenCellRequestEffect } from '../openCellRequest';
@@ -153,7 +153,7 @@ function isSelectionOutsideResolvedTable(update: ViewUpdate, resolvedActiveCell:
 
 function cursorInsideAnyTable(update: ViewUpdate): boolean {
     const cursorPos = update.state.selection.main.head;
-    return findTableRanges(update.state).some((table) => cursorPos >= table.from && cursorPos <= table.to);
+    return resolveContainingTableAtPos(update.state, cursorPos) !== null;
 }
 
 function isUndoRedo(update: ViewUpdate): boolean {

--- a/src/contentScript/tableRuntime/navigation/cursorUtils.ts
+++ b/src/contentScript/tableRuntime/navigation/cursorUtils.ts
@@ -1,10 +1,9 @@
 import { EditorView } from '@codemirror/view';
-import { findTableRanges } from '../tableResolution';
+import { resolveContainingTableAtPos } from '../tableResolution';
 
 export function moveCursorOutOfTable(view: EditorView, offset: number = 1): boolean {
-    const tables = findTableRanges(view.state);
     const cursor = view.state.selection.main.head;
-    const tableContainingCursor = tables.find((t) => cursor >= t.from && cursor <= t.to);
+    const tableContainingCursor = resolveContainingTableAtPos(view.state, cursor);
     if (!tableContainingCursor) {
         return false;
     }

--- a/src/contentScript/tableRuntime/openCellRequest.ts
+++ b/src/contentScript/tableRuntime/openCellRequest.ts
@@ -1,7 +1,7 @@
 import { EditorState, StateEffect, StateField, type ChangeDesc } from '@codemirror/state';
 import { keymap, EditorView, ViewPlugin, ViewUpdate } from '@codemirror/view';
 import { logger } from '../../logger';
-import { setActiveCellEffect, type ActiveCell } from '../tableState/activeCellState';
+import { mapActiveCellThroughChanges, setActiveCellEffect, type ActiveCell } from '../tableState/activeCellState';
 import { clearCellSelectionEffect } from '../tableState/cellSelectionState';
 import type { ResolvedActiveCell } from './activeCell/resolvedActiveCell';
 
@@ -52,6 +52,15 @@ export interface PreparedOpenCellRequestTransaction {
 
 let nextOpenCellRequestId = 1;
 
+/**
+ * Maps a pending request's anchor through a change set, dropping the request when the
+ * anchor can no longer identify the table it was made against.
+ *
+ * The deletion scan is specific to open requests: an anchor sitting inside a deleted range
+ * maps to the deletion point rather than disappearing, so a request whose table was removed
+ * would otherwise survive and reopen against whatever text replaced it. Bounds-safe mapping
+ * is shared with the active-cell field so both agree on which anchors are salvageable.
+ */
 function mapActiveCell(activeCell: ActiveCell, changes: ChangeDesc): ActiveCell | undefined {
     let tableStartDeleted = false;
     changes.iterChangedRanges((fromA, toA) => {
@@ -63,15 +72,8 @@ function mapActiveCell(activeCell: ActiveCell, changes: ChangeDesc): ActiveCell 
         return undefined;
     }
 
-    const tableFrom = changes.mapPos(activeCell.tableFrom, 1);
-    if (!Number.isFinite(tableFrom) || tableFrom < 0) {
-        return undefined;
-    }
-
-    return {
-        ...activeCell,
-        tableFrom,
-    };
+    // `undefined` (not null) is what StateEffect.map needs in order to drop the effect.
+    return mapActiveCellThroughChanges(activeCell, changes) ?? undefined;
 }
 
 function createOpenCellRequestId(): string {

--- a/src/contentScript/tableRuntime/selection/cellSelectionKeymap.ts
+++ b/src/contentScript/tableRuntime/selection/cellSelectionKeymap.ts
@@ -4,7 +4,7 @@ import { clearCellSelectionEffect, getCellSelection } from '../../tableState/cel
 import { getActiveCell } from '../../tableState/activeCellState';
 import { createActiveCellFromRanges } from '../activeCell/activeCellFactory';
 import { extendExistingCellSelection, startCellSelectionFromActiveCell } from './cellSelectionController';
-import { resolveTableAtPos } from '../tableResolution';
+import { resolveContainingTableAtPos } from '../tableResolution';
 import { buildTableContext } from '../../tableModel/tableContext';
 import { canHandleTableSelectionKeydown } from './cellSelectionShortcutScope';
 import { handleSelectionDelete } from './cellSelectionClipboard';
@@ -37,7 +37,7 @@ function activateSelectionFocus(view: EditorView): boolean {
         return false;
     }
 
-    const table = resolveTableAtPos(view.state, selection.tableFrom);
+    const table = resolveContainingTableAtPos(view.state, selection.tableFrom);
     if (!table) {
         return false;
     }

--- a/src/contentScript/tableRuntime/tableResolution.ts
+++ b/src/contentScript/tableRuntime/tableResolution.ts
@@ -33,8 +33,26 @@ export function trimTrailingNonTableLines(text: string): string {
     return lines.join('\n');
 }
 
+function findTableAncestor(node: SyntaxNode): SyntaxNode | null {
+    let current: SyntaxNode | null = node;
+    while (current && current.name !== 'Table') {
+        current = current.parent;
+    }
+    return current?.name === 'Table' ? current : null;
+}
+
+function buildResolvedTable(state: EditorState, node: Pick<SyntaxNode, 'from' | 'to'>): ResolvedTable {
+    const rawText = state.doc.sliceString(node.from, node.to);
+    const text = trimTrailingNonTableLines(rawText);
+    return { from: node.from, to: node.from + text.length, text };
+}
+
+function containsPosition(table: ResolvedTable, pos: number): boolean {
+    return pos >= table.from && pos <= table.to;
+}
+
 /**
- * Resolve the Lezer `Table` node that contains `pos`.
+ * Resolve the Lezer `Table` node at `pos` using forward boundary affinity.
  */
 export function resolveTableAtPos(
     state: EditorState,
@@ -46,20 +64,40 @@ export function resolveTableAtPos(
         return null;
     }
 
-    let node: SyntaxNode | null = tree.resolve(pos, 1);
-    while (node && node.name !== 'Table') {
-        node = node.parent;
-    }
+    const table = findTableAncestor(tree.resolve(pos, 1));
+    return table ? buildResolvedTable(state, table) : null;
+}
 
-    if (!node || node.name !== 'Table') {
+/**
+ * Resolves the table range containing `pos` after applying the same trailing-line
+ * trimming used by full-document table discovery. The second lookup preserves
+ * inclusive containment when `pos` is exactly at the end of a table node.
+ */
+export function resolveContainingTableAtPos(
+    state: EditorState,
+    pos: number,
+    timeoutMs: number = TABLE_SYNTAX_TREE_TIMEOUT_MS
+): ResolvedTable | null {
+    const tree = ensureSyntaxTree(state, pos, timeoutMs);
+    if (!tree) {
         return null;
     }
 
-    const rawText = state.doc.sliceString(node.from, node.to);
-    const text = trimTrailingNonTableLines(rawText);
-    const to = node.from + text.length;
+    const tableAfter = findTableAncestor(tree.resolve(pos, 1));
+    if (tableAfter) {
+        const resolved = buildResolvedTable(state, tableAfter);
+        if (containsPosition(resolved, pos)) {
+            return resolved;
+        }
+    }
 
-    return { from: node.from, to, text };
+    const tableBefore = findTableAncestor(tree.resolve(pos, -1));
+    if (!tableBefore || (tableAfter && tableBefore.from === tableAfter.from && tableBefore.to === tableAfter.to)) {
+        return null;
+    }
+
+    const resolved = buildResolvedTable(state, tableBefore);
+    return containsPosition(resolved, pos) ? resolved : null;
 }
 
 /**
@@ -67,7 +105,6 @@ export function resolveTableAtPos(
  */
 export function findTableRanges(state: EditorState, timeoutMs: number = TABLE_SYNTAX_TREE_TIMEOUT_MS): ResolvedTable[] {
     const tables: ResolvedTable[] = [];
-    const doc = state.doc;
 
     const tree = ensureSyntaxTree(state, state.doc.length, timeoutMs);
     if (!tree) {
@@ -77,10 +114,7 @@ export function findTableRanges(state: EditorState, timeoutMs: number = TABLE_SY
     tree.iterate({
         enter: (node) => {
             if (node.name === 'Table') {
-                const rawText = doc.sliceString(node.from, node.to);
-                const text = trimTrailingNonTableLines(rawText);
-                const to = node.from + text.length;
-                tables.push({ from: node.from, to, text });
+                tables.push(buildResolvedTable(state, node));
             }
         },
     });

--- a/src/contentScript/tableRuntime/tableResolution.ts
+++ b/src/contentScript/tableRuntime/tableResolution.ts
@@ -35,10 +35,11 @@ export function trimTrailingNonTableLines(text: string): string {
 
 function findTableAncestor(node: SyntaxNode): SyntaxNode | null {
     let current: SyntaxNode | null = node;
+    // Exits with either a `Table` node or null once the walk runs off the top of the tree.
     while (current && current.name !== 'Table') {
         current = current.parent;
     }
-    return current?.name === 'Table' ? current : null;
+    return current;
 }
 
 function buildResolvedTable(state: EditorState, node: Pick<SyntaxNode, 'from' | 'to'>): ResolvedTable {

--- a/src/contentScript/tableRuntime/tableResolution.ts
+++ b/src/contentScript/tableRuntime/tableResolution.ts
@@ -82,6 +82,10 @@ export function resolveContainingTableAtPos(
     }
 
     const tableBefore = findTableAncestor(tree.resolve(pos, -1));
+    // The range comparison is an optimization, not a correctness guard: when both lookups
+    // land on the same node, containment was already checked above and failed, so falling
+    // through would return null anyway. Short-circuiting skips a redundant slice and trim
+    // of what may be a large table.
     if (!tableBefore || (tableAfter && tableBefore.from === tableAfter.from && tableBefore.to === tableAfter.to)) {
         return null;
     }

--- a/src/contentScript/tableRuntime/tableResolution.ts
+++ b/src/contentScript/tableRuntime/tableResolution.ts
@@ -52,26 +52,15 @@ function containsPosition(table: ResolvedTable, pos: number): boolean {
 }
 
 /**
- * Resolve the Lezer `Table` node at `pos` using forward boundary affinity.
- */
-export function resolveTableAtPos(
-    state: EditorState,
-    pos: number,
-    timeoutMs: number = TABLE_SYNTAX_TREE_TIMEOUT_MS
-): ResolvedTable | null {
-    const tree = ensureSyntaxTree(state, pos, timeoutMs);
-    if (!tree) {
-        return null;
-    }
-
-    const table = findTableAncestor(tree.resolve(pos, 1));
-    return table ? buildResolvedTable(state, table) : null;
-}
-
-/**
- * Resolves the table range containing `pos` after applying the same trailing-line
- * trimming used by full-document table discovery. The second lookup preserves
- * inclusive containment when `pos` is exactly at the end of a table node.
+ * Resolves the table containing `pos`, or null if `pos` lies outside every table.
+ *
+ * The range returned matches what {@link findTableRanges} reports for the same table, so
+ * point lookups and full-document discovery agree on table boundaries.
+ *
+ * Two tree lookups are needed. The forward lookup misses a table ending exactly at `pos`,
+ * since nothing after `pos` belongs to it; the backward lookup covers that boundary. Each
+ * candidate is containment-checked against the *trimmed* range, because Lezer's `Table`
+ * node can extend past the last real table row.
  */
 export function resolveContainingTableAtPos(
     state: EditorState,
@@ -154,9 +143,9 @@ export function resolveCellDocRange(params: { tableFrom: number; ranges: TableCe
 }
 
 /**
- * Resolve a table at `pos` and build a full TableContext (parsed table + cell ranges).
- * Convenience wrapper combining resolveTableAtPos + buildTableContext.
+ * Resolve the table containing `pos` and build a full TableContext (parsed table + cell ranges).
+ * Convenience wrapper combining resolveContainingTableAtPos + buildTableContext.
  */
 export function resolveTableContextAtPos(state: EditorState, pos: number, timeoutMs?: number): TableContext | null {
-    return resolveTableContextFromResolved(resolveTableAtPos(state, pos, timeoutMs));
+    return resolveTableContextFromResolved(resolveContainingTableAtPos(state, pos, timeoutMs));
 }

--- a/src/contentScript/tableState/activeCellState.ts
+++ b/src/contentScript/tableState/activeCellState.ts
@@ -36,14 +36,16 @@ export const activeCellField = StateField.define<ActiveCell | null>({
         }
 
         if (tr.docChanged) {
-            const mappedTableFrom = tr.changes.mapPos(value.tableFrom, 1);
-            if (!Number.isFinite(mappedTableFrom) || mappedTableFrom < 0) {
+            // `tableFrom` anchors into the pre-transaction document. A stale anchor can fall
+            // outside it, and `mapPos` throws a RangeError for out-of-range positions rather
+            // than returning a sentinel, so drop such anchors before mapping.
+            if (value.tableFrom < 0 || value.tableFrom > tr.startState.doc.length) {
                 return null;
             }
 
             return {
                 ...value,
-                tableFrom: mappedTableFrom,
+                tableFrom: tr.changes.mapPos(value.tableFrom, 1),
             };
         }
 

--- a/src/contentScript/tableState/activeCellState.ts
+++ b/src/contentScript/tableState/activeCellState.ts
@@ -19,7 +19,12 @@ export const clearActiveCellEffect = StateEffect.define<void>();
 
 /**
  * Maps an active-cell anchor from the pre-change document into the changed document.
- * Stale anchors are rejected before `mapPos` can throw for an out-of-range position.
+ *
+ * Stale anchors are rejected up front, before `mapPos` can throw for a position outside
+ * the pre-change document. `Number.isFinite` is load-bearing here: both range comparisons
+ * evaluate false for NaN, so neither one would reject it. Once the anchor is known to be
+ * within `[0, changes.length]`, `mapPos` always returns a finite in-document position, so
+ * the result needs no further checking.
  */
 export function mapActiveCellThroughChanges(activeCell: ActiveCell | null, changes: ChangeDesc): ActiveCell | null {
     if (
@@ -31,8 +36,7 @@ export function mapActiveCellThroughChanges(activeCell: ActiveCell | null, chang
         return null;
     }
 
-    const tableFrom = changes.mapPos(activeCell.tableFrom, 1);
-    return Number.isFinite(tableFrom) && tableFrom >= 0 ? { ...activeCell, tableFrom } : null;
+    return { ...activeCell, tableFrom: changes.mapPos(activeCell.tableFrom, 1) };
 }
 
 export const activeCellField = StateField.define<ActiveCell | null>({

--- a/src/contentScript/tableState/activeCellState.ts
+++ b/src/contentScript/tableState/activeCellState.ts
@@ -1,4 +1,4 @@
-import { EditorState, StateEffect, StateField } from '@codemirror/state';
+import { EditorState, StateEffect, StateField, type ChangeDesc } from '@codemirror/state';
 import type { CellCoords, TableSection } from '../tableModel/types';
 
 export type ActiveCellSection = TableSection;
@@ -16,6 +16,24 @@ export function isSameActiveCell(a: ActiveCell | null, b: ActiveCell | null): bo
 
 export const setActiveCellEffect = StateEffect.define<ActiveCell>();
 export const clearActiveCellEffect = StateEffect.define<void>();
+
+/**
+ * Maps an active-cell anchor from the pre-change document into the changed document.
+ * Stale anchors are rejected before `mapPos` can throw for an out-of-range position.
+ */
+export function mapActiveCellThroughChanges(activeCell: ActiveCell | null, changes: ChangeDesc): ActiveCell | null {
+    if (
+        !activeCell ||
+        !Number.isFinite(activeCell.tableFrom) ||
+        activeCell.tableFrom < 0 ||
+        activeCell.tableFrom > changes.length
+    ) {
+        return null;
+    }
+
+    const tableFrom = changes.mapPos(activeCell.tableFrom, 1);
+    return Number.isFinite(tableFrom) && tableFrom >= 0 ? { ...activeCell, tableFrom } : null;
+}
 
 export const activeCellField = StateField.define<ActiveCell | null>({
     create() {
@@ -36,17 +54,7 @@ export const activeCellField = StateField.define<ActiveCell | null>({
         }
 
         if (tr.docChanged) {
-            // `tableFrom` anchors into the pre-transaction document. A stale anchor can fall
-            // outside it, and `mapPos` throws a RangeError for out-of-range positions rather
-            // than returning a sentinel, so drop such anchors before mapping.
-            if (value.tableFrom < 0 || value.tableFrom > tr.startState.doc.length) {
-                return null;
-            }
-
-            return {
-                ...value,
-                tableFrom: tr.changes.mapPos(value.tableFrom, 1),
-            };
+            return mapActiveCellThroughChanges(value, tr.changes);
         }
 
         return value;


### PR DESCRIPTION
Replace full document scans with a point-based resolver for improved efficiency. Address latent crash bugs by ensuring bounds-checking for anchors and rejecting out-of-document anchors. Unify point resolvers to streamline functionality and resolve issues with undo/redo behavior. Update tests to reflect these changes.