### PR TITLE
refactor: height cache to use separate indexes

### DIFF
--- a/docs/Architecture/Table-Display.md
+++ b/docs/Architecture/Table-Display.md
@@ -66,9 +66,13 @@ Prevents scroll jumping via multi-layered approach:
 **ResizeObserver**: After async render:
 
 1. `view.requestMeasure()` notifies CodeMirror.
-2. Updates **LRU height cache** (200 entries).
+2. Updates **LRU height cache** (200 tables per index).
 
-**Height Cache**: Hybrid lookup by position and source text.
+**Height Cache**: Two LRU indexes over the same measurements, one keyed by source text and one by
+document position, so a height survives both in-table edits (position unchanged) and edits above the
+table (text unchanged). Text is consulted first: a text hit is the table's own measurement, whereas a
+position hit only reports whatever was last measured at that offset and goes stale when a table above
+is deleted.
 
 **`coordsAt()`**: Returns cell bounding rectangle for precise scroll-to-cell during navigation.
 

--- a/src/contentScript/__tests__/tableHeightCache.test.ts
+++ b/src/contentScript/__tests__/tableHeightCache.test.ts
@@ -34,6 +34,19 @@ describe('tableHeightCache', () => {
         expect(tableHeightCache.get({ tableFrom: table.tableFrom, tableText: '| edited |\n| --- |' })).toBe(HEIGHT);
     });
 
+    it('prefers its own measurement over whatever was last measured at its position', () => {
+        const evicted = tableAt(1);
+        const shiftedUp = { tableFrom: evicted.tableFrom, tableText: tableAt(2).tableText };
+        const OWN_HEIGHT = 300;
+
+        // Both tables have been measured; then the one above is deleted and the second
+        // table slides into the first one's offset.
+        tableHeightCache.set({ ...evicted, heightPx: HEIGHT });
+        tableHeightCache.set({ ...tableAt(2), heightPx: OWN_HEIGHT });
+
+        expect(tableHeightCache.get(shiftedUp)).toBe(OWN_HEIGHT);
+    });
+
     it('ignores non-positive and non-finite measurements', () => {
         const table = tableAt(1);
 

--- a/src/contentScript/__tests__/tableHeightCache.test.ts
+++ b/src/contentScript/__tests__/tableHeightCache.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { MAX_ENTRIES, tableHeightCache } from '../tableWidget/tableHeightCache';
+
+const HEIGHT = 120;
+
+/** Distinct table text and a distinct document position for table number `n`. */
+function tableAt(n: number): { tableFrom: number; tableText: string } {
+    return { tableFrom: n * 1000, tableText: `| h${n} |\n| --- |\n| c${n} |` };
+}
+
+describe('tableHeightCache', () => {
+    beforeEach(() => {
+        tableHeightCache.clear();
+    });
+
+    it('returns a measured height for the same table', () => {
+        const table = tableAt(1);
+        tableHeightCache.set({ ...table, heightPx: HEIGHT });
+
+        expect(tableHeightCache.get(table)).toBe(HEIGHT);
+    });
+
+    it('returns the height after the table moves, matching on text', () => {
+        const table = tableAt(1);
+        tableHeightCache.set({ ...table, heightPx: HEIGHT });
+
+        expect(tableHeightCache.get({ tableFrom: table.tableFrom + 500, tableText: table.tableText })).toBe(HEIGHT);
+    });
+
+    it('returns the height after the table text changes, matching on position', () => {
+        const table = tableAt(1);
+        tableHeightCache.set({ ...table, heightPx: HEIGHT });
+
+        expect(tableHeightCache.get({ tableFrom: table.tableFrom, tableText: '| edited |\n| --- |' })).toBe(HEIGHT);
+    });
+
+    it('ignores non-positive and non-finite measurements', () => {
+        const table = tableAt(1);
+
+        tableHeightCache.set({ ...table, heightPx: 0 });
+        tableHeightCache.set({ ...table, heightPx: Number.NaN });
+
+        expect(tableHeightCache.get(table)).toBeUndefined();
+    });
+
+    it('retains MAX_ENTRIES tables, not half that', () => {
+        // Every measurement writes both a text and a position entry. Under a single
+        // shared budget that made the real capacity MAX_ENTRIES / 2 tables.
+        for (let n = 0; n < MAX_ENTRIES; n++) {
+            tableHeightCache.set({ ...tableAt(n), heightPx: HEIGHT });
+        }
+
+        expect(tableHeightCache.get(tableAt(0))).toBe(HEIGHT);
+        expect(tableHeightCache.get(tableAt(MAX_ENTRIES - 1))).toBe(HEIGHT);
+    });
+
+    it('evicts the least recently used table once full', () => {
+        for (let n = 0; n < MAX_ENTRIES; n++) {
+            tableHeightCache.set({ ...tableAt(n), heightPx: HEIGHT });
+        }
+
+        tableHeightCache.set({ ...tableAt(MAX_ENTRIES), heightPx: HEIGHT });
+
+        expect(tableHeightCache.get(tableAt(0))).toBeUndefined();
+        expect(tableHeightCache.get(tableAt(MAX_ENTRIES))).toBe(HEIGHT);
+    });
+
+    it('spares a table that was read recently', () => {
+        for (let n = 0; n < MAX_ENTRIES; n++) {
+            tableHeightCache.set({ ...tableAt(n), heightPx: HEIGHT });
+        }
+
+        // Reading table 0 refreshes its recency, so the next insert evicts a table
+        // that has not been touched since it was measured.
+        expect(tableHeightCache.get(tableAt(0))).toBe(HEIGHT);
+        tableHeightCache.set({ ...tableAt(MAX_ENTRIES), heightPx: HEIGHT });
+
+        expect(tableHeightCache.get(tableAt(0))).toBe(HEIGHT);
+    });
+});

--- a/src/contentScript/tableWidget/tableHeightCache.ts
+++ b/src/contentScript/tableWidget/tableHeightCache.ts
@@ -5,39 +5,64 @@
  * can stabilize scrolling when large block widgets are mounted/rebuilt.
  */
 
-const MAX_ENTRIES = 200;
+/** Per-index capacity: each index holds up to this many tables. */
+export const MAX_ENTRIES = 200;
+
+/**
+ * Bounded map with least-recently-used eviction.
+ *
+ * Insertion order is recency order: `get` and `set` both move a key to the end,
+ * so the oldest key is always the first one `keys()` yields.
+ */
+class LruMap<K, V> {
+    private readonly entries = new Map<K, V>();
+
+    constructor(private readonly maxEntries: number) {}
+
+    public get(key: K): V | undefined {
+        const value = this.entries.get(key);
+        if (value === undefined) {
+            return undefined;
+        }
+        // Refresh recency.
+        this.entries.delete(key);
+        this.entries.set(key, value);
+        return value;
+    }
+
+    public set(key: K, value: V): void {
+        // A key already present is being refreshed, not added, so it needs no eviction.
+        if (!this.entries.delete(key) && this.entries.size >= this.maxEntries) {
+            const oldest = this.entries.keys().next().value as K | undefined;
+            if (oldest !== undefined) {
+                this.entries.delete(oldest);
+            }
+        }
+        this.entries.set(key, value);
+    }
+
+    public clear(): void {
+        this.entries.clear();
+    }
+}
 
 class TableHeightCache {
-    private readonly cache = new Map<string, number>();
-
-    private getTextKey(tableText: string): string {
-        return `text:${tableText}`;
-    }
-
-    private getFromKey(tableFrom: number): string {
-        return `from:${tableFrom}`;
-    }
+    // Two independent indexes over the same measurements. Sharing one budget would
+    // halve the effective capacity, since every measurement writes to both, and would
+    // let a table's two entries evict each other.
+    private readonly byText = new LruMap<string, number>(MAX_ENTRIES);
+    private readonly byPosition = new LruMap<number, number>(MAX_ENTRIES);
 
     public getMeasureKey(tableFrom: number, tableText: string): string {
         // Prefer a stable per-table key for requestMeasure deduping.
-        return `${this.getFromKey(tableFrom)}|${this.getTextKey(tableText)}`;
-    }
-
-    private getByKey(key: string): number | undefined {
-        const value = this.cache.get(key);
-        if (value !== undefined) {
-            // Refresh recency.
-            this.cache.delete(key);
-            this.cache.set(key, value);
-        }
-        return value;
+        return `from:${tableFrom}|text:${tableText}`;
     }
 
     public get(params: { tableFrom: number; tableText: string }): number | undefined {
         // During in-table edits, `tableText` changes but `tableFrom` usually doesn't.
         // During edits above the table, `tableFrom` changes but `tableText` doesn't.
         // Checking both makes the cache useful in both situations.
-        return this.getByKey(this.getFromKey(params.tableFrom)) ?? this.getByKey(this.getTextKey(params.tableText));
+        return this.byPosition.get(params.tableFrom) ?? this.byText.get(params.tableText);
     }
 
     public set(params: { tableFrom: number; tableText: string; heightPx: number }): void {
@@ -46,24 +71,13 @@ class TableHeightCache {
             return;
         }
 
-        const keys = [this.getFromKey(tableFrom), this.getTextKey(tableText)];
-        for (const key of keys) {
-            // Refresh recency.
-            if (this.cache.has(key)) {
-                this.cache.delete(key);
-            } else if (this.cache.size >= MAX_ENTRIES) {
-                const firstKey = this.cache.keys().next().value as string | undefined;
-                if (firstKey !== undefined) {
-                    this.cache.delete(firstKey);
-                }
-            }
-
-            this.cache.set(key, heightPx);
-        }
+        this.byText.set(tableText, heightPx);
+        this.byPosition.set(tableFrom, heightPx);
     }
 
     public clear(): void {
-        this.cache.clear();
+        this.byText.clear();
+        this.byPosition.clear();
     }
 }
 

--- a/src/contentScript/tableWidget/tableHeightCache.ts
+++ b/src/contentScript/tableWidget/tableHeightCache.ts
@@ -62,7 +62,12 @@ class TableHeightCache {
         // During in-table edits, `tableText` changes but `tableFrom` usually doesn't.
         // During edits above the table, `tableFrom` changes but `tableText` doesn't.
         // Checking both makes the cache useful in both situations.
-        return this.byPosition.get(params.tableFrom) ?? this.byText.get(params.tableText);
+        //
+        // Text wins: identical source at the same editor width renders to the same
+        // height, so a text hit is this table's own measurement. A position hit only
+        // means some table was last measured at that offset, which stops being this
+        // table as soon as one above it is deleted.
+        return this.byText.get(params.tableText) ?? this.byPosition.get(params.tableFrom);
     }
 
     public set(params: { tableFrom: number; tableText: string; heightPx: number }): void {


### PR DESCRIPTION
Introduce two independent LRU indexes for height caching, one keyed by source text and the other by document position. This change improves cache efficiency and ensures that height measurements remain accurate during edits. The lookup order now prioritizes text-based measurements, reducing stale height estimates. Each index maintains its own budget, allowing for a maximum of 200 entries per index.