### PR TITLE
refactor: TableWidget to use exact source text for DOM reuse

### DIFF
--- a/docs/Architecture/Table-Display.md
+++ b/docs/Architecture/Table-Display.md
@@ -27,16 +27,20 @@ Rendered cell HTML can include images, videos, and Joplin-rendered YouTube embed
 - **In-Cell Edits**: No rebuild; decorations mapped to preserve existing DOM.
 - **Sync Transactions**: From nested editor explicitly skip rebuilds.
 
-### 2. DOM Reuse (Content Hash)
+### 2. DOM Reuse (Exact Source Text)
 
-Each `TableWidget` has `contentHash` (FNV-1a of table text).
+Each rendered widget root is associated with the exact table source it was built from.
 
 On `updateDOM()`:
 
-- Hash matches → DOM reused (return `true`).
-- Hash differs → CodeMirror destroys/recreates.
+- Source text matches → DOM reused (return `true`); position-only changes refresh `data-table-from`.
+- Source text differs, or the element is unrecognised → CodeMirror destroys/recreates.
 
-Prevents flicker when rebuilding decorations for position sync.
+Comparison is against the text itself, not a hash: a hash match only makes identical content
+probable, and a collision would silently reuse DOM showing stale rows.
+
+Prevents flicker when rebuilding decorations for position sync, and keeps stateful embedded
+content (videos, iframes) alive across rebuilds.
 
 ### 3. Table Context Cache
 

--- a/docs/Architecture/Table-Display.md
+++ b/docs/Architecture/Table-Display.md
@@ -31,7 +31,11 @@ Rendered cell HTML can include images, videos, and Joplin-rendered YouTube embed
 
 Each rendered widget root is associated with the exact table source it was built from.
 
-On `updateDOM()`:
+`eq()` compares source text and document position, so a table that neither changed nor moved is
+skipped entirely during a rebuild. Position is part of the comparison because in-cell edits map
+decorations rather than rebuilding them, leaving a widget's recorded position stale.
+
+When `eq()` reports a difference, `updateDOM()` decides between reuse and rebuild:
 
 - Source text matches → DOM reused (return `true`); position-only changes refresh `data-table-from`.
 - Source text differs, or the element is unrecognised → CodeMirror destroys/recreates.

--- a/src/contentScript/__tests__/tableWidgetDomReuse.test.ts
+++ b/src/contentScript/__tests__/tableWidgetDomReuse.test.ts
@@ -7,10 +7,28 @@ import { markdownRenderServiceFacet } from '../services/markdownRenderer';
 import { MarkdownTable } from '../tableModel/MarkdownTable';
 import { computeMarkdownTableCellRanges } from '../tableModel/markdownTableCellRanges';
 import { TableWidget } from '../tableWidget/TableWidget';
+import { tableHeightCache } from '../tableWidget/tableHeightCache';
+
+const observerCallbacks: Array<() => void> = [];
 
 class ResizeObserverMock {
     observe = vi.fn();
     disconnect = vi.fn();
+
+    constructor(callback: () => void) {
+        observerCallbacks.push(callback);
+    }
+}
+
+/** Fires every ResizeObserver created during the test, as a real resize would. */
+function triggerResize(): void {
+    for (const callback of observerCallbacks) {
+        callback();
+    }
+}
+
+function stubHeight(element: HTMLElement, heightPx: number): void {
+    vi.spyOn(element, 'getBoundingClientRect').mockReturnValue({ height: heightPx } as DOMRect);
 }
 
 const TABLE_TEXT = ['| H1 | H2 |', '| --- | --- |', '| a | b |'].join('\n');
@@ -39,17 +57,25 @@ function createView(): EditorView {
     return {
         state,
         dom: document.createElement('div'),
-        requestMeasure: vi.fn(),
+        // CodeMirror batches these into its measure phase; running read() inline keeps the
+        // assertions synchronous without changing what the widget schedules.
+        requestMeasure: vi.fn((spec: { read: () => void }) => spec.read()),
+        // destroy() routes through cleanupHostedNestedEditors, which looks up the nested editor
+        // plugin. No nested editor is mounted in these tests.
+        plugin: vi.fn(() => null),
     } as unknown as EditorView;
 }
 
 describe('TableWidget DOM reuse', () => {
     beforeEach(() => {
+        observerCallbacks.length = 0;
+        tableHeightCache.clear();
         vi.stubGlobal('ResizeObserver', ResizeObserverMock as unknown as typeof ResizeObserver);
     });
 
     afterEach(() => {
         vi.unstubAllGlobals();
+        vi.restoreAllMocks();
     });
 
     it('reuses the existing DOM when the table source is unchanged', () => {
@@ -86,6 +112,48 @@ describe('TableWidget DOM reuse', () => {
         const foreignDom = document.createElement('div');
 
         expect(createWidget(TABLE_TEXT).updateDOM(foreignDom, view)).toBe(false);
+    });
+
+    describe('height measurement', () => {
+        const MEASURED_HEIGHT = 250;
+        const ORIGINAL_FROM = 0;
+        const MOVED_FROM = 120;
+        // Queries the cache by position alone: tableHeightCache.get() also matches on text, so
+        // an unrelated text forces the lookup to be satisfied by the position key or not at all.
+        const UNRELATED_TEXT = 'unrelated';
+
+        it('records the current position after the table moved, not the mounted one', () => {
+            const view = createView();
+            const dom = createWidget(TABLE_TEXT, ORIGINAL_FROM).toDOM(view);
+            document.body.appendChild(dom);
+
+            expect(createWidget(TABLE_TEXT, MOVED_FROM).updateDOM(dom, view)).toBe(true);
+
+            // Stub only now, so the assertion reflects the ResizeObserver callback alone. That
+            // callback is created once at mount and outlives the widget that created it, so it
+            // must resolve the position at fire time rather than at creation time.
+            stubHeight(dom, MEASURED_HEIGHT);
+            triggerResize();
+
+            expect(tableHeightCache.get({ tableFrom: MOVED_FROM, tableText: UNRELATED_TEXT })).toBe(MEASURED_HEIGHT);
+            expect(tableHeightCache.get({ tableFrom: ORIGINAL_FROM, tableText: UNRELATED_TEXT })).toBeUndefined();
+
+            dom.remove();
+        });
+
+        it('records the last known height on destroy', () => {
+            const view = createView();
+            const widget = createWidget(TABLE_TEXT, ORIGINAL_FROM);
+            const dom = widget.toDOM(view);
+            document.body.appendChild(dom);
+
+            stubHeight(dom, MEASURED_HEIGHT);
+            widget.destroy(dom);
+
+            expect(tableHeightCache.get({ tableFrom: ORIGINAL_FROM, tableText: UNRELATED_TEXT })).toBe(MEASURED_HEIGHT);
+
+            dom.remove();
+        });
     });
 
     describe('eq', () => {

--- a/src/contentScript/__tests__/tableWidgetDomReuse.test.ts
+++ b/src/contentScript/__tests__/tableWidgetDomReuse.test.ts
@@ -1,12 +1,17 @@
 /** @vitest-environment jsdom */
 
+import { markdown } from '@codemirror/lang-markdown';
 import { EditorState } from '@codemirror/state';
 import { EditorView } from '@codemirror/view';
+import { GFM } from '@lezer/markdown';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { markdownRenderServiceFacet } from '../services/markdownRenderer';
 import { MarkdownTable } from '../tableModel/MarkdownTable';
 import { computeMarkdownTableCellRanges } from '../tableModel/markdownTableCellRanges';
+import { rebuildAllTableWidgetsEffect } from '../tableState/tableWidgetEffects';
 import { TableWidget } from '../tableWidget/TableWidget';
+import { getWidgetSelector } from '../tableWidget/domHelpers';
+import { tableDecorationField } from '../tableWidget/tableDecorationField';
 import { tableHeightCache } from '../tableWidget/tableHeightCache';
 
 const observerCallbacks: Array<() => void> = [];
@@ -18,6 +23,18 @@ class ResizeObserverMock {
     constructor(callback: () => void) {
         observerCallbacks.push(callback);
     }
+}
+
+if (!Range.prototype.getBoundingClientRect) {
+    Object.defineProperty(Range.prototype, 'getBoundingClientRect', {
+        value: () => new DOMRect(),
+    });
+}
+
+if (!Range.prototype.getClientRects) {
+    Object.defineProperty(Range.prototype, 'getClientRects', {
+        value: () => [],
+    });
 }
 
 /** Fires every ResizeObserver created during the test, as a real resize would. */
@@ -66,6 +83,29 @@ function createView(): EditorView {
     } as unknown as EditorView;
 }
 
+function createRealView(doc: string): { parent: HTMLElement; view: EditorView } {
+    const parent = document.createElement('div');
+    document.body.appendChild(parent);
+
+    const state = EditorState.create({
+        doc,
+        extensions: [
+            markdown({ extensions: [GFM] }),
+            markdownRenderServiceFacet.of({
+                getCached: vi.fn(() => undefined),
+                render: vi.fn(async () => ''),
+                clear: vi.fn(),
+            }),
+            tableDecorationField,
+        ],
+    });
+
+    return {
+        parent,
+        view: new EditorView({ parent, state }),
+    };
+}
+
 describe('TableWidget DOM reuse', () => {
     beforeEach(() => {
         observerCallbacks.length = 0;
@@ -112,6 +152,70 @@ describe('TableWidget DOM reuse', () => {
         const foreignDom = document.createElement('div');
 
         expect(createWidget(TABLE_TEXT).updateDOM(foreignDom, view)).toBe(false);
+    });
+
+    describe('CodeMirror reconciliation', () => {
+        it('keeps the DOM node when an unchanged table decoration is rebuilt', () => {
+            const { parent, view } = createRealView(TABLE_TEXT);
+
+            try {
+                const originalTable = view.contentDOM.querySelector(`${getWidgetSelector()} table`);
+                expect(originalTable).not.toBeNull();
+
+                view.dispatch({ effects: rebuildAllTableWidgetsEffect.of(undefined) });
+
+                expect(view.contentDOM.querySelector(`${getWidgetSelector()} table`)).toBe(originalTable);
+            } finally {
+                view.destroy();
+                parent.remove();
+            }
+        });
+
+        it('keeps the DOM node and refreshes its position when the table moves', () => {
+            const { parent, view } = createRealView(TABLE_TEXT);
+            const prefix = 'intro\n\n';
+
+            try {
+                const originalWidget = view.contentDOM.querySelector(getWidgetSelector());
+                const originalTable = originalWidget?.querySelector('table');
+                expect(originalWidget).not.toBeNull();
+                expect(originalTable).not.toBeNull();
+
+                view.dispatch({ changes: { from: 0, insert: prefix } });
+
+                const movedWidget = view.contentDOM.querySelector(getWidgetSelector());
+                expect(movedWidget?.querySelector('table')).toBe(originalTable);
+                expect(movedWidget?.getAttribute('data-table-from')).toBe(String(prefix.length));
+            } finally {
+                view.destroy();
+                parent.remove();
+            }
+        });
+
+        it('replaces the DOM node when the table source changes', () => {
+            const { parent, view } = createRealView(TABLE_TEXT);
+
+            try {
+                const originalTable = view.contentDOM.querySelector(`${getWidgetSelector()} table`);
+                expect(originalTable).not.toBeNull();
+
+                const editedCellFrom = TABLE_TEXT.lastIndexOf('b');
+                view.dispatch({
+                    changes: {
+                        from: editedCellFrom,
+                        to: editedCellFrom + 1,
+                        insert: 'CHANGED',
+                    },
+                });
+
+                const editedTable = view.contentDOM.querySelector(`${getWidgetSelector()} table`);
+                expect(editedTable).not.toBe(originalTable);
+                expect(editedTable?.textContent).toContain('CHANGED');
+            } finally {
+                view.destroy();
+                parent.remove();
+            }
+        });
     });
 
     describe('height measurement', () => {

--- a/src/contentScript/__tests__/tableWidgetDomReuse.test.ts
+++ b/src/contentScript/__tests__/tableWidgetDomReuse.test.ts
@@ -1,0 +1,90 @@
+/** @vitest-environment jsdom */
+
+import { EditorState } from '@codemirror/state';
+import { EditorView } from '@codemirror/view';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { markdownRenderServiceFacet } from '../services/markdownRenderer';
+import { MarkdownTable } from '../tableModel/MarkdownTable';
+import { computeMarkdownTableCellRanges } from '../tableModel/markdownTableCellRanges';
+import { TableWidget } from '../tableWidget/TableWidget';
+
+class ResizeObserverMock {
+    observe = vi.fn();
+    disconnect = vi.fn();
+}
+
+const TABLE_TEXT = ['| H1 | H2 |', '| --- | --- |', '| a | b |'].join('\n');
+const EDITED_TABLE_TEXT = ['| H1 | H2 |', '| --- | --- |', '| a | CHANGED |'].join('\n');
+
+function createWidget(tableText: string, tableFrom = 0): TableWidget {
+    const table = MarkdownTable.parse(tableText);
+    const cellRanges = computeMarkdownTableCellRanges(tableText);
+    if (!table || !cellRanges) {
+        throw new Error('Expected test table to parse');
+    }
+    return new TableWidget(table, cellRanges, tableText, tableFrom);
+}
+
+function createView(): EditorView {
+    const state = EditorState.create({
+        extensions: [
+            markdownRenderServiceFacet.of({
+                getCached: vi.fn(() => ''),
+                render: vi.fn(async () => ''),
+                clear: vi.fn(),
+            }),
+        ],
+    });
+
+    return {
+        state,
+        dom: document.createElement('div'),
+        requestMeasure: vi.fn(),
+    } as unknown as EditorView;
+}
+
+describe('TableWidget DOM reuse', () => {
+    beforeEach(() => {
+        vi.stubGlobal('ResizeObserver', ResizeObserverMock as unknown as typeof ResizeObserver);
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it('reuses the existing DOM when the table source is unchanged', () => {
+        const view = createView();
+        const dom = createWidget(TABLE_TEXT).toDOM(view);
+        const originalTable = dom.querySelector('table');
+
+        const reused = createWidget(TABLE_TEXT).updateDOM(dom, view);
+
+        expect(reused).toBe(true);
+        // Reuse must preserve the actual nodes — this is what keeps videos and embeds alive.
+        expect(dom.querySelector('table')).toBe(originalTable);
+    });
+
+    it('rebuilds when the table source changed', () => {
+        const view = createView();
+        const dom = createWidget(TABLE_TEXT).toDOM(view);
+
+        expect(createWidget(EDITED_TABLE_TEXT).updateDOM(dom, view)).toBe(false);
+    });
+
+    it('reuses the DOM when only the document position changed', () => {
+        const view = createView();
+        const dom = createWidget(TABLE_TEXT, 0).toDOM(view);
+
+        const reused = createWidget(TABLE_TEXT, 120).updateDOM(dom, view);
+
+        expect(reused).toBe(true);
+        expect(dom.getAttribute('data-table-from')).toBe('120');
+    });
+
+    it('rebuilds when the DOM was not produced by a table widget', () => {
+        const view = createView();
+        const foreignDom = document.createElement('div');
+
+        expect(createWidget(TABLE_TEXT).updateDOM(foreignDom, view)).toBe(false);
+    });
+});

--- a/src/contentScript/__tests__/tableWidgetDomReuse.test.ts
+++ b/src/contentScript/__tests__/tableWidgetDomReuse.test.ts
@@ -87,4 +87,21 @@ describe('TableWidget DOM reuse', () => {
 
         expect(createWidget(TABLE_TEXT).updateDOM(foreignDom, view)).toBe(false);
     });
+
+    describe('eq', () => {
+        it('is equal when neither the source nor the position changed', () => {
+            expect(createWidget(TABLE_TEXT, 40).eq(createWidget(TABLE_TEXT, 40))).toBe(true);
+        });
+
+        it('is not equal when the source changed', () => {
+            expect(createWidget(TABLE_TEXT, 40).eq(createWidget(EDITED_TABLE_TEXT, 40))).toBe(false);
+        });
+
+        it('is not equal when only the position changed', () => {
+            // In-cell edits map decorations instead of rebuilding them, so a widget's tableFrom
+            // drifts from the document. Comparing it routes the table through updateDOM(), which
+            // refreshes the recorded position the height cache keys off.
+            expect(createWidget(TABLE_TEXT, 40).eq(createWidget(TABLE_TEXT, 120))).toBe(false);
+        });
+    });
 });

--- a/src/contentScript/__tests__/tableWidgetMarkdownRenderer.test.ts
+++ b/src/contentScript/__tests__/tableWidgetMarkdownRenderer.test.ts
@@ -46,7 +46,7 @@ describe('TableWidget markdown rendering', () => {
             requestMeasure: vi.fn(),
         } as unknown as EditorView;
 
-        const widget = new TableWidget(table, cellRanges, tableText, 0, tableText.length, 'hash');
+        const widget = new TableWidget(table, cellRanges, tableText, 0);
         const dom = widget.toDOM(view);
         document.body.appendChild(dom);
         rendered.resolve('<p><strong>rendered</strong></p>');
@@ -84,7 +84,7 @@ describe('TableWidget markdown rendering', () => {
         } as unknown as EditorView;
 
         const tableFrom = 50;
-        const widget = new TableWidget(table, cellRanges, tableText, tableFrom, tableFrom + tableText.length, 'hash');
+        const widget = new TableWidget(table, cellRanges, tableText, tableFrom);
         const dom = widget.toDOM(view);
         const targetCell = dom.querySelector('tbody td:nth-child(2)') as HTMLElement | null;
         if (!targetCell) {

--- a/src/contentScript/tableState/tableWidgetEffects.ts
+++ b/src/contentScript/tableState/tableWidgetEffects.ts
@@ -6,10 +6,10 @@ import { StateEffect } from '@codemirror/state';
  * rendered HTML table stale.
  *
  * Rebuilds are deliberately document-wide rather than scoped to the mutated table. Rebuilding a
- * decoration does not re-render a widget: `TableWidget.eq()` always returns false and
- * `updateDOM()` reuses the existing DOM whenever the content hash matches, so unchanged tables
- * cost a reparse, not a re-render. Scoping the rebuild would trade that bounded cost for the
- * range-splicing complexity this design exists to avoid.
+ * decoration does not re-render a widget: `TableWidget.eq()` compares source text and position,
+ * so a table that neither changed nor moved is skipped outright, and one that only moved reuses
+ * its DOM via `updateDOM()`. Unchanged tables cost a reparse, not a re-render. Scoping the
+ * rebuild would trade that bounded cost for the range-splicing complexity this design avoids.
  *
  * Two consumers also read this effect as a signal that the widget DOM was replaced:
  * `mainEditorGuardPolicy` allows the transaction through without cell-range sanitization, and

--- a/src/contentScript/tableWidget/TableWidget.ts
+++ b/src/contentScript/tableWidget/TableWidget.ts
@@ -306,8 +306,8 @@ export class TableWidget extends WidgetType {
     }
 
     destroy(dom: HTMLElement): void {
-        // CodeMirror calls destroy() on the widget that mounted the DOM, which may be several
-        // reuses behind the one it currently shows. Read the recorded state rather than `this`.
+        // After updateDOM() reuses an element, CodeMirror associates it with the newer widget.
+        // Read the per-DOM state so cleanup uses the element's current recorded identity.
         const state = widgetDomState.get(dom);
         if (!state) {
             return;

--- a/src/contentScript/tableWidget/TableWidget.ts
+++ b/src/contentScript/tableWidget/TableWidget.ts
@@ -70,14 +70,23 @@ export class TableWidget extends WidgetType {
         super();
     }
 
-    eq(_other: TableWidget): boolean {
-        // Always return false to trigger updateDOM() call.
-        // updateDOM() will decide whether to reuse the DOM based on the rendered source text.
-        return false;
+    eq(other: TableWidget): boolean {
+        // Everything else the widget exposes derives from the source text: `tableData` is
+        // MarkdownTable.parse(text) and `cellRanges` is computeMarkdownTableCellRanges(text).
+        // Text equality therefore implies the rendered DOM and estimated height match too.
+        //
+        // `tableFrom` is load-bearing, not defensive: in-cell edits take the `mapDecorations`
+        // path, which shifts decoration ranges without rebuilding widgets, so a widget's
+        // `tableFrom` drifts from the document. Comparing it routes those tables through
+        // updateDOM() to refresh their recorded position.
+        return this.tableText === other.tableText && this.tableFrom === other.tableFrom;
     }
 
     updateDOM(dom: HTMLElement, view: EditorView): boolean {
-        // Called when eq() returns false. We decide here whether to reuse the DOM.
+        // Reached when eq() returned false, i.e. the text or the position changed. A text change
+        // needs a full rebuild; a position change can reuse the DOM after refreshing the state
+        // that tracks it. This work cannot move into eq() because it has side effects.
+        //
         // An unrecognised DOM has no recorded text, so it falls through to a rebuild.
         if (widgetRenderedText.get(dom) !== this.tableText) {
             // Content changed (structural edit) - must rebuild DOM via toDOM().
@@ -121,7 +130,9 @@ export class TableWidget extends WidgetType {
         const container = doc.createElement('div');
         container.className = CLASS_TABLE_WIDGET;
 
-        // Used by extension-level interaction handlers as a reliable fallback.
+        // Records the position this DOM was rendered at, for the height-cache keys used by
+        // requestTableMeasurement() and destroy(). Interaction handlers deliberately do not
+        // read it — they resolve identity via posAtDOM(); see findTableWidgetElement().
         container.setAttribute(`data-${ATTR_TABLE_FROM}`, String(this.tableFrom));
 
         // Record the exact source this DOM renders so updateDOM() can distinguish a content

--- a/src/contentScript/tableWidget/TableWidget.ts
+++ b/src/contentScript/tableWidget/TableWidget.ts
@@ -27,6 +27,14 @@ const widgetViews = new WeakMap<HTMLElement, EditorView>();
 /** Associates widget DOM elements with their ResizeObserver for safe DOM reuse. */
 const widgetResizeObservers = new WeakMap<HTMLElement, ResizeObserver>();
 
+/**
+ * Associates widget DOM elements with the exact table source they were rendered from.
+ * `updateDOM()` compares against this to decide whether the DOM can be reused. Holding the
+ * text itself rather than a hash keeps the comparison exact: a hash match would only make
+ * identical content probable, and a collision would silently show stale rows.
+ */
+const widgetRenderedText = new WeakMap<HTMLElement, string>();
+
 function getViewResizeObserver(view: EditorView): typeof ResizeObserver {
     return (
         (getViewWindow(view) as Window & { ResizeObserver?: typeof ResizeObserver }).ResizeObserver ?? ResizeObserver
@@ -53,33 +61,25 @@ function requestTableMeasurement(view: EditorView, container: HTMLElement, table
  * Supports rendering markdown content inside cells
  */
 export class TableWidget extends WidgetType {
-    private readonly contentHash: string;
-    private readonly cellRanges: TableCellRanges;
-
     constructor(
         private tableData: MarkdownTable,
-        cellRanges: TableCellRanges,
+        private readonly cellRanges: TableCellRanges,
         private tableText: string,
-        private tableFrom: number,
-        private tableTo: number,
-        contentHash: string
+        private tableFrom: number
     ) {
         super();
-        // Hash is pre-computed by the extension to avoid redundant hashing.
-        this.contentHash = contentHash;
-        this.cellRanges = cellRanges;
     }
 
     eq(_other: TableWidget): boolean {
         // Always return false to trigger updateDOM() call.
-        // updateDOM() will decide whether to reuse the DOM based on content hash.
+        // updateDOM() will decide whether to reuse the DOM based on the rendered source text.
         return false;
     }
 
     updateDOM(dom: HTMLElement, view: EditorView): boolean {
         // Called when eq() returns false. We decide here whether to reuse the DOM.
-        // Check if the table content is the same by comparing stored hash.
-        if (dom.dataset.tableTextHash !== this.contentHash) {
+        // An unrecognised DOM has no recorded text, so it falls through to a rebuild.
+        if (widgetRenderedText.get(dom) !== this.tableText) {
             // Content changed (structural edit) - must rebuild DOM via toDOM().
             return false;
         }
@@ -124,8 +124,9 @@ export class TableWidget extends WidgetType {
         // Used by extension-level interaction handlers as a reliable fallback.
         container.setAttribute(`data-${ATTR_TABLE_FROM}`, String(this.tableFrom));
 
-        // Store content hash for updateDOM() to detect content vs position-only changes.
-        container.dataset.tableTextHash = this.contentHash;
+        // Record the exact source this DOM renders so updateDOM() can distinguish a content
+        // change from a position-only change.
+        widgetRenderedText.set(container, this.tableText);
 
         const table = doc.createElement('table');
         table.className = CLASS_TABLE_WIDGET_TABLE;

--- a/src/contentScript/tableWidget/TableWidget.ts
+++ b/src/contentScript/tableWidget/TableWidget.ts
@@ -21,19 +21,25 @@ import { buildRenderableContent, containsMarkdown, escapeHtmlPreservingBr } from
 import { getViewDocument, getViewWindow } from '../shared/domContext';
 import { logger } from '../../logger';
 
-/** Associates widget DOM elements with their EditorView for cleanup during destroy. */
-const widgetViews = new WeakMap<HTMLElement, EditorView>();
-
-/** Associates widget DOM elements with their ResizeObserver for safe DOM reuse. */
-const widgetResizeObservers = new WeakMap<HTMLElement, ResizeObserver>();
-
 /**
- * Associates widget DOM elements with the exact table source they were rendered from.
- * `updateDOM()` compares against this to decide whether the DOM can be reused. Holding the
- * text itself rather than a hash keeps the comparison exact: a hash match would only make
- * identical content probable, and a collision would silently show stale rows.
+ * What a rendered widget root currently represents.
+ *
+ * A widget root outlives the `TableWidget` instance that built it — CodeMirror hands the same
+ * DOM to successive widgets via `updateDOM()`. Anything captured from `this` at mount time is
+ * therefore a snapshot that silently goes stale, so per-DOM state lives here instead and
+ * `updateDOM()` is its single writer.
+ *
+ * `tableText` also serves as the reuse test: holding the text rather than a hash keeps the
+ * comparison exact, where a collision would silently show stale rows.
  */
-const widgetRenderedText = new WeakMap<HTMLElement, string>();
+interface WidgetDomState {
+    view: EditorView;
+    observer: ResizeObserver;
+    tableText: string;
+    tableFrom: number;
+}
+
+const widgetDomState = new WeakMap<HTMLElement, WidgetDomState>();
 
 function getViewResizeObserver(view: EditorView): typeof ResizeObserver {
     return (
@@ -41,18 +47,27 @@ function getViewResizeObserver(view: EditorView): typeof ResizeObserver {
     );
 }
 
-function requestTableMeasurement(view: EditorView, container: HTMLElement, tableFrom: number, tableText: string): void {
-    view.requestMeasure({
+function requestTableMeasurement(container: HTMLElement): void {
+    const state = widgetDomState.get(container);
+    if (!state) {
+        return;
+    }
+
+    state.view.requestMeasure({
         read: () => {
-            if (!container.isConnected) {
+            // Re-read the state: the table may have moved between scheduling and measuring.
+            const current = widgetDomState.get(container);
+            if (!current || !container.isConnected) {
                 return;
             }
 
-            const currentFrom = Number(container.getAttribute(`data-${ATTR_TABLE_FROM}`)) || tableFrom;
-            const height = container.getBoundingClientRect().height;
-            tableHeightCache.set({ tableFrom: currentFrom, tableText, heightPx: height });
+            tableHeightCache.set({
+                tableFrom: current.tableFrom,
+                tableText: current.tableText,
+                heightPx: container.getBoundingClientRect().height,
+            });
         },
-        key: tableHeightCache.getMeasureKey(tableFrom, tableText),
+        key: tableHeightCache.getMeasureKey(state.tableFrom, state.tableText),
     });
 }
 
@@ -87,38 +102,22 @@ export class TableWidget extends WidgetType {
         // needs a full rebuild; a position change can reuse the DOM after refreshing the state
         // that tracks it. This work cannot move into eq() because it has side effects.
         //
-        // An unrecognised DOM has no recorded text, so it falls through to a rebuild.
-        if (widgetRenderedText.get(dom) !== this.tableText) {
+        // An unrecognised DOM has no recorded state, so it falls through to a rebuild.
+        const state = widgetDomState.get(dom);
+        if (!state || state.tableText !== this.tableText) {
             // Content changed (structural edit) - must rebuild DOM via toDOM().
             return false;
         }
 
-        // Also check if position changed - when positions shift significantly (e.g., undo
-        // removes text above table), CodeMirror might incorrectly match DOMs.
-        // We update the data attribute to reflect the new position, but we return true (reuse)
-        // because the content is the same. This preserves heavy DOM elements like videos.
-        const oldFrom = Number(dom.getAttribute(`data-${ATTR_TABLE_FROM}`));
-        if (oldFrom !== this.tableFrom) {
-            dom.setAttribute(`data-${ATTR_TABLE_FROM}`, String(this.tableFrom));
-        }
-
-        // Content and position are the same - safe to reuse the DOM.
-        // Update the view mapping so destroy() can clean up correctly.
-        widgetViews.set(dom, view);
-
-        // Ensure a ResizeObserver exists for this DOM, even when it was reused.
-        if (!widgetResizeObservers.has(dom)) {
-            const ResizeObserverCtor = getViewResizeObserver(view);
-            const observer = new ResizeObserverCtor(() => {
-                requestTableMeasurement(view, dom, this.tableFrom, this.tableText);
-            });
-            observer.observe(dom);
-            widgetResizeObservers.set(dom, observer);
-        }
+        // Only the position changed, so the DOM stays as-is — preserving heavy elements like
+        // videos — and the recorded state is advanced to match. This is the single write point.
+        state.view = view;
+        state.tableFrom = this.tableFrom;
+        dom.setAttribute(`data-${ATTR_TABLE_FROM}`, String(this.tableFrom));
 
         // Prime CodeMirror's vertical layout info immediately on reuse instead of
         // waiting for ResizeObserver, which may fire too late for the first undo.
-        requestTableMeasurement(view, dom, this.tableFrom, this.tableText);
+        requestTableMeasurement(dom);
 
         return true;
     }
@@ -130,14 +129,10 @@ export class TableWidget extends WidgetType {
         const container = doc.createElement('div');
         container.className = CLASS_TABLE_WIDGET;
 
-        // Records the position this DOM was rendered at, for the height-cache keys used by
-        // requestTableMeasurement() and destroy(). Interaction handlers deliberately do not
-        // read it — they resolve identity via posAtDOM(); see findTableWidgetElement().
+        // Mirrors the recorded position for DOM inspection. Written only from widgetDomState,
+        // and never read back: interaction handlers resolve identity via posAtDOM() instead;
+        // see findTableWidgetElement().
         container.setAttribute(`data-${ATTR_TABLE_FROM}`, String(this.tableFrom));
-
-        // Record the exact source this DOM renders so updateDOM() can distinguish a content
-        // change from a position-only change.
-        widgetRenderedText.set(container, this.tableText);
 
         const table = doc.createElement('table');
         table.className = CLASS_TABLE_WIDGET_TABLE;
@@ -196,18 +191,26 @@ export class TableWidget extends WidgetType {
 
         // Use ResizeObserver to notify CodeMirror whenever the table height changes.
         // This eliminates the race condition between async rendering and CM6's coordinate system.
+        // The callback deliberately captures nothing but the element: it outlives this widget,
+        // and requestTableMeasurement() reads whatever the element currently represents.
         const observer = new ResizeObserverCtor(() => {
             // requestMeasure is debounced internally by CM6, so safe to call frequently.
-            requestTableMeasurement(view, container, this.tableFrom, this.tableText);
+            requestTableMeasurement(container);
+        });
+
+        // Record the state before observing: the observer may fire immediately, and
+        // requestTableMeasurement() is a no-op until the element is registered.
+        widgetDomState.set(container, {
+            view,
+            observer,
+            tableText: this.tableText,
+            tableFrom: this.tableFrom,
         });
         observer.observe(container);
-        widgetResizeObservers.set(container, observer);
 
-        // Store view reference for cleanup when widget is destroyed
-        widgetViews.set(container, view);
         // Prime the measurement immediately on mount so the first scroll-preserving
         // undo/redo in a fresh note uses real widget geometry instead of estimates.
-        requestTableMeasurement(view, container, this.tableFrom, this.tableText);
+        requestTableMeasurement(container);
 
         return container;
     }
@@ -303,24 +306,28 @@ export class TableWidget extends WidgetType {
     }
 
     destroy(dom: HTMLElement): void {
-        // Disconnect ResizeObserver to prevent memory leaks.
-        const observer = widgetResizeObservers.get(dom);
-        if (observer) {
-            observer.disconnect();
-            widgetResizeObservers.delete(dom);
+        // CodeMirror calls destroy() on the widget that mounted the DOM, which may be several
+        // reuses behind the one it currently shows. Read the recorded state rather than `this`.
+        const state = widgetDomState.get(dom);
+        if (!state) {
+            return;
         }
+
+        // Disconnect ResizeObserver to prevent memory leaks.
+        state.observer.disconnect();
 
         // Record a last-known height right before teardown. This helps future remounts even if
         // the widget is destroyed before the measurement queue runs.
-        const height = dom.getBoundingClientRect().height;
-        const currentFrom = Number(dom.getAttribute(`data-${ATTR_TABLE_FROM}`)) || this.tableFrom;
-        tableHeightCache.set({ tableFrom: currentFrom, tableText: this.tableText, heightPx: height });
+        tableHeightCache.set({
+            tableFrom: state.tableFrom,
+            tableText: state.tableText,
+            heightPx: dom.getBoundingClientRect().height,
+        });
+
+        widgetDomState.delete(dom);
 
         // Ensure any nested editor hosted in this widget is closed when the widget is destroyed.
         // This prevents "orphan" subviews from keeping DOM alive and causing scroll jumps.
-        const view = widgetViews.get(dom);
-        if (view) {
-            cleanupHostedNestedEditors(view, dom);
-        }
+        cleanupHostedNestedEditors(state.view, dom);
     }
 }

--- a/src/contentScript/tableWidget/domHelpers.ts
+++ b/src/contentScript/tableWidget/domHelpers.ts
@@ -21,21 +21,18 @@ export const SECTION_HEADER = 'header';
 export const SECTION_BODY = 'body';
 
 /**
- * Returns the CSS selector for the table widget, optionally targeting a specific table instance.
+ * Returns the CSS selector matching every table widget root.
  *
- * @param tableId - Optional TableId identifying the table.
+ * Deliberately position-agnostic: identity comes from `posAtDOM()` via
+ * `findTableWidgetElement()`, never from `data-table-from`.
+ *
  * @returns The CSS selector string.
  *
  * @example
  * getWidgetSelector(); // returns '.cm-table-widget'
- * getWidgetSelector(makeTableId(105)); // returns '.cm-table-widget[data-table-from="105"]'
  */
-export function getWidgetSelector(tableId?: TableId): string {
-    const base = `.${CLASS_TABLE_WIDGET}`;
-    if (tableId !== undefined) {
-        return `${base}[data-${ATTR_TABLE_FROM}="${tableId}"]`;
-    }
-    return base;
+export function getWidgetSelector(): string {
+    return `.${CLASS_TABLE_WIDGET}`;
 }
 
 /**

--- a/src/contentScript/tableWidget/tableDecorationField.ts
+++ b/src/contentScript/tableWidget/tableDecorationField.ts
@@ -2,7 +2,6 @@ import { EditorState, RangeSetBuilder, StateField } from '@codemirror/state';
 import { syntaxTreeAvailable } from '@codemirror/language';
 import { Decoration, DecorationSet, EditorView } from '@codemirror/view';
 import { logger } from '../../logger';
-import { hashTableText } from '../shared/hashUtils';
 import { buildTableContext } from '../tableModel/tableContext';
 import { findTableRanges } from '../tableRuntime/tableResolution';
 import { TableWidget } from './TableWidget';
@@ -38,9 +37,7 @@ function buildTableDecorations(state: EditorState): TableDecorationState {
             continue;
         }
 
-        const contentHash = hashTableText(table.text);
-
-        const widget = new TableWidget(ctx.table, ctx.cellRanges, table.text, table.from, table.to, contentHash);
+        const widget = new TableWidget(ctx.table, ctx.cellRanges, table.text, table.from);
         const decoration = Decoration.replace({
             widget,
             block: true,


### PR DESCRIPTION
Replace hash-based comparison with direct source text comparison for widget DOM reuse, eliminating potential collisions and improving performance. Update related logic to ensure accurate height measurements and simplify state management within the widget. Adjust tests and documentation to reflect these changes.