### PR TITLE
fix: failure to render tables when syntax tree parse timeout is exceeded

### DIFF
--- a/src/contentScript/__tests__/tableDecorationField.test.ts
+++ b/src/contentScript/__tests__/tableDecorationField.test.ts
@@ -1,0 +1,49 @@
+import { ensureSyntaxTree } from '@codemirror/language';
+import type { EditorState } from '@codemirror/state';
+import { describe, expect, it, vi } from 'vitest';
+import { tableDecorationField } from '../tableWidget/tableDecorationField';
+import { createMarkdownState } from './testMarkdownState';
+
+const TABLE_COUNT = 5;
+const TABLE = ['| H1 | H2 |', '| --- | --- |', '| a | b |'].join('\n');
+const FILLER = 'lorem ipsum dolor sit amet '.repeat(40);
+const LONG_TABLE_DOCUMENT = Array.from({ length: TABLE_COUNT }, () => `${FILLER}\n\n${TABLE}`).join('\n\n');
+const CLOCK_ADVANCE_MS = 2_000;
+const COMPLETE_PARSE_TIMEOUT_MS = 1_000;
+
+describe('tableDecorationField', () => {
+    it('rebuilds incomplete decorations when parsing finishes without a document change', () => {
+        // CodeMirror checks Date.now between parser steps. Advancing the clock beyond the
+        // production budget on every check forces a deterministic timeout.
+        let now = 0;
+        const dateNow = vi.spyOn(Date, 'now').mockImplementation(() => {
+            now += CLOCK_ADVANCE_MS;
+            return now;
+        });
+
+        let state: EditorState;
+        try {
+            state = createMarkdownState(LONG_TABLE_DOCUMENT, [tableDecorationField]);
+        } finally {
+            dateNow.mockRestore();
+        }
+
+        expect(state.field(tableDecorationField)).toMatchObject({
+            decorations: { size: 0 },
+            treeIncomplete: true,
+        });
+
+        expect(ensureSyntaxTree(state, state.doc.length, COMPLETE_PARSE_TIMEOUT_MS)).not.toBeNull();
+
+        // ensureSyntaxTree advances the shared parse context. A subsequent empty transaction
+        // exposes that completed tree, as CodeMirror's background parser does when it dispatches.
+        const parserUpdate = state.update({});
+        expect(parserUpdate.docChanged).toBe(false);
+        state = parserUpdate.state;
+
+        expect(state.field(tableDecorationField)).toMatchObject({
+            decorations: { size: TABLE_COUNT },
+            treeIncomplete: false,
+        });
+    });
+});

--- a/src/contentScript/__tests__/tableResolution.test.ts
+++ b/src/contentScript/__tests__/tableResolution.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { EditorState } from '@codemirror/state';
 import { findTableRanges, resolveContainingTableAtPos } from '../tableRuntime/tableResolution';
 import { createMarkdownState } from './testMarkdownState';
 
@@ -106,6 +107,9 @@ describe('resolveContainingTableAtPos', () => {
             it(`agrees for ${name}`, () => {
                 const state = createMarkdownState(doc);
                 const ranges = findTableRanges(state);
+                if (!ranges) {
+                    throw new Error('syntax tree unavailable for test document');
+                }
 
                 const disagreements: string[] = [];
                 for (let pos = 0; pos <= doc.length; pos++) {
@@ -121,6 +125,22 @@ describe('resolveContainingTableAtPos', () => {
                 expect(disagreements).toEqual([]);
             });
         }
+    });
+});
+
+describe('findTableRanges', () => {
+    it('returns null when no syntax tree is available', () => {
+        // A state without a markdown language never produces a syntax tree —
+        // the same signal callers see when ensureSyntaxTree times out.
+        const state = EditorState.create({ doc: TABLE });
+
+        expect(findTableRanges(state)).toBeNull();
+    });
+
+    it('returns an empty array for a parsed document without tables', () => {
+        const state = createMarkdownState('just a paragraph');
+
+        expect(findTableRanges(state)).toEqual([]);
     });
 });
 

--- a/src/contentScript/tableRuntime/tableResolution.ts
+++ b/src/contentScript/tableRuntime/tableResolution.ts
@@ -96,13 +96,20 @@ export function resolveContainingTableAtPos(
 
 /**
  * Find all markdown table ranges in the document using the syntax tree.
+ *
+ * Returns `null` (rather than an empty array) when the syntax tree could not be
+ * produced within the timeout, so callers can distinguish "no tables" from
+ * "parse incomplete" and retry once parsing finishes.
  */
-export function findTableRanges(state: EditorState, timeoutMs: number = TABLE_SYNTAX_TREE_TIMEOUT_MS): ResolvedTable[] {
+export function findTableRanges(
+    state: EditorState,
+    timeoutMs: number = TABLE_SYNTAX_TREE_TIMEOUT_MS
+): ResolvedTable[] | null {
     const tables: ResolvedTable[] = [];
 
     const tree = ensureSyntaxTree(state, state.doc.length, timeoutMs);
     if (!tree) {
-        return tables;
+        return null;
     }
 
     tree.iterate({

--- a/src/contentScript/tableWidget/tableDecorationField.ts
+++ b/src/contentScript/tableWidget/tableDecorationField.ts
@@ -1,4 +1,5 @@
 import { EditorState, RangeSetBuilder, StateField } from '@codemirror/state';
+import { syntaxTreeAvailable } from '@codemirror/language';
 import { Decoration, DecorationSet, EditorView } from '@codemirror/view';
 import { logger } from '../../logger';
 import { hashTableText } from '../shared/hashUtils';
@@ -7,14 +8,29 @@ import { findTableRanges } from '../tableRuntime/tableResolution';
 import { TableWidget } from './TableWidget';
 import { decideTableDecorationUpdate } from './tableDecorationPolicy';
 
+interface TableDecorationState {
+    decorations: DecorationSet;
+    /**
+     * True when the last build ran before the document was fully parsed
+     * (ensureSyntaxTree timed out), so tables may be missing. The background
+     * parser dispatches transactions as it progresses; once the full tree is
+     * available, the field rebuilds instead of keeping the incomplete set.
+     */
+    treeIncomplete: boolean;
+}
+
 /**
  * Build decorations for all tables in the document.
  * Tables are always rendered as widgets - editing happens via nested cell editors.
  */
-function buildTableDecorations(state: EditorState): DecorationSet {
-    const decorations = new RangeSetBuilder<Decoration>();
+function buildTableDecorations(state: EditorState): TableDecorationState {
     const tables = findTableRanges(state);
+    if (!tables) {
+        logger.warn('Syntax tree unavailable within timeout; table rendering deferred until parsing completes');
+        return { decorations: Decoration.none, treeIncomplete: true };
+    }
 
+    const decorations = new RangeSetBuilder<Decoration>();
     for (const table of tables) {
         // RangeSetBuilder requires ranges in ascending document order.
         const ctx = buildTableContext(table);
@@ -33,7 +49,7 @@ function buildTableDecorations(state: EditorState): DecorationSet {
         decorations.add(table.from, table.to, decoration);
     }
 
-    return decorations.finish();
+    return { decorations: decorations.finish(), treeIncomplete: false };
 }
 
 /**
@@ -41,24 +57,30 @@ function buildTableDecorations(state: EditorState): DecorationSet {
  * Block decorations MUST be provided via StateField, not ViewPlugin.
  * Tables are always rendered as widgets (unless source mode is toggled).
  */
-export const tableDecorationField = StateField.define<DecorationSet>({
+export const tableDecorationField = StateField.define<TableDecorationState>({
     create(state) {
         logger.info('Table decoration field initialized');
         return buildTableDecorations(state);
     },
-    update(decorations, transaction) {
+    update(value, transaction) {
         const decision = decideTableDecorationUpdate(transaction);
 
         switch (decision.type) {
             case 'noneDecorations':
-                return Decoration.none;
+                return { decorations: Decoration.none, treeIncomplete: false };
             case 'keepDecorations':
-                return decorations;
+                if (value.treeIncomplete && syntaxTreeAvailable(transaction.state)) {
+                    return buildTableDecorations(transaction.state);
+                }
+                return value;
             case 'mapDecorations':
-                return decorations.map(transaction.changes);
+                return {
+                    decorations: value.decorations.map(transaction.changes),
+                    treeIncomplete: value.treeIncomplete,
+                };
             case 'rebuildAllDecorations':
                 return buildTableDecorations(transaction.state);
         }
     },
-    provide: (field) => EditorView.decorations.from(field),
+    provide: (field) => EditorView.decorations.from(field, (value) => value.decorations),
 });


### PR DESCRIPTION
## Background/Issue

When the `ensureSyntaxTree` timeout is exceeded, scrolling does advance the parse. CodeMirror's background ParseWorker reacts to viewport changes (its `update` reschedules work when the viewport moves past the parsed region), so scrolling through the note causes the tree to keep growing during idle time, and the worker dispatches its `Language.setState` transactions as it goes.

**But those transactions would never rebuild the decorations.** They fall through to `keepDecorations`, and the field keeps holding its empty set. The tree being fully available afterward changes nothing, because `buildTableDecorations` only runs again on a decision of `rebuildAllDecorations`, which requires a doc edit, a clear-active-cell effect, an explicit rebuild effect, or a source-mode toggle.

## Changes:

- tableResolution.ts — `findTableRanges` now returns `null` when `ensureSyntaxTree` times out, instead of an empty array, so callers can tell "no tables" apart from "parse incomplete".
- tableDecorationField.ts — the field now stores `{ decorations, treeIncomplete }` instead of a bare `DecorationSet`. When a build hits the timeout, it logs a warning and sets `treeIncomplete`. On subsequent `keepDecorations` transactions — which includes the transactions CodeMirror's background parser dispatches as it makes progress — it checks `syntaxTreeAvailable(state)` (a cheap flag read) and rebuilds once the full tree exists. `mapDecorations` carries the flag forward; entering raw mode clears it, since leaving raw mode already forces a full rebuild. The `provide` uses the two-argument `EditorView.decorations.from(field, getter)` to keep exposing just the decoration set.
- tableResolution.test.ts — added a small `findTableRanges` describe pinning the new contract (`null` when no tree is available, `[]` for a parsed doc without tables), and the existing exhaustive-agreement test now fails loudly if the tree were ever unavailable.

> [!NOTE]
> The background parser only parses to viewport + 100k chars, so in a pathologically large note the rebuild may not trigger until the user scrolls toward the end, but this is far larger than what anyone would reasonably have in a Joplin note.

