### PR TITLE
refactor: remove dead payload

### DIFF
--- a/src/contentScript/__tests__/mainEditorGuard.test.ts
+++ b/src/contentScript/__tests__/mainEditorGuard.test.ts
@@ -95,7 +95,7 @@ describe('createMainEditorActiveCellGuard', () => {
 
         const tr = state.update({
             changes: { from: 0, to: firstLineEnd, insert: '| X | Y |' },
-            effects: rebuildTableWidgetsEffect.of({ tableFrom: 0 }),
+            effects: rebuildTableWidgetsEffect.of(undefined),
         });
 
         expect(tr.state.doc.toString()).toContain('| X | Y |');

--- a/src/contentScript/__tests__/nestedEditorLifecycle.test.ts
+++ b/src/contentScript/__tests__/nestedEditorLifecycle.test.ts
@@ -354,10 +354,7 @@ describe('nestedEditorLifecycle', () => {
         };
 
         view.dispatch({
-            effects: [
-                setActiveCellEffect.of(nextActiveCell),
-                rebuildTableWidgetsEffect.of({ tableFrom: nextActiveCell.tableFrom }),
-            ],
+            effects: [setActiveCellEffect.of(nextActiveCell), rebuildTableWidgetsEffect.of(undefined)],
         });
 
         expect(nestedEditorControllerMock.closeNestedEditor).not.toHaveBeenCalled();
@@ -735,7 +732,7 @@ describe('nestedEditorLifecycle', () => {
             changes: { from: tableFrom, to: tableTo, insert: updatedTable },
             effects: [
                 setActiveCellEffect.of(nextCell),
-                rebuildTableWidgetsEffect.of({ tableFrom }),
+                rebuildTableWidgetsEffect.of(undefined),
                 ...openRequestEffects({
                     requestId: 'request-structural-reopen',
                     activeCell: nextCell,

--- a/src/contentScript/__tests__/tableRuntimePolicies.test.ts
+++ b/src/contentScript/__tests__/tableRuntimePolicies.test.ts
@@ -602,10 +602,7 @@ describe('tableRuntimePolicies', () => {
         const tr = startState.update({
             changes: { from: 0, to: nonCanonicalDoc.length, insert: canonicalDoc },
             selection: { anchor: nextActiveCell.selectionAnchor },
-            effects: [
-                setActiveCellEffect.of(nextActiveCell.activeCell),
-                rebuildTableWidgetsEffect.of({ tableFrom: 0 }),
-            ],
+            effects: [setActiveCellEffect.of(nextActiveCell.activeCell), rebuildTableWidgetsEffect.of(undefined)],
             annotations: normalizeBeforeEditAnnotation.of(true),
         });
         const facts = defaultRuntimeFacts({

--- a/src/contentScript/tableRuntime/lifecycle/tableNormalization.ts
+++ b/src/contentScript/tableRuntime/lifecycle/tableNormalization.ts
@@ -102,7 +102,7 @@ export function planNormalizeTableBeforeOpen(params: {
                     normalizeIfNeeded: false,
                 }),
                 triggerOpenCellRequestEffect.of({ requestId: currentRequest.requestId }),
-                rebuildTableWidgetsEffect.of({ tableFrom: replacement.tableFrom }),
+                rebuildTableWidgetsEffect.of(undefined),
             ],
             annotations: normalizeBeforeEditAnnotation.of(true),
             scrollIntoView: false,

--- a/src/contentScript/tableRuntime/operations/runStructuralMutation.ts
+++ b/src/contentScript/tableRuntime/operations/runStructuralMutation.ts
@@ -93,10 +93,7 @@ export function runStructuralMutationAndReopen(params: RunStructuralMutationAndR
     if (prepared.kind === 'deleteTable') {
         params.view.dispatch({
             changes: { from: prepared.tableFrom, to: prepared.tableTo, insert: '' },
-            effects: [
-                clearActiveCellEffect.of(undefined),
-                rebuildTableWidgetsEffect.of({ tableFrom: prepared.tableFrom }),
-            ],
+            effects: [clearActiveCellEffect.of(undefined), rebuildTableWidgetsEffect.of(undefined)],
         });
         params.afterDispatch?.();
 
@@ -125,7 +122,7 @@ export function runStructuralMutationAndReopen(params: RunStructuralMutationAndR
               }
             : {}),
         ...openTransaction,
-        effects: [...openTransaction.effects, rebuildTableWidgetsEffect.of({ tableFrom: prepared.tableFrom })],
+        effects: [...openTransaction.effects, rebuildTableWidgetsEffect.of(undefined)],
     });
     params.afterDispatch?.();
 

--- a/src/contentScript/tableState/tableWidgetEffects.ts
+++ b/src/contentScript/tableState/tableWidgetEffects.ts
@@ -1,16 +1,25 @@
 import { StateEffect } from '@codemirror/state';
 
 /**
- * Forces a specific table widget to rebuild on the next transaction.
- * Carries the tableFrom position to identify which table needs rebuilding.
+ * Marks a transaction that structurally rewrote a table's source (row/column insert/delete,
+ * normalization), so decorations are rebuilt rather than mapped — mapping would leave the
+ * rendered HTML table stale.
  *
- * This is used for structural table edits (row/column insert/delete) where mapping existing
- * widget decorations would leave the rendered HTML table stale.
+ * Rebuilds are deliberately document-wide rather than scoped to the mutated table. Rebuilding a
+ * decoration does not re-render a widget: `TableWidget.eq()` always returns false and
+ * `updateDOM()` reuses the existing DOM whenever the content hash matches, so unchanged tables
+ * cost a reparse, not a re-render. Scoping the rebuild would trade that bounded cost for the
+ * range-splicing complexity this design exists to avoid.
+ *
+ * Two consumers also read this effect as a signal that the widget DOM was replaced:
+ * `mainEditorGuardPolicy` allows the transaction through without cell-range sanitization, and
+ * `tableToolbarPlugin` defers repositioning until the rebuilt DOM exists.
  */
-export const rebuildTableWidgetsEffect = StateEffect.define<{ tableFrom: number }>();
+export const rebuildTableWidgetsEffect = StateEffect.define<void>();
 
 /**
- * Forces all table widgets to rebuild on the next transaction.
- * Used when the document is replaced externally (e.g., sync update).
+ * Forces a rebuild from a transaction that carries no document change, which would otherwise be
+ * treated as "keep decorations". Used to recover after an external full-document replace
+ * (e.g. a Joplin sync update) once the replacing transaction has settled.
  */
 export const rebuildAllTableWidgetsEffect = StateEffect.define<void>();


### PR DESCRIPTION
Removed the dead `{ tableFrom: number }` payload from `rebuildTableWidgetsEffect` — written at 3 production sites, read at 0 — and rewrote the JSDoc in tableWidgetEffects.ts to document the actual design: document-wide rebuild is deliberate, because `eq()` → false plus the `updateDOM()` hash check means unchanged tables reuse their DOM, so a rebuild costs a reparse rather than a re-render.