### PR TITLE
refactor: data attribute handling and improve test fixtures

### DIFF
--- a/src/contentScript/__tests__/cellContentUtils.test.ts
+++ b/src/contentScript/__tests__/cellContentUtils.test.ts
@@ -3,24 +3,24 @@ import { buildRenderableContent, containsMarkdown, escapeLeadingBlockMarkers } f
 
 describe('escapeLeadingBlockMarkers', () => {
     it('escapes leading heading markers', () => {
-        expect(escapeLeadingBlockMarkers('# Title')).toBe('\\# Title');
-        expect(escapeLeadingBlockMarkers('   ## Title')).toBe('   \\## Title');
+        expect(escapeLeadingBlockMarkers('# Title')).toBe(String.raw`\# Title`);
+        expect(escapeLeadingBlockMarkers('   ## Title')).toBe(String.raw`   \## Title`);
     });
 
     it('escapes leading blockquote markers', () => {
-        expect(escapeLeadingBlockMarkers('> Quote')).toBe('\\> Quote');
-        expect(escapeLeadingBlockMarkers('>Quote')).toBe('\\>Quote');
+        expect(escapeLeadingBlockMarkers('> Quote')).toBe(String.raw`\> Quote`);
+        expect(escapeLeadingBlockMarkers('>Quote')).toBe(String.raw`\>Quote`);
     });
 
     it('escapes leading unordered list markers', () => {
-        expect(escapeLeadingBlockMarkers('- Item')).toBe('\\- Item');
-        expect(escapeLeadingBlockMarkers('* Item')).toBe('\\* Item');
-        expect(escapeLeadingBlockMarkers('+ Item')).toBe('\\+ Item');
+        expect(escapeLeadingBlockMarkers('- Item')).toBe(String.raw`\- Item`);
+        expect(escapeLeadingBlockMarkers('* Item')).toBe(String.raw`\* Item`);
+        expect(escapeLeadingBlockMarkers('+ Item')).toBe(String.raw`\+ Item`);
     });
 
     it('escapes leading ordered list markers', () => {
-        expect(escapeLeadingBlockMarkers('1. Item')).toBe('1\\. Item');
-        expect(escapeLeadingBlockMarkers('12) Item')).toBe('12\\) Item');
+        expect(escapeLeadingBlockMarkers('1. Item')).toBe(String.raw`1\. Item`);
+        expect(escapeLeadingBlockMarkers('12) Item')).toBe(String.raw`12\) Item`);
     });
 
     it('does not escape inline formatting', () => {
@@ -43,7 +43,7 @@ describe('buildRenderableContent', () => {
     it('keeps fallback display text unescaped while escaping the render cache key', () => {
         const result = buildRenderableContent('# Heading');
         expect(result.displayText).toBe('# Heading');
-        expect(result.cacheKey).toBe('\\# Heading');
+        expect(result.cacheKey).toBe(String.raw`\# Heading`);
     });
 
     it('uses the normalized display text as the cache key for reference-looking links', () => {
@@ -53,7 +53,7 @@ describe('buildRenderableContent', () => {
     });
 
     it('unescapes pipes for display and cache lookup', () => {
-        const result = buildRenderableContent('a \\| b');
+        const result = buildRenderableContent(String.raw`a \| b`);
         expect(result.displayText).toBe('a | b');
         expect(result.cacheKey).toBe('a | b');
     });

--- a/src/contentScript/__tests__/cellSelectionClipboard.test.ts
+++ b/src/contentScript/__tests__/cellSelectionClipboard.test.ts
@@ -25,7 +25,12 @@ import {
 } from '../tableRuntime/selection/cellSelectionClipboard';
 import { CLASS_CELL_EDITOR } from '../shared/tableDomClasses';
 
-const doc = ['| H\\|1 | H2 | H3 |', '| :--- | ---: | --- |', '| a | b\\|c |  |', '| x | <br> | z |'].join('\n');
+const doc = [
+    String.raw`| H\|1 | H2 | H3 |`,
+    '| :--- | ---: | --- |',
+    String.raw`| a | b\|c |  |`,
+    '| x | <br> | z |',
+].join('\n');
 
 function selection(anchor: CellSelection['anchor'], focus: CellSelection['focus']): CellSelection {
     return { tableFrom: 0, anchor, focus };
@@ -61,7 +66,7 @@ describe('cellSelectionClipboard', () => {
                 state,
                 selection({ section: 'header', row: 0, col: 0 }, { section: 'header', row: 0, col: 1 })
             )
-        ).toEqual([['H\\|1', 'H2']]);
+        ).toEqual([[String.raw`H\|1`, 'H2']]);
     });
 
     it('extracts body-only selections', () => {
@@ -73,7 +78,7 @@ describe('cellSelectionClipboard', () => {
                 selection({ section: 'body', row: 0, col: 1 }, { section: 'body', row: 1, col: 2 })
             )
         ).toEqual([
-            ['b\\|c', ''],
+            [String.raw`b\|c`, ''],
             ['<br>', 'z'],
         ]);
     });
@@ -88,7 +93,7 @@ describe('cellSelectionClipboard', () => {
             )
         ).toEqual([
             ['H2', 'H3'],
-            ['b\\|c', ''],
+            [String.raw`b\|c`, ''],
         ]);
     });
 
@@ -100,7 +105,7 @@ describe('cellSelectionClipboard', () => {
                 state,
                 selection({ section: 'header', row: 0, col: 0 }, { section: 'body', row: 1, col: 1 })
             )
-        ).toBe(['| H\\|1 | H2 |', '| :--- | ---: |', '| a | b\\|c |', '| x | <br> |'].join('\n'));
+        ).toBe([String.raw`| H\|1 | H2 |`, '| :--- | ---: |', String.raw`| a | b\|c |`, '| x | <br> |'].join('\n'));
     });
 
     it('serializes body-only selections as a valid standalone markdown table', () => {
@@ -111,7 +116,7 @@ describe('cellSelectionClipboard', () => {
                 state,
                 selection({ section: 'body', row: 0, col: 0 }, { section: 'body', row: 1, col: 1 })
             )
-        ).toBe(['| a | b\\|c |', '| --- | --- |', '| x | <br> |'].join('\n'));
+        ).toBe([String.raw`| a | b\|c |`, '| --- | --- |', '| x | <br> |'].join('\n'));
     });
 
     it('serializes vertical single-column selections without turning them into a row', () => {
@@ -197,7 +202,7 @@ describe('cellSelectionClipboard', () => {
 
         expect(rewrite).not.toBeNull();
         expect(rewrite?.tableText).toBe(
-            ['| H\\|1 |  |  |', '| :--- | ---: | --- |', '| a |  |  |', '| x |  |  |'].join('\n')
+            [String.raw`| H\|1 |  |  |`, '| :--- | ---: | --- |', '| a |  |  |', '| x |  |  |'].join('\n')
         );
         expect(rewrite?.selection).toEqual(
             selection({ section: 'header', row: 0, col: 1 }, { section: 'body', row: 1, col: 2 })
@@ -350,7 +355,7 @@ describe('cellSelectionClipboard', () => {
 
         expect(rewrite).not.toBeNull();
         expect(rewrite?.tableText).toBe(
-            ['| H\\|1 | P1 | H3 |', '| :--- | ---: | --- |', '| a | Q1 |  |', '| x | <br> | z |'].join('\n')
+            [String.raw`| H\|1 | P1 | H3 |`, '| :--- | ---: | --- |', '| a | Q1 |  |', '| x | <br> | z |'].join('\n')
         );
         expect(rewrite?.selection).toEqual(
             selection({ section: 'header', row: 0, col: 1 }, { section: 'body', row: 0, col: 1 })
@@ -379,7 +384,7 @@ describe('cellSelectionClipboard', () => {
         expect(rewrite).not.toBeNull();
         expect(rewrite?.tableText).toBe(
             [
-                '| H\\|1 | H2 | H3 |  |',
+                String.raw`| H\|1 | H2 | H3 |  |`,
                 '| :--- | ---: | --- | :---: |',
                 '| a | P1 | P2 | P3 |',
                 '| x | Q1 | Q2 | Q3 |',
@@ -452,7 +457,7 @@ describe('cellSelectionClipboard', () => {
 
         expect(event.preventDefault).toHaveBeenCalledTimes(1);
         expect(mutableView.state.doc.toString()).toBe(
-            ['| H\\|1 | H2 | H3 |', '| :--- | ---: | --- |', '| a | P1 | P2 |', '| x | Q1 | Q2 |'].join('\n')
+            [String.raw`| H\|1 | H2 | H3 |`, '| :--- | ---: | --- |', '| a | P1 | P2 |', '| x | Q1 | Q2 |'].join('\n')
         );
         expect(getActiveCell(mutableView.state)).toBeNull();
         expect(getCellSelection(mutableView.state)).toEqual(
@@ -496,7 +501,7 @@ describe('cellSelectionClipboard', () => {
         ).toBe(true);
 
         expect(mutableView.state.doc.toString()).toBe(
-            ['| H\\|1 | H2 | H3 |', '| :--- | ---: | --- |', '| a | P1 | P2 |', '| x | Q1 | Q2 |'].join('\n')
+            [String.raw`| H\|1 | H2 | H3 |`, '| :--- | ---: | --- |', '| a | P1 | P2 |', '| x | Q1 | Q2 |'].join('\n')
         );
         expect(getActiveCell(mutableView.state)).toBeNull();
         expect(getCellSelection(mutableView.state)).toEqual(

--- a/src/contentScript/__tests__/cellTextCodec.test.ts
+++ b/src/contentScript/__tests__/cellTextCodec.test.ts
@@ -14,13 +14,13 @@ import { MarkdownTable } from '../tableModel/MarkdownTable';
 
 describe('escapeUnescapedPipes', () => {
     it('escapes unescaped pipes', () => {
-        expect(escapeUnescapedPipes('a|b')).toBe('a\\|b');
-        expect(escapeUnescapedPipes('|')).toBe('\\|');
-        expect(escapeUnescapedPipes('a|b|c')).toBe('a\\|b\\|c');
+        expect(escapeUnescapedPipes('a|b')).toBe(String.raw`a\|b`);
+        expect(escapeUnescapedPipes('|')).toBe(String.raw`\|`);
+        expect(escapeUnescapedPipes('a|b|c')).toBe(String.raw`a\|b\|c`);
     });
 
     it('keeps already-escaped pipes intact', () => {
-        expect(escapeUnescapedPipes('a\\|b')).toBe('a\\|b');
+        expect(escapeUnescapedPipes(String.raw`a\|b`)).toBe(String.raw`a\|b`);
     });
 });
 
@@ -41,12 +41,12 @@ describe('normalizeBrTags', () => {
 
 describe('sanitizeLocalText / unsanitizeRootText', () => {
     it('converts local newlines and pipes to markdown-safe cell text', () => {
-        expect(sanitizeLocalText('a\nb|c')).toBe('a<br>b\\|c');
+        expect(sanitizeLocalText('a\nb|c')).toBe(String.raw`a<br>b\|c`);
     });
 
     it('normalizes self-closing br tags before syncing to root text', () => {
-        expect(sanitizeLocalText('a<br/>b|c')).toBe('a<br>b\\|c');
-        expect(sanitizeLocalText('a<br />b|c')).toBe('a<br>b\\|c');
+        expect(sanitizeLocalText('a<br/>b|c')).toBe(String.raw`a<br>b\|c`);
+        expect(sanitizeLocalText('a<br />b|c')).toBe(String.raw`a<br>b\|c`);
     });
 
     it('preserves trailing spaces during live editing sync', () => {
@@ -54,7 +54,7 @@ describe('sanitizeLocalText / unsanitizeRootText', () => {
     });
 
     it('converts root markdown-safe cell text back to local display text', () => {
-        expect(unsanitizeRootText('a<br>b\\|c')).toBe('a\nb|c');
+        expect(unsanitizeRootText(String.raw`a<br>b\|c`)).toBe('a\nb|c');
     });
 });
 
@@ -63,11 +63,11 @@ describe('selection mapping', () => {
         const localText = 'a\nb|c';
         const rootSelection = toRootSelection({ anchor: 0, head: localText.length }, localText);
 
-        expect(rootSelection).toEqual({ anchor: 0, head: 'a<br>b\\|c'.length });
+        expect(rootSelection).toEqual({ anchor: 0, head: String.raw`a<br>b\|c`.length });
     });
 
     it('maps root selection back to local selection', () => {
-        const rootText = 'a<br>b\\|c';
+        const rootText = String.raw`a<br>b\|c`;
         const localSelection = toLocalSelection({ anchor: 0, head: rootText.length }, rootText);
 
         expect(localSelection).toEqual({ anchor: 0, head: 'a\nb|c'.length });
@@ -118,7 +118,7 @@ describe('sanitizeCellChanges', () => {
         const result = sanitizeCellChanges(tr, 2, 4);
         expect(result.rejected).toBe(false);
         expect(result.didModifyInserts).toBe(true);
-        expect(result.changes).toEqual([{ from: 2, to: 2, insert: 'a<br>b\\|c' }]);
+        expect(result.changes).toEqual([{ from: 2, to: 2, insert: String.raw`a<br>b\|c` }]);
     });
 
     it('canonicalizes self-closing br tags during direct main-editor paste', () => {
@@ -133,6 +133,6 @@ describe('sanitizeCellChanges', () => {
         const result = sanitizeCellChanges(tr, 2, 4);
         expect(result.rejected).toBe(false);
         expect(result.didModifyInserts).toBe(true);
-        expect(result.changes).toEqual([{ from: 2, to: 2, insert: 'a<br>b\\|c' }]);
+        expect(result.changes).toEqual([{ from: 2, to: 2, insert: String.raw`a<br>b\|c` }]);
     });
 });

--- a/src/contentScript/__tests__/mainEditorGuard.test.ts
+++ b/src/contentScript/__tests__/mainEditorGuard.test.ts
@@ -112,7 +112,7 @@ describe('createMainEditorActiveCellGuard', () => {
 
         // Simulate pasting "Line1\nLine2|Val" into H1
         const pasteContent = 'Line1\nLine2|Val';
-        const expectedContent = 'Line1<br>Line2\\|Val';
+        const expectedContent = String.raw`Line1<br>Line2\|Val`;
 
         // Insert at start of cell
         const tr = state.update({

--- a/src/contentScript/__tests__/markdownTableCellRanges.test.ts
+++ b/src/contentScript/__tests__/markdownTableCellRanges.test.ts
@@ -38,14 +38,14 @@ describe('computeMarkdownTableCellRanges', () => {
         expect(sliceRange(text, ranges.rows[0][1].from, ranges.rows[0][1].to)).toBe('d');
     });
 
-    it('does not treat escaped pipes (\\|) as delimiters', () => {
-        const text = ['| a\\|b | c |', '| --- | --- |', '| d | e |'].join('\n');
+    it(String.raw`does not treat escaped pipes (\|) as delimiters`, () => {
+        const text = [String.raw`| a\|b | c |`, '| --- | --- |', '| d | e |'].join('\n');
         const ranges = computeMarkdownTableCellRanges(text);
         expect(ranges).not.toBeNull();
         if (!ranges) return;
 
         expect(ranges.headers).toHaveLength(2);
-        expect(sliceRange(text, ranges.headers[0].from, ranges.headers[0].to)).toBe('a\\|b');
+        expect(sliceRange(text, ranges.headers[0].from, ranges.headers[0].to)).toBe(String.raw`a\|b`);
         expect(sliceRange(text, ranges.headers[1].from, ranges.headers[1].to)).toBe('c');
     });
 

--- a/src/contentScript/__tests__/markdownTableRowScanner.test.ts
+++ b/src/contentScript/__tests__/markdownTableRowScanner.test.ts
@@ -11,14 +11,14 @@ describe('scanMarkdownTableRow', () => {
     it('ignores escaped pipes', () => {
         // String is: | a\|b | c |
         // Positions:  0123456789...
-        const line = '| a\\|b | c |';
+        const line = String.raw`| a\|b | c |`;
         const { delimiters } = scanMarkdownTableRow(line);
         expect(delimiters).toEqual([0, 7, 11]);
     });
 
     it('handles escaped backslash before pipe', () => {
         // \\| means escaped backslash followed by unescaped pipe
-        const line = '| a\\\\| b |';
+        const line = String.raw`| a\\| b |`;
         const { delimiters } = scanMarkdownTableRow(line);
         expect(delimiters).toEqual([0, 5, 9]);
     });

--- a/src/contentScript/__tests__/nestedEditorLifecycle.test.ts
+++ b/src/contentScript/__tests__/nestedEditorLifecycle.test.ts
@@ -150,7 +150,6 @@ vi.mock('../nestedEditor/nestedEditorController', () => ({
 }));
 
 describe('nestedEditorLifecycle', () => {
-    const originalRequestAnimationFrame = globalThis.requestAnimationFrame;
     let animationFrameQueue: FrameRequestCallback[] = [];
 
     const flushAnimationFrames = (): void => {
@@ -170,14 +169,14 @@ describe('nestedEditorLifecycle', () => {
         nestedEditorControllerMock.openNestedEditor.mockReturnValue(true);
         nestedEditorControllerMock.isNestedEditorOpen.mockReturnValue(false);
         animationFrameQueue = [];
-        globalThis.requestAnimationFrame = ((callback: FrameRequestCallback) => {
+        vi.stubGlobal('requestAnimationFrame', ((callback: FrameRequestCallback) => {
             animationFrameQueue.push(callback);
             return animationFrameQueue.length;
-        }) as typeof requestAnimationFrame;
+        }) as typeof requestAnimationFrame);
     });
 
     afterEach(() => {
-        globalThis.requestAnimationFrame = originalRequestAnimationFrame;
+        vi.unstubAllGlobals();
         document.body.innerHTML = '';
     });
 

--- a/src/contentScript/__tests__/nestedEditorUndoRegression.test.ts
+++ b/src/contentScript/__tests__/nestedEditorUndoRegression.test.ts
@@ -63,8 +63,6 @@ const TEST_HOST_CONFIG = {
 };
 
 describe('nested editor undo regression', () => {
-    const originalResizeObserver = globalThis.ResizeObserver;
-    const originalRequestAnimationFrame = globalThis.requestAnimationFrame;
     let animationFrameQueue: FrameRequestCallback[] = [];
 
     const flushAnimationFrames = (): void => {
@@ -75,17 +73,16 @@ describe('nested editor undo regression', () => {
     };
 
     beforeEach(() => {
-        globalThis.ResizeObserver = ResizeObserverMock as unknown as typeof ResizeObserver;
+        vi.stubGlobal('ResizeObserver', ResizeObserverMock as unknown as typeof ResizeObserver);
         animationFrameQueue = [];
-        globalThis.requestAnimationFrame = ((callback: FrameRequestCallback) => {
+        vi.stubGlobal('requestAnimationFrame', ((callback: FrameRequestCallback) => {
             animationFrameQueue.push(callback);
             return animationFrameQueue.length;
-        }) as typeof requestAnimationFrame;
+        }) as typeof requestAnimationFrame);
     });
 
     afterEach(() => {
-        globalThis.ResizeObserver = originalResizeObserver;
-        globalThis.requestAnimationFrame = originalRequestAnimationFrame;
+        vi.unstubAllGlobals();
         document.body.innerHTML = '';
     });
 

--- a/src/contentScript/__tests__/tableRuntimePolicies.test.ts
+++ b/src/contentScript/__tests__/tableRuntimePolicies.test.ts
@@ -496,7 +496,7 @@ describe('tableRuntimePolicies', () => {
             throw new Error('Expected sanitize decision');
         }
 
-        expect(decision.selection.main.head).toBe(resolved.editableFrom + 'a<br>b\\|c'.length);
+        expect(decision.selection.main.head).toBe(resolved.editableFrom + String.raw`a<br>b\|c`.length);
     });
 
     it('plans raw mode exit as cursor reactivation', () => {

--- a/src/contentScript/__tests__/tableWidgetInteractions.test.ts
+++ b/src/contentScript/__tests__/tableWidgetInteractions.test.ts
@@ -70,7 +70,11 @@ describe('table widget interactions', () => {
             ],
         });
         const widget = {};
+        // This file runs in the `node` environment, so the anchor is stubbed.
+        // It must mirror every DOM API the link handler reads: `dataset` for
+        // Joplin's internal-link attributes, `getAttribute` for the href.
         const link = {
+            dataset: {} as DOMStringMap,
             getAttribute: vi.fn((name: string) => (name === 'href' ? 'https://example.com' : null)),
         };
         const target = {

--- a/src/contentScript/__tests__/tableWidgetMarkdownRenderer.test.ts
+++ b/src/contentScript/__tests__/tableWidgetMarkdownRenderer.test.ts
@@ -15,14 +15,12 @@ class ResizeObserverMock {
 }
 
 describe('TableWidget markdown rendering', () => {
-    const originalResizeObserver = window.ResizeObserver;
-
     beforeEach(() => {
-        window.ResizeObserver = ResizeObserverMock as unknown as typeof ResizeObserver;
+        vi.stubGlobal('ResizeObserver', ResizeObserverMock as unknown as typeof ResizeObserver);
     });
 
     afterEach(() => {
-        window.ResizeObserver = originalResizeObserver;
+        vi.unstubAllGlobals();
     });
 
     it('uses the markdown renderer supplied by the editor state facet', async () => {

--- a/src/contentScript/tableWidget/cellSelectionVisuals.ts
+++ b/src/contentScript/tableWidget/cellSelectionVisuals.ts
@@ -3,10 +3,10 @@ import { getCellSelection, isCellInRect, toSelectionRect } from '../tableState/c
 import { CLASS_CELL_SELECTED, findTableWidgetElement } from './domHelpers';
 import { makeTableId, type CellCoords } from '../tableModel/types';
 
-function readCoords(cell: Element): CellCoords | null {
-    const section = cell.getAttribute('data-section');
-    const row = Number(cell.getAttribute('data-row'));
-    const col = Number(cell.getAttribute('data-col'));
+function readCoords(cell: HTMLElement): CellCoords | null {
+    const section = cell.dataset.section;
+    const row = Number(cell.dataset.row);
+    const col = Number(cell.dataset.col);
 
     if ((section !== 'header' && section !== 'body') || Number.isNaN(row) || Number.isNaN(col)) {
         return null;
@@ -27,7 +27,9 @@ function collectSelectedCells(view: EditorView): HTMLElement[] {
     }
 
     const rect = toSelectionRect(selection);
-    const cells = widget.querySelectorAll('td[data-section][data-row][data-col], th[data-section][data-row][data-col]');
+    const cells = widget.querySelectorAll<HTMLElement>(
+        'td[data-section][data-row][data-col], th[data-section][data-row][data-col]'
+    );
     const selectedCells: HTMLElement[] = [];
 
     for (const cell of cells) {
@@ -36,7 +38,7 @@ function collectSelectedCells(view: EditorView): HTMLElement[] {
             continue;
         }
 
-        selectedCells.push(cell as HTMLElement);
+        selectedCells.push(cell);
     }
 
     return selectedCells;

--- a/src/contentScript/tableWidget/tableWidgetExtension.ts
+++ b/src/contentScript/tableWidget/tableWidgetExtension.ts
@@ -59,7 +59,7 @@ const tableWidgetInteractionHandlers = EditorView.domEventHandlers({
 /**
  * Content script module export.
  */
-export default function (context: ContentScriptContext) {
+export default function tableWidgetExtension(context: ContentScriptContext) {
     logger.info('Content script loaded');
 
     const joplinBridge = createJoplinBridge(context.postMessage);

--- a/src/contentScript/tableWidget/tableWidgetInteractions.ts
+++ b/src/contentScript/tableWidget/tableWidgetInteractions.ts
@@ -17,13 +17,12 @@ function getLinkHrefFromTarget(target: HTMLElement): string | null {
 
     // Check for Joplin internal link data attributes first
     // renderMarkup converts :/id links to href="#" with data attributes
-    const resourceId = link.getAttribute('data-resource-id');
-    const noteId = link.getAttribute('data-note-id') || link.getAttribute('data-item-id');
-
+    const resourceId = link.dataset.resourceId;
     if (resourceId) {
         return `:/${resourceId}`;
     }
 
+    const noteId = link.dataset.noteId || link.dataset.itemId;
     if (noteId) {
         return `:/${noteId}`;
     }
@@ -52,7 +51,7 @@ function scrollToAnchor(view: EditorView, anchor: string): void {
     if (fnMatch) {
         const label = fnMatch[1];
         // Search for the footnote definition [^label]: in the document
-        const pattern = new RegExp(`^\\s*\\[\\^${escapeRegex(label)}\\]:`, 'i');
+        const pattern = new RegExp(String.raw`^\s*\[\^${escapeRegex(label)}\]:`, 'i');
         const pos = findPatternPosition(view, pattern);
         if (pos !== null) {
             scrollToPosition(view, pos);


### PR DESCRIPTION
Refactor the handling of data attributes using `dataset` for better reliability and readability. Update test fixtures to utilize `String.raw` for improved clarity and prevent issues with escaped characters. Enhance global stubbing in tests to ensure isolation and prevent leaks between test cases.