### PR TITLE
chore: enable eslint-plugin-unicorn with scoped opt-outs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,7 @@ Start here when exploring the codebase:
 - **Sync transactions**: Always use `syncAnnotation` when forwarding changes between main and nested editors. Without it, changes trigger infinite re-render loops.
 - **Block decorations**: Must be provided via `StateField`, not `ViewPlugin`. CodeMirror requires decorations affecting layout to come from state.
 - **Build command**: Use `npm run dist`, not `npm run build` or `npx tsc`.
+- **Runtime baseline is ES2020**: the manifest declares `platforms: ["desktop", "mobile"]` and the build is ts-loader only — no Babel, no polyfills — so everything in `src/` ships verbatim to Joplin's mobile WebView (Android floor: API 24). Do not use `Array#at`, `String#replaceAll`, `Object.hasOwn`, `Promise.withResolvers`, or similar post-ES2020 APIs. `tsconfig` `target` and the unicorn opt-outs in `eslint.config.mjs` enforce this together; change them as a pair.
 
 ## Build, Test, and Development Commands
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,6 +4,7 @@ import js from '@eslint/js';
 import tsParser from '@typescript-eslint/parser';
 import tsPlugin from '@typescript-eslint/eslint-plugin';
 import importPlugin from 'eslint-plugin-import-x';
+import unicorn from 'eslint-plugin-unicorn';
 import prettier from 'eslint-config-prettier';
 import globals from 'globals';
 
@@ -21,6 +22,7 @@ export default [
     },
 
     js.configs.recommended,
+    unicorn.configs.unopinionated,
 
     // Project TS/JS sources
     {
@@ -46,6 +48,41 @@ export default [
             // report an error if any circular dependency is found
             'import/no-cycle': ['error', { maxDepth: Infinity }],
             'no-useless-escape': 'off',
+
+            // --- eslint-plugin-unicorn opt-outs ---
+            //
+            // Group 1: rules that push APIs newer than our runtime baseline.
+            // The manifest declares `platforms: ["desktop", "mobile"]`, and the
+            // build is ts-loader only (no Babel, no polyfills), so anything
+            // these rules suggest ships verbatim to Joplin's mobile WebView.
+            // Joplin's Android floor is API 24, where the system WebView may
+            // predate all of the below. Keep tsconfig `target` at es2020 in
+            // sync with this list.
+            'unicorn/prefer-at': 'off', // Array#at — ES2022 / Chrome 92 / iOS 15.4
+            'unicorn/prefer-string-replace-all': 'off', // String#replaceAll — ES2021
+            'unicorn/prefer-dom-node-replace-children': 'off', // replaceChildren — Chrome 86 / Safari 14
+            'unicorn/prefer-promise-with-resolvers': 'off', // Promise.withResolvers — ES2024
+
+            // Group 2: rules whose output we judged worse than the code it
+            // replaces, or pure churn. Not compatibility-related — revisit
+            // freely if the trade-off reads differently later.
+            //
+            // Rewrites `[a[i], a[j]] = [a[j], a[i]]` into a 3-line temp swap.
+            'unicorn/no-unreadable-array-destructuring': 'off',
+            // Rewrites the literal '   ' into ' '.repeat(3) in test fixtures.
+            'unicorn/prefer-string-repeat': 'off',
+            // Converts short if/else-if chains to switch; the autofix leaves
+            // stray blank lines and `// No default` markers behind.
+            'unicorn/prefer-switch': 'off',
+            // `return undefined` is the clearer form where undefined is a
+            // meaningful sentinel that callers branch on.
+            'unicorn/no-useless-undefined': 'off',
+            // appendChild -> append across ~66 call sites: safe, but no
+            // behavioural or readability gain for the diff it costs.
+            'unicorn/prefer-dom-node-append': 'off',
+            // Flags addEventListener(..., true) but not the matching
+            // removeEventListener, so enabling it guarantees asymmetry.
+            'unicorn/prefer-add-event-listener-options': 'off',
         },
     },
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
                 "eslint": "^10.7.0",
                 "eslint-config-prettier": "^10.1.8",
                 "eslint-plugin-import-x": "^4.17.1",
+                "eslint-plugin-unicorn": "^72.0.0",
                 "fs-extra": "^10.1.0",
                 "glob": "^8.0.3",
                 "globals": "^17.7.0",
@@ -505,6 +506,27 @@
             "engines": {
                 "node": "^20.19.0 || ^22.13.0 || >=24"
             }
+        },
+        "node_modules/@eslint/css-tree": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/@eslint/css-tree/-/css-tree-4.0.5.tgz",
+            "integrity": "sha512-iPmijIAq4hlIJB86PYmY/fcZORHtjphSqICDbwuw32A/JmkhZQ/K/6TjHE03zqf3n5yABpVcbRAMG8Mi9ojy8g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mdn-data": "2.29.0",
+                "source-map-js": "^1.2.1"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.13.0 || >=24"
+            }
+        },
+        "node_modules/@eslint/css-tree/node_modules/mdn-data": {
+            "version": "2.29.0",
+            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.29.0.tgz",
+            "integrity": "sha512-pVxQFCcaYUEAH853+v7yoI/qzhxXSq1bTb9obMYGYAN1c3Hen+XDCEvr296XhstrwlSTNgOR7mCSD4JPjbJe5A==",
+            "dev": true,
+            "license": "CC0-1.0"
         },
         "node_modules/@eslint/js": {
             "version": "10.0.1",
@@ -2887,9 +2909,9 @@
             "license": "MIT"
         },
         "node_modules/baseline-browser-mapping": {
-            "version": "2.10.13",
-            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.13.tgz",
-            "integrity": "sha512-BL2sTuHOdy0YT1lYieUxTw/QMtPBC3pmlJC6xk8BBYVv6vcw3SGdKemQ+Xsx9ik2F/lYDO9tqsFQH1r9PFuHKw==",
+            "version": "2.11.3",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.3.tgz",
+            "integrity": "sha512-sbT0Ui/CZwyAyy7icT1Gw5P1LKRlFaHwaF6tDCW5YHq2X5SeeZFphBuIagopSfwSSZq3sQcbmEL072yphxm7ew==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
@@ -2946,9 +2968,9 @@
             }
         },
         "node_modules/browserslist": {
-            "version": "4.28.2",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
-            "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+            "version": "4.28.7",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.7.tgz",
+            "integrity": "sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==",
             "dev": true,
             "funding": [
                 {
@@ -2966,10 +2988,10 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "baseline-browser-mapping": "^2.10.12",
-                "caniuse-lite": "^1.0.30001782",
-                "electron-to-chromium": "^1.5.328",
-                "node-releases": "^2.0.36",
+                "baseline-browser-mapping": "^2.10.44",
+                "caniuse-lite": "^1.0.30001806",
+                "electron-to-chromium": "^1.5.393",
+                "node-releases": "^2.0.51",
                 "update-browserslist-db": "^1.2.3"
             },
             "bin": {
@@ -2986,10 +3008,23 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/builtin-modules": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-5.3.0.tgz",
+            "integrity": "sha512-hMQUl2bUFG339QygPM97E+mc8OY1IAchORZxm4a/frcYwKzozMzRVDBwHW0NjOqGElLm2O37AVQE8ikxlZHrMQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18.20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001784",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001784.tgz",
-            "integrity": "sha512-WU346nBTklUV9YfUl60fqRbU5ZqyXlqvo1SgigE1OAXK5bFL8LL9q1K7aap3N739l4BvNqnkm3YrGHiY9sfUQw==",
+            "version": "1.0.30001806",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+            "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
             "dev": true,
             "funding": [
                 {
@@ -3034,6 +3069,13 @@
                 "url": "https://github.com/chalk/chalk?sponsor=1"
             }
         },
+        "node_modules/change-case": {
+            "version": "5.4.4",
+            "resolved": "https://registry.npmjs.org/change-case/-/change-case-5.4.4.tgz",
+            "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/chownr": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
@@ -3052,6 +3094,22 @@
             "license": "MIT",
             "engines": {
                 "node": ">=6.0"
+            }
+        },
+        "node_modules/ci-info": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+            "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/sibiraj-s"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/clone-deep": {
@@ -3106,6 +3164,19 @@
                 "node": ">= 12.0.0"
             }
         },
+        "node_modules/convert-hrtime": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/convert-hrtime/-/convert-hrtime-5.0.0.tgz",
+            "integrity": "sha512-lOETlkIeYSJWcbbcvjRKGxVMXJR+8+OQb/mTPbA4ObPMytYIsUbuOE0Jzy60hjARYszq1id0j8KgVhC+WGZVTg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/convert-source-map": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -3135,6 +3206,20 @@
             },
             "peerDependencies": {
                 "webpack": "^5.1.0"
+            }
+        },
+        "node_modules/core-js-compat": {
+            "version": "3.49.0",
+            "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.49.0.tgz",
+            "integrity": "sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "browserslist": "^4.28.1"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/core-js"
             }
         },
         "node_modules/crelt": {
@@ -3218,6 +3303,19 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/detect-indent": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-7.0.2.tgz",
+            "integrity": "sha512-y+8xyqdGLL+6sh0tVeHcfP/QDd8gUgbasolJJpY7NgeQGSZ739bDtSiaiDgtoicy+mtYB81dKLxO9xRhCyIB3A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/detect-libc": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -3238,9 +3336,9 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.331",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.331.tgz",
-            "integrity": "sha512-IbxXrsTlD3hRodkLnbxAPP4OuJYdWCeM3IOdT+CpcMoIwIoDfCmRpEtSPfwBXxVkg9xmBeY7Lz2Eo2TDn/HC3Q==",
+            "version": "1.5.396",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.396.tgz",
+            "integrity": "sha512-yHiw2Y3C3H9U6TMbOfoWK/BPreiOPXRfTWPBwQBoZG6/8TB6eOPnsy5oaRYuatR7Fw2SJ4kKforgufeo7fq0EQ==",
             "dev": true,
             "license": "ISC"
         },
@@ -3256,6 +3354,19 @@
             },
             "engines": {
                 "node": ">=10.13.0"
+            }
+        },
+        "node_modules/entities": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+            "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=0.12"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
             }
         },
         "node_modules/envinfo": {
@@ -3436,6 +3547,44 @@
                 "eslint-import-resolver-node": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/eslint-plugin-unicorn": {
+            "version": "72.0.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-72.0.0.tgz",
+            "integrity": "sha512-hqO6ksoOHO+ZhdseTuKRVQbx9U7PRO/cv8qAR1mctwzdVO2hYud8uS9luAhp43RJgziYgHAph8eHyipT8GL0ng==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@eslint-community/eslint-utils": "^4.9.1",
+                "@eslint/css-tree": "^4.0.4",
+                "browserslist": "^4.28.4",
+                "change-case": "^5.4.4",
+                "ci-info": "^4.4.0",
+                "core-js-compat": "^3.49.0",
+                "detect-indent": "^7.0.2",
+                "entities": "^4.5.0",
+                "find-up-simple": "^1.0.1",
+                "globals": "^17.7.0",
+                "indent-string": "^5.0.0",
+                "is-builtin-module": "^5.0.0",
+                "is-identifier": "^1.1.0",
+                "pluralize": "^8.0.0",
+                "quote-js-string": "^0.1.0",
+                "regjsparser": "^0.13.2",
+                "reserved-identifiers": "^1.2.0",
+                "semver": "^7.8.5",
+                "strip-indent": "^4.1.1",
+                "yaml": "^2.9.0"
+            },
+            "engines": {
+                "node": ">=22"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/eslint-plugin-unicorn?sponsor=1"
+            },
+            "peerDependencies": {
+                "eslint": ">=10.4"
             }
         },
         "node_modules/eslint-scope": {
@@ -3696,6 +3845,19 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/find-up-simple": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/find-up-simple/-/find-up-simple-1.0.1.tgz",
+            "integrity": "sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/flat": {
             "version": "5.0.2",
             "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
@@ -3788,6 +3950,19 @@
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/function-timeout": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/function-timeout/-/function-timeout-1.0.2.tgz",
+            "integrity": "sha512-939eZS4gJ3htTHAldmyyuzlrD58P03fHG49v2JfFXbV6OhvZKRC9j2yAtdHw/zrp2zXHuv05zMIy40F0ge7spA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/get-tsconfig": {
@@ -3923,6 +4098,22 @@
                 "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
             }
         },
+        "node_modules/identifier-regex": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/identifier-regex/-/identifier-regex-1.1.0.tgz",
+            "integrity": "sha512-SLX4H/vtcYlYnL7XqnuJKHU7Z8517TgsW9nmQiGOgMCjQ8V/deLYu6bEmbGoXe7WMMhc9+EUGyFFneHja8KabA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "reserved-identifiers": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/ignore": {
             "version": "5.3.2",
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3963,6 +4154,19 @@
                 "node": ">=0.8.19"
             }
         },
+        "node_modules/indent-string": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+            "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/inflight": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -3990,6 +4194,22 @@
             "license": "MIT",
             "engines": {
                 "node": ">=10.13.0"
+            }
+        },
+        "node_modules/is-builtin-module": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-5.0.0.tgz",
+            "integrity": "sha512-f4RqJKBUe5rQkJ2eJEJBXSticB3hGbN9j0yxxMQFqIW89Jp9WYFtzfTcRlstDKVUTRzSOTLKRfO9vIztenwtxA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "builtin-modules": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18.20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/is-core-module": {
@@ -4029,6 +4249,23 @@
             },
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/is-identifier": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-identifier/-/is-identifier-1.1.0.tgz",
+            "integrity": "sha512-NhOds0mDx9lJu+1lBRO0xbwFo5nobA7GCk/0e5xjr6+6XugX985+0OyGX35BNrTkPAsdLcIKg02HUQJOK8D8kw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "identifier-regex": "^1.1.0",
+                "super-regex": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/is-number": {
@@ -4163,6 +4400,19 @@
             },
             "funding": {
                 "url": "https://github.com/inikulin/parse5?sponsor=1"
+            }
+        },
+        "node_modules/jsesc": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+            "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "jsesc": "bin/jsesc"
+            },
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/json-buffer": {
@@ -4611,6 +4861,24 @@
                 "@jridgewell/sourcemap-codec": "^1.5.5"
             }
         },
+        "node_modules/make-asynchronous": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/make-asynchronous/-/make-asynchronous-1.1.0.tgz",
+            "integrity": "sha512-ayF7iT+44LXdxJLTrTd3TLQpFDDvPCBxXxbv+pMUSuHA5Q8zyAfwkRP6aHHwNVFBUFWtxAHqwNJxF8vMZLAbVg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "p-event": "^6.0.0",
+                "type-fest": "^4.6.0",
+                "web-worker": "^1.5.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/mdn-data": {
             "version": "2.27.1",
             "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
@@ -4780,11 +5048,14 @@
             }
         },
         "node_modules/node-releases": {
-            "version": "2.0.37",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
-            "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
+            "version": "2.0.51",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
+            "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
         },
         "node_modules/normalize-path": {
             "version": "3.0.0",
@@ -4907,6 +5178,22 @@
                 "@oxc-resolver/binding-win32-x64-msvc": "11.24.2"
             }
         },
+        "node_modules/p-event": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/p-event/-/p-event-6.0.1.tgz",
+            "integrity": "sha512-Q6Bekk5wpzW5qIyUP4gdMEujObYstZl6DMMOSenwBvV0BlE5LkDwkjs5yHbZmdCEq2o4RJx4tE1vwxFVf2FG1w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "p-timeout": "^6.1.2"
+            },
+            "engines": {
+                "node": ">=16.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/p-limit": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -4934,6 +5221,19 @@
             },
             "engines": {
                 "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/p-timeout": {
+            "version": "6.1.4",
+            "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.4.tgz",
+            "integrity": "sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.16"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -5072,6 +5372,16 @@
                 "node": ">=8"
             }
         },
+        "node_modules/pluralize": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+            "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/postcss": {
             "version": "8.5.16",
             "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
@@ -5137,6 +5447,19 @@
                 "node": ">=6"
             }
         },
+        "node_modules/quote-js-string": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/quote-js-string/-/quote-js-string-0.1.0.tgz",
+            "integrity": "sha512-Y3NoRtprEEZQD8RfxMCfS0ZTqc4e+i18OrXEXAvpM6TfC/3y+0L5rNbZiSnbBBEkDfFzbpd8o+cE8q3/anjMGA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=22"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/quote-js-string?sponsor=1"
+            }
+        },
         "node_modules/rechoir": {
             "version": "0.8.0",
             "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.8.0.tgz",
@@ -5150,6 +5473,19 @@
                 "node": ">= 10.13.0"
             }
         },
+        "node_modules/regjsparser": {
+            "version": "0.13.2",
+            "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.13.2.tgz",
+            "integrity": "sha512-NgRBy2Nx/bE+9F27nVHnqcN5HjyLmecqsqx2PJHu3/IEtADD4WuxuXIVExD5PoSDFVrl78dOonfcOe5O+5nbzQ==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "jsesc": "~3.1.0"
+            },
+            "bin": {
+                "regjsparser": "bin/parser"
+            }
+        },
         "node_modules/require-from-string": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -5158,6 +5494,19 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/reserved-identifiers": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/reserved-identifiers/-/reserved-identifiers-1.2.0.tgz",
+            "integrity": "sha512-yE7KUfFvaBFzGPs5H3Ops1RevfUEsDc5Iz65rOwWg4lE8HJSYtle77uul3+573457oHvBKuHYDl/xqUkKpEEdw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/resolve": {
@@ -5329,9 +5678,9 @@
             "license": "MIT"
         },
         "node_modules/semver": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-            "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+            "version": "7.8.5",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+            "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -5451,11 +5800,42 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/strip-indent": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-4.1.1.tgz",
+            "integrity": "sha512-SlyRoSkdh1dYP0PzclLE7r0M9sgbFKKMFXpFRUMNuKhQSbC6VQIGzq3E0qsfvGJaUFJPGv6Ws1NZ/haTAjfbMA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/style-mod": {
             "version": "4.1.3",
             "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
             "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
             "license": "MIT"
+        },
+        "node_modules/super-regex": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/super-regex/-/super-regex-1.1.0.tgz",
+            "integrity": "sha512-WHkws2ZflZe41zj6AolvvmaTrWds/VuyeYr9iPVv/oQeaIoVxMKaushfFWpOGDT+GuBrM/sVqF8KUCYQlSSTdQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "function-timeout": "^1.0.1",
+                "make-asynchronous": "^1.0.1",
+                "time-span": "^5.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
         },
         "node_modules/supports-color": {
             "version": "7.2.0",
@@ -5626,6 +6006,22 @@
                 "source-map": "^0.6.0"
             }
         },
+        "node_modules/time-span": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/time-span/-/time-span-5.1.0.tgz",
+            "integrity": "sha512-75voc/9G4rDIJleOo4jPvN4/YC4GRZrY8yy1uU4lwrB3XEQbWve8zXoO5No4eFrGcTAMYyoY67p8jRQdtA1HbA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "convert-hrtime": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/tinybench": {
             "version": "2.9.0",
             "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -5792,6 +6188,19 @@
             },
             "engines": {
                 "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/type-fest": {
+            "version": "4.41.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+            "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+            "dev": true,
+            "license": "(MIT OR CC0-1.0)",
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/typescript": {
@@ -6131,6 +6540,13 @@
             "engines": {
                 "node": ">=10.13.0"
             }
+        },
+        "node_modules/web-worker": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.5.0.tgz",
+            "integrity": "sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==",
+            "dev": true,
+            "license": "Apache-2.0"
         },
         "node_modules/webidl-conversions": {
             "version": "8.0.1",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
         "eslint": "^10.7.0",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-import-x": "^4.17.1",
+        "eslint-plugin-unicorn": "^72.0.0",
         "fs-extra": "^10.1.0",
         "glob": "^8.0.3",
         "globals": "^17.7.0",

--- a/src/contentScript/__tests__/htmlPostProcessor.test.ts
+++ b/src/contentScript/__tests__/htmlPostProcessor.test.ts
@@ -46,8 +46,7 @@ describe('postProcessHtml', () => {
     });
 
     test('converts footnote refs in text nodes but not inside code/pre', () => {
-        const html =
-            '<div>' + 'Before [^abc] after' + '<code>code [^nope]</code>' + '<pre>pre [^nope2]</pre>' + '</div>';
+        const html = '<div>Before [^abc] after<code>code [^nope]</code><pre>pre [^nope2]</pre></div>';
 
         const result = postProcessHtml(html);
         const doc = parseHtml(result);

--- a/src/contentScript/__tests__/tableDecorationField.test.ts
+++ b/src/contentScript/__tests__/tableDecorationField.test.ts
@@ -8,8 +8,8 @@ const TABLE_COUNT = 5;
 const TABLE = ['| H1 | H2 |', '| --- | --- |', '| a | b |'].join('\n');
 const FILLER = 'lorem ipsum dolor sit amet '.repeat(40);
 const LONG_TABLE_DOCUMENT = Array.from({ length: TABLE_COUNT }, () => `${FILLER}\n\n${TABLE}`).join('\n\n');
-const CLOCK_ADVANCE_MS = 2_000;
-const COMPLETE_PARSE_TIMEOUT_MS = 1_000;
+const CLOCK_ADVANCE_MS = 2000;
+const COMPLETE_PARSE_TIMEOUT_MS = 1000;
 
 describe('tableDecorationField', () => {
     it('rebuilds incomplete decorations when parsing finishes without a document change', () => {

--- a/src/contentScript/__tests__/tableNavigation.test.ts
+++ b/src/contentScript/__tests__/tableNavigation.test.ts
@@ -74,8 +74,8 @@ describe('navigateCell', () => {
     const getBeginRequestValue = () => getEffects().find((effect) => effect.is?.(beginOpenCellRequestEffect))?.value;
 
     const setupTable = (rows: number, cols: number) => {
-        const headers = Array(cols).fill({});
-        const bodyRows = Array(rows).fill(Array(cols).fill({}));
+        const headers = Array.from({ length: cols }, () => ({}));
+        const bodyRows = Array.from({ length: rows }, () => Array.from({ length: cols }, () => ({})));
         currentCtx = {
             from: 0,
             to: 100,

--- a/src/contentScript/__tests__/tableToolbarPlugin.test.ts
+++ b/src/contentScript/__tests__/tableToolbarPlugin.test.ts
@@ -72,9 +72,12 @@ function createResolvedCell(activeCell: ActiveCell): ResolvedActiveCell {
 }
 
 function getToolbarButton(plugin: TableToolbarPlugin, ariaLabel: string): HTMLButtonElement {
+    // jsdom does not expose a global `CSS`, and the labels here are test-owned
+    // literals with no characters needing escaping.
+    // eslint-disable-next-line unicorn/require-css-escape
     const button = plugin.dom.querySelector(`button[aria-label="${ariaLabel}"]`);
     if (!(button instanceof HTMLButtonElement)) {
-        throw new Error(`Missing toolbar button: ${ariaLabel}`);
+        throw new TypeError(`Missing toolbar button: ${ariaLabel}`);
     }
 
     return button;
@@ -87,7 +90,7 @@ function setCurrentActiveCell(plugin: TableToolbarPlugin, cell: ActiveCell): voi
 function createToolbarButtons(plugin: TableToolbarPlugin): void {
     const createButtons = Reflect.get(plugin as unknown as object, 'createButtons');
     if (typeof createButtons !== 'function') {
-        throw new Error('Missing createButtons on toolbar plugin');
+        throw new TypeError('Missing createButtons on toolbar plugin');
     }
 
     createButtons.call(plugin);

--- a/src/contentScript/editorBridge/cellTextCodec.ts
+++ b/src/contentScript/editorBridge/cellTextCodec.ts
@@ -17,7 +17,7 @@ export interface SanitizeChangesResult {
     changes: SimpleChange[];
 }
 
-const SELECTION_MARK = '\u0000';
+const SELECTION_MARK = '\u{0}';
 const UNESCAPED_PIPE_PATTERN = /(?<!\\)(\\\\)*\|/g;
 const LINE_BREAK_PATTERN = /\r\n|\n|\r/g;
 
@@ -39,7 +39,7 @@ function escapeUnescapedPipesWithContext(text: string, precedingBackslashes: num
 
         if (ch === '|') {
             const isAlreadyEscaped = backslashRun % 2 === 1;
-            result += isAlreadyEscaped ? '|' : '\\|';
+            result += isAlreadyEscaped ? '|' : String.raw`\|`;
             backslashRun = 0;
             continue;
         }
@@ -56,11 +56,17 @@ export function convertNewlinesToBr(text: string): string {
 }
 
 export function unsanitizeRootText(rootText: string): string {
-    return rootText.split('<br>').join('\n').split('\\|').join('|');
+    return rootText
+        .split('<br>')
+        .join('\n')
+        .split(String.raw`\|`)
+        .join('|');
 }
 
 export function sanitizeLocalText(localText: string): string {
-    return normalizeBrTags(localText).replace(LINE_BREAK_PATTERN, '<br>').replace(UNESCAPED_PIPE_PATTERN, '\\$&');
+    return normalizeBrTags(localText)
+        .replace(LINE_BREAK_PATTERN, '<br>')
+        .replace(UNESCAPED_PIPE_PATTERN, String.raw`\$&`);
 }
 
 function toSpan(selection: LocalSelection): { from: number; to: number; forward: boolean } {
@@ -88,7 +94,7 @@ function mapSelectionThroughTransform(
     const transformed = transform(marked);
     const mappedFrom = transformed.indexOf(SELECTION_MARK);
     const mappedTo = transformed.lastIndexOf(SELECTION_MARK) - 1;
-    if (mappedFrom < 0 || mappedTo < -1) {
+    if (mappedFrom === -1 || mappedTo < -1) {
         return { anchor: 0, head: 0 };
     }
 

--- a/src/contentScript/nestedEditor/nestedEditorController.ts
+++ b/src/contentScript/nestedEditor/nestedEditorController.ts
@@ -252,9 +252,7 @@ class NestedEditorController {
             const { displayText, cacheKey } = buildRenderableContent(cellText);
             const cached = renderer.getCached(cacheKey);
 
-            if (cached !== undefined) {
-                this.contentEl.innerHTML = cached;
-            } else {
+            if (cached === undefined) {
                 this.contentEl.innerHTML = escapeHtmlPreservingBr(displayText);
                 if (containsMarkdown(cacheKey)) {
                     const contentEl = this.contentEl;
@@ -269,6 +267,8 @@ class NestedEditorController {
                             logger.error('Failed to render nested editor markdown:', error);
                         });
                 }
+            } else {
+                this.contentEl.innerHTML = cached;
             }
         }
 

--- a/src/contentScript/services/htmlPostProcessor.ts
+++ b/src/contentScript/services/htmlPostProcessor.ts
@@ -18,20 +18,26 @@ function cleanupAndOptimizeHtml(html: string): string {
     template.innerHTML = html;
 
     // Remove Joplin source blocks
-    template.content.querySelectorAll('.joplin-source').forEach((el) => el.remove());
+    for (const element of template.content.querySelectorAll('.joplin-source')) {
+        element.remove();
+    }
 
     // Joplin resource links sometimes render an icon span that depends on editor-global
     // font/icon CSS (e.g. Font Awesome). Inside table cells this can degrade into a
     // broken glyph (often a question mark). Remove the icon element but keep the
     // resource link text and any placeholders.
-    template.content.querySelectorAll('.resource-icon').forEach((el) => el.remove());
+    for (const element of template.content.querySelectorAll('.resource-icon')) {
+        element.remove();
+    }
 
     // Optimize KaTeX: Replace HTML/CSS representation with clean MathML
-    template.content.querySelectorAll('.katex').forEach((katexElement) => {
+    for (const katexElement of template.content.querySelectorAll('.katex')) {
         const math = katexElement.querySelector('math');
         if (math) {
             // Remove annotations (often contains raw TeX)
-            math.querySelectorAll('annotation').forEach((ann) => ann.remove());
+            for (const annotation of math.querySelectorAll('annotation')) {
+                annotation.remove();
+            }
 
             // Remove direct text node children of <math> - these are accessibility fallback
             // text that becomes visible when extracted from the hidden .katex-mathml span
@@ -49,7 +55,7 @@ function cleanupAndOptimizeHtml(html: string): string {
                 katexElement.replaceWith(math);
             }
         }
-    });
+    }
 
     return template.innerHTML;
 }

--- a/src/contentScript/services/htmlSanitizer.ts
+++ b/src/contentScript/services/htmlSanitizer.ts
@@ -30,14 +30,22 @@ function isAllowedYouTubeEmbedSrc(src: string): boolean {
 
 /**
  * Configure DOMPurify hooks once globally to avoid re-adding them on every render.
+ *
+ * Deliberately registered at module load: the hook enforces the iframe
+ * allowlist, so it must be in place before any caller can reach
+ * DOMPurify.sanitize. Deferring it behind an init function would make the
+ * security property depend on every call site remembering to trigger it.
  */
+// eslint-disable-next-line unicorn/no-top-level-side-effects
 DOMPurify.addHook('afterSanitizeElements', (node) => {
     // Only allow trusted YouTube embed iframes; remove everything else.
-    if (node instanceof Element && node.tagName === 'IFRAME') {
-        const src = node.getAttribute('src');
-        if (!src || !isAllowedYouTubeEmbedSrc(src)) {
-            node.remove();
-        }
+    if (!(node instanceof Element && node.tagName === 'IFRAME')) {
+        return;
+    }
+
+    const src = node.getAttribute('src');
+    if (!src || !isAllowedYouTubeEmbedSrc(src)) {
+        node.remove();
     }
 });
 

--- a/src/contentScript/services/linkOpener.ts
+++ b/src/contentScript/services/linkOpener.ts
@@ -8,6 +8,10 @@ export interface LinkOpener {
 export function createLinkOpener(openLink: (href: string) => Promise<void>): LinkOpener {
     return {
         open(href) {
+            // Fire-and-forget by design: `open` is declared void so DOM event
+            // handlers can call it without awaiting. Making this async would
+            // return a promise nobody consumes.
+            // eslint-disable-next-line unicorn/prefer-await
             openLink(href).catch((error) => {
                 logger.error('Failed to open link:', error);
             });

--- a/src/contentScript/shared/cellContentUtils.ts
+++ b/src/contentScript/shared/cellContentUtils.ts
@@ -41,7 +41,7 @@ export function escapeLeadingBlockMarkers(text: string): string {
     }
 
     // Blockquote: "> " (space optional)
-    if (/^>/.test(rest)) {
+    if (rest.startsWith('>')) {
         return `${leading}\\${rest}`;
     }
 

--- a/src/contentScript/shared/domContext.ts
+++ b/src/contentScript/shared/domContext.ts
@@ -5,6 +5,10 @@ function getNodeDocument(node: Node): Document {
 }
 
 export function getDocumentWindow(doc: Document): Window {
+    // `globalThis` is typed as `typeof globalThis`, which is not assignable to
+    // `Window` (it lacks `name`). The alternatives are a double cast that
+    // defeats type checking, or this.
+    // eslint-disable-next-line unicorn/prefer-global-this
     return doc.defaultView ?? window;
 }
 

--- a/src/contentScript/shared/hashUtils.ts
+++ b/src/contentScript/shared/hashUtils.ts
@@ -3,10 +3,14 @@
  * Fast, simple, and provides reasonable distribution for short strings.
  */
 function fnv1aHash(text: string): number {
-    let hash = 2166136261;
+    let hash = 2_166_136_261;
     for (let i = 0; i < text.length; i++) {
+        // FNV-1a is defined over code units, and this runs once per table on
+        // every decoration rebuild. Iterating code points instead would mean
+        // allocating a string per character in a hot path.
+        // eslint-disable-next-line unicorn/prefer-code-point
         hash ^= text.charCodeAt(i);
-        hash = Math.imul(hash, 16777619);
+        hash = Math.imul(hash, 16_777_619);
     }
     return hash >>> 0; // Convert to unsigned 32-bit
 }

--- a/src/contentScript/shared/transactionUtils.ts
+++ b/src/contentScript/shared/transactionUtils.ts
@@ -2,7 +2,7 @@ import { Transaction } from '@codemirror/state';
 import { syncAnnotation } from '../editorBridge/syncAnnotation';
 
 export function hasSyncAnnotation(transactions: readonly Transaction[]): boolean {
-    return transactions.some((tr) => Boolean(tr.annotation(syncAnnotation)));
+    return transactions.some((tr) => tr.annotation(syncAnnotation));
 }
 
 /**

--- a/src/contentScript/tableModel/MarkdownTable.ts
+++ b/src/contentScript/tableModel/MarkdownTable.ts
@@ -68,7 +68,7 @@ function padArrayToLength<T>(arr: readonly T[], length: number, filler: T): T[] 
         return [...arr];
     }
 
-    return [...arr, ...new Array(length - arr.length).fill(filler)];
+    return [...arr, ...Array.from({ length: length - arr.length }, () => filler)];
 }
 
 function getColumnCount(
@@ -98,7 +98,7 @@ function normalizeState(input: {
 }
 
 function createEmptyRow(columnCount: number): string[] {
-    return new Array(columnCount).fill('');
+    return Array.from({ length: columnCount }, () => '');
 }
 
 function cloneUnifiedRows(headers: readonly string[], rows: readonly (readonly string[])[]): string[][] {
@@ -485,7 +485,7 @@ export class MarkdownTable {
         }
 
         while (nextRows.length < requiredRowCount) {
-            nextRows.push(new Array(requiredColCount).fill(''));
+            nextRows.push(Array.from({ length: requiredColCount }, () => ''));
         }
 
         for (let row = 0; row < nextRows.length; row++) {

--- a/src/contentScript/tableModel/markdownTableCellRanges.ts
+++ b/src/contentScript/tableModel/markdownTableCellRanges.ts
@@ -175,11 +175,11 @@ export function computeMarkdownTableCellRanges(text: string): TableCellRanges | 
     }
 
     const headerLine = lines[0];
-    const separatorLine = lines[1];
-
     if (!headerLine.line.includes('|')) {
         return null;
     }
+
+    const separatorLine = lines[1];
     if (!isSeparatorRow(separatorLine.line)) {
         return null;
     }

--- a/src/contentScript/tableModel/markdownTableRowScanner.ts
+++ b/src/contentScript/tableModel/markdownTableRowScanner.ts
@@ -21,13 +21,12 @@ export function scanMarkdownTableRow(line: string): TableRowScanResult {
     let isEscaped = false;
 
     for (let i = 0; i < line.length; i++) {
-        const ch = line[i];
-
         if (isEscaped) {
             isEscaped = false;
             continue;
         }
 
+        const ch = line[i];
         if (ch === '\\') {
             isEscaped = true;
             continue;

--- a/src/contentScript/tableRuntime/activeCell/resolvedActiveCell.ts
+++ b/src/contentScript/tableRuntime/activeCell/resolvedActiveCell.ts
@@ -98,12 +98,10 @@ export const resolvedActiveCellField = StateField.define<ResolvedActiveCell | nu
     },
     update(value, tr) {
         // Re-derive when doc or active cell identity changes.
-        if (!tr.docChanged) {
-            // Use the false flag so states without activeCellField (e.g. nested editor
-            // states, autocomplete states) return undefined instead of throwing.
-            if (tr.startState.field(activeCellField, false) === tr.state.field(activeCellField, false)) {
-                return value;
-            }
+        // Use the false flag so states without activeCellField (e.g. nested editor
+        // states, autocomplete states) return undefined instead of throwing.
+        if (!tr.docChanged && tr.startState.field(activeCellField, false) === tr.state.field(activeCellField, false)) {
+            return value;
         }
         return resolveActiveCell(tr.state, getActiveCell(tr.state));
     },

--- a/src/contentScript/tableRuntime/lifecycle/nestedEditorLifecycle.ts
+++ b/src/contentScript/tableRuntime/lifecycle/nestedEditorLifecycle.ts
@@ -57,11 +57,9 @@ interface OpenRequestExecutionGuardResult {
 
 export const nestedEditorLifecyclePlugin = ViewPlugin.fromClass(
     class {
-        private pendingFullReplaceRebuild: boolean;
+        private pendingFullReplaceRebuild: boolean = false;
 
-        constructor(private view: EditorView) {
-            this.pendingFullReplaceRebuild = false;
-        }
+        constructor(private view: EditorView) {}
 
         update(update: ViewUpdate): void {
             const facts = classifyTableRuntimeFacts(update, {
@@ -207,12 +205,12 @@ export const nestedEditorLifecyclePlugin = ViewPlugin.fromClass(
                 return null;
             }
 
-            const targetActiveCell = request.activeCell;
             if (!this.view.dom.isConnected) {
                 this.failOpenRequest(requestId);
                 return null;
             }
 
+            const targetActiveCell = request.activeCell;
             if (!isSameActiveCell(getActiveCell(this.view.state), targetActiveCell)) {
                 this.failOpenRequest(requestId);
                 return null;

--- a/src/contentScript/tableRuntime/lifecycle/structuralChangeDetection.ts
+++ b/src/contentScript/tableRuntime/lifecycle/structuralChangeDetection.ts
@@ -12,11 +12,9 @@ function hasUnescapedPipe(text: string): boolean {
             backslashRun++;
             continue;
         }
-        if (ch === '|') {
-            // Pipe is escaped only if preceded by odd number of backslashes
-            if (backslashRun % 2 === 0) {
-                return true;
-            }
+        // Pipe is escaped only if preceded by odd number of backslashes
+        if (ch === '|' && backslashRun % 2 === 0) {
+            return true;
         }
         backslashRun = 0;
     }

--- a/src/contentScript/tableRuntime/lifecycle/transactionFactPredicates.ts
+++ b/src/contentScript/tableRuntime/lifecycle/transactionFactPredicates.ts
@@ -4,11 +4,11 @@ import { cellSelectionTransitionAnnotation } from '../../tableState/cellSelectio
 import { normalizeBeforeEditAnnotation } from './tableNormalization';
 
 export function hasNormalizeBeforeEditAnnotation(transactions: readonly Transaction[]): boolean {
-    return transactions.some((tr) => Boolean(tr.annotation(normalizeBeforeEditAnnotation)));
+    return transactions.some((tr) => tr.annotation(normalizeBeforeEditAnnotation));
 }
 
 export function hasCellSelectionTransitionAnnotation(transactions: readonly Transaction[]): boolean {
-    return transactions.some((tr) => Boolean(tr.annotation(cellSelectionTransitionAnnotation)));
+    return transactions.some((tr) => tr.annotation(cellSelectionTransitionAnnotation));
 }
 
 export function hasFullDocumentReplace(transactions: readonly Transaction[]): boolean {

--- a/src/contentScript/tableRuntime/selection/cellSelectionClipboard.ts
+++ b/src/contentScript/tableRuntime/selection/cellSelectionClipboard.ts
@@ -324,15 +324,15 @@ export function createTableClipboardRewriteSpec(
     ];
 
     return {
-        ...(rewrite.tableText !== (currentTable?.text ?? '')
-            ? {
+        ...(rewrite.tableText === (currentTable?.text ?? '')
+            ? {}
+            : {
                   changes: {
                       from: rewrite.tableFrom,
                       to: currentTable?.to ?? rewrite.tableFrom,
                       insert: rewrite.tableText,
                   },
-              }
-            : {}),
+              }),
         selection: EditorSelection.single(rewrite.selectionAnchorPos),
         effects,
         annotations: cellSelectionTransitionAnnotation.of(true),

--- a/src/contentScript/tableWidget/tableStyles.ts
+++ b/src/contentScript/tableWidget/tableStyles.ts
@@ -56,13 +56,13 @@ export const tableStyles = EditorView.baseTheme({
     // Keep truly empty cells (no content wrapper yet) at a consistent height
     // with cells that contain a line of text or the caret.
     [`.${CLASS_TABLE_WIDGET_TABLE} td:empty::before, .${CLASS_TABLE_WIDGET_TABLE} th:empty::before`]: {
-        content: '"\u00a0"',
+        content: '"\u{A0}"',
         display: 'inline-block',
         lineHeight: 'inherit',
     },
     // Keep empty cells at a consistent height with cells that contain a line of text.
     [`.${CLASS_TABLE_WIDGET_TABLE} .${CLASS_CELL_CONTENT}:empty::before`]: {
-        content: '"\u00a0"',
+        content: '"\u{A0}"',
         display: 'inline-block',
     },
     // Reset white-space to prevent newlines in serialized HTML from rendering as gaps

--- a/src/contentScript/tableWidget/tableWidgetInteractions.ts
+++ b/src/contentScript/tableWidget/tableWidgetInteractions.ts
@@ -123,7 +123,7 @@ function scrollToPosition(view: EditorView, pos: number): void {
 
 /** Escape special regex characters in a string */
 function escapeRegex(str: string): string {
-    return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    return str.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
 }
 
 export function handleTableInteraction(view: EditorView, event: Event): boolean {
@@ -227,23 +227,20 @@ export function handleTableInteraction(view: EditorView, event: Event): boolean 
         event.preventDefault();
         event.stopPropagation();
 
-        const currentSelection = getCellSelection(view.state);
-        const hasSelection = Boolean(currentSelection);
-        if (mouseEvent.shiftKey) {
-            if (
-                setOrExtendCellSelectionToCoords(
-                    view,
-                    { section, row: section === SECTION_HEADER ? 0 : row, col },
-                    ctx.from
-                )
-            ) {
-                return true;
-            }
+        if (
+            mouseEvent.shiftKey &&
+            setOrExtendCellSelectionToCoords(
+                view,
+                { section, row: section === SECTION_HEADER ? 0 : row, col },
+                ctx.from
+            )
+        ) {
+            return true;
         }
 
         requestOpenCell(view, {
             target: { resolvedCell },
-            clearCellSelection: hasSelection,
+            clearCellSelection: Boolean(getCellSelection(view.state)),
             normalizeIfNeeded: true,
         });
 

--- a/src/contentScript/toolbar/tableToolbarPlugin.ts
+++ b/src/contentScript/toolbar/tableToolbarPlugin.ts
@@ -102,13 +102,13 @@ export class TableToolbarPlugin {
             btn.className = 'cm-table-toolbar-btn';
             btn.type = 'button';
             btn.setAttribute('aria-label', ariaLabel);
-            btn.onclick = (e) => {
+            btn.addEventListener('click', (e) => {
                 e.preventDefault();
                 e.stopPropagation();
                 if (onClick() === false) {
                     this.restoreNestedEditorFocusAfterNoop();
                 }
-            };
+            });
             btn.appendChild(svg);
             btn.classList.add('cm-table-toolbar-icon-btn');
             this.dom.appendChild(btn);

--- a/src/contentScript/toolbar/tableToolbarPlugin.ts
+++ b/src/contentScript/toolbar/tableToolbarPlugin.ts
@@ -94,7 +94,10 @@ export class TableToolbarPlugin {
 
     private createButtons() {
         const doc = getViewDocument(this.view);
-        this.dom.replaceChildren();
+        // `innerHTML = ''` rather than `replaceChildren()`: the latter needs
+        // Chrome 86 / Safari 14, above this plugin's mobile WebView baseline.
+        // See the ES2020 runtime note in AGENTS.md.
+        this.dom.innerHTML = '';
 
         const createIconBtn = (title: string, ariaLabel: string, svg: SVGSVGElement, onClick: () => boolean) => {
             const btn = doc.createElement('button');

--- a/src/contentScript/toolbar/toolbarLayout.ts
+++ b/src/contentScript/toolbar/toolbarLayout.ts
@@ -184,11 +184,13 @@ export function renderToolbarButtonGroups(
     renderButton: (button: ToolbarButtonDescriptor) => void,
     renderSeparator: () => void
 ): void {
-    groups.forEach((group, groupIndex) => {
-        group.forEach(renderButton);
+    for (const [groupIndex, group] of groups.entries()) {
+        for (const button of group) {
+            renderButton(button);
+        }
 
         if (groupIndex < groups.length - 1) {
             renderSeparator();
         }
-    });
+    }
 }


### PR DESCRIPTION
Adopt the unopinionated preset of eslint-plugin-unicorn while maintaining ES2020 as the target for mobile compatibility. Disable specific rules that conflict with mobile support and improve code readability. Fix instances of `replaceChildren` to ensure compatibility with the supported Android API level. Address remaining linting violations and enhance code quality throughout the project.