### PR TITLE
refactor: shared cell render module

### DIFF
--- a/src/contentScript/__tests__/renderCellInto.test.ts
+++ b/src/contentScript/__tests__/renderCellInto.test.ts
@@ -1,0 +1,95 @@
+/** @vitest-environment jsdom */
+
+import { describe, expect, it, vi } from 'vitest';
+import type { MarkdownRenderService } from '../services/markdownRenderer';
+import { renderCellMarkdownInto } from '../services/renderCellInto';
+import { deferred } from './testUtils';
+
+function createRenderer(overrides: Partial<MarkdownRenderService> = {}): MarkdownRenderService {
+    return {
+        getCached: vi.fn(() => undefined),
+        render: vi.fn(() => Promise.resolve('')),
+        clear: vi.fn(),
+        ...overrides,
+    };
+}
+
+function createTarget(connected = true): HTMLElement {
+    const el = document.createElement('div');
+    if (connected) {
+        document.body.appendChild(el);
+    }
+    return el;
+}
+
+describe('renderCellMarkdownInto', () => {
+    it('writes cached HTML immediately without requesting a render', () => {
+        const renderer = createRenderer({ getCached: vi.fn(() => '<p><strong>cached</strong></p>') });
+        const target = createTarget();
+
+        renderCellMarkdownInto(target, '**cached**', renderer);
+
+        expect(target.innerHTML).toBe('<p><strong>cached</strong></p>');
+        expect(renderer.render).not.toHaveBeenCalled();
+        target.remove();
+    });
+
+    it('normalizes cell text before cache lookup and rendering', () => {
+        const rendered = deferred<string>();
+        const renderer = createRenderer({ render: vi.fn(() => rendered.promise) });
+        const target = createTarget();
+
+        // Escaped pipes are unescaped, and a leading list marker is escaped so the cell
+        // renders as inline markdown rather than a list.
+        renderCellMarkdownInto(target, '- a \\| b', renderer);
+
+        expect(renderer.getCached).toHaveBeenCalledWith('\\- a | b');
+        expect(renderer.render).toHaveBeenCalledWith('\\- a | b');
+        rendered.resolve('<p>- a | b</p>');
+        target.remove();
+    });
+
+    it('shows escaped text first, then swaps in the async result', async () => {
+        const rendered = deferred<string>();
+        const renderer = createRenderer({ render: vi.fn(() => rendered.promise) });
+        const target = createTarget();
+
+        renderCellMarkdownInto(target, 'a <b> **c**<br>d', renderer);
+
+        // <br> survives as a real line break; other markup is escaped.
+        expect(target.innerHTML).toBe('a &lt;b&gt; **c**<br>d');
+
+        rendered.resolve('<p>rendered</p>');
+        await rendered.promise;
+        await Promise.resolve();
+
+        expect(target.innerHTML).toBe('<p>rendered</p>');
+        target.remove();
+    });
+
+    it('skips the async swap when the target left the DOM', async () => {
+        const rendered = deferred<string>();
+        const renderer = createRenderer({ render: vi.fn(() => rendered.promise) });
+        const target = createTarget();
+
+        renderCellMarkdownInto(target, '**body**', renderer);
+        target.remove();
+
+        rendered.resolve('<p>rendered</p>');
+        await rendered.promise;
+        await Promise.resolve();
+
+        expect(target.innerHTML).toBe('**body**');
+    });
+
+    it('does not request a render for plain text', () => {
+        const renderer = createRenderer();
+        const target = createTarget();
+
+        renderCellMarkdownInto(target, 'plain text', renderer);
+
+        expect(target.innerHTML).toBe('plain text');
+        expect(renderer.render).not.toHaveBeenCalled();
+        target.remove();
+    });
+});

--- a/src/contentScript/nestedEditor/nestedEditorController.ts
+++ b/src/contentScript/nestedEditor/nestedEditorController.ts
@@ -24,14 +24,13 @@ import {
     type ResolvedActiveCell,
 } from '../tableRuntime/activeCell/resolvedActiveCell';
 import { clearActiveCellEffect, getActiveCell } from '../tableState/activeCellState';
-import { buildRenderableContent, containsMarkdown, escapeHtmlPreservingBr } from '../shared/cellContentUtils';
 import { CLASS_CELL_ACTIVE } from '../shared/tableDomClasses';
 import { markdownRenderServiceFacet } from '../services/markdownRenderer';
+import { renderCellMarkdownInto } from '../services/renderCellInto';
 import type { NestedEditorHostConfig } from '../../contentScriptBridge/hostEditorConfigBridge';
 import { createNestedEditorFeatureExtensions } from './nestedEditorFeatureConfig';
 import { requestViewAnimationFrame } from '../shared/domContext';
 import { clamp } from '../shared/numberUtils';
-import { logger } from '../../logger';
 
 const SYNTAX_TREE_PARSE_TIMEOUT = 50;
 
@@ -249,27 +248,8 @@ class NestedEditorController {
             const renderer = mainView.state.facet(markdownRenderServiceFacet);
             const { contentFrom, contentTo } = cellRange;
             const cellText = mainView.state.doc.sliceString(contentFrom, contentTo).trim();
-            const { displayText, cacheKey } = buildRenderableContent(cellText);
-            const cached = renderer.getCached(cacheKey);
 
-            if (cached !== undefined) {
-                this.contentEl.innerHTML = cached;
-            } else {
-                this.contentEl.innerHTML = escapeHtmlPreservingBr(displayText);
-                if (containsMarkdown(cacheKey)) {
-                    const contentEl = this.contentEl;
-                    void renderer
-                        .render(cacheKey)
-                        .then((html) => {
-                            if (contentEl.isConnected) {
-                                contentEl.innerHTML = html;
-                            }
-                        })
-                        .catch((error) => {
-                            logger.error('Failed to render nested editor markdown:', error);
-                        });
-                }
-            }
+            renderCellMarkdownInto(this.contentEl, cellText, renderer);
         }
 
         this.session = null;

--- a/src/contentScript/services/renderCellInto.ts
+++ b/src/contentScript/services/renderCellInto.ts
@@ -1,0 +1,46 @@
+import { buildRenderableContent, containsMarkdown, escapeHtmlPreservingBr } from '../shared/cellContentUtils';
+import type { MarkdownRenderService } from './markdownRenderer';
+import { logger } from '../../logger';
+
+/**
+ * Renders a cell's markdown into an existing element.
+ *
+ * Shared by the table widget (which renders into a freshly created content wrapper) and the
+ * nested editor controller (which renders back into the wrapper it took over on activation),
+ * so both paths stay identical: cached HTML is written synchronously, and a cache miss shows
+ * escaped text first and swaps in the rendered HTML when it arrives.
+ *
+ * The caller owns the target element; this function only writes its content.
+ */
+export function renderCellMarkdownInto(target: HTMLElement, markdown: string, renderer: MarkdownRenderService): void {
+    const { displayText, cacheKey } = buildRenderableContent(markdown);
+
+    // Check if we have cached rendered HTML for the normalized cell content
+    const cached = renderer.getCached(cacheKey);
+    if (cached !== undefined) {
+        target.innerHTML = cached;
+        return;
+    }
+
+    // Show content with <br> rendered as line breaks while async render runs
+    target.innerHTML = escapeHtmlPreservingBr(displayText);
+
+    // Check if content likely contains markdown (optimization)
+    if (!containsMarkdown(cacheKey)) {
+        return;
+    }
+
+    // Request async rendering and update when ready
+    void renderer
+        .render(cacheKey)
+        .then((html) => {
+            // Only update if the target is still in the DOM.
+            // Note: Height re-measurement is handled automatically by ResizeObserver.
+            if (target.isConnected) {
+                target.innerHTML = html;
+            }
+        })
+        .catch((error) => {
+            logger.error('Failed to render cell markdown:', error);
+        });
+}

--- a/src/contentScript/tableWidget/TableWidget.ts
+++ b/src/contentScript/tableWidget/TableWidget.ts
@@ -20,9 +20,8 @@ import {
     getCellSelector,
 } from './domHelpers';
 import { estimateTableHeight } from './tableHeightEstimation';
-import { buildRenderableContent, containsMarkdown, escapeHtmlPreservingBr } from '../shared/cellContentUtils';
+import { renderCellMarkdownInto } from '../services/renderCellInto';
 import { getViewDocument, getViewWindow } from '../shared/domContext';
-import { logger } from '../../logger';
 
 /**
  * What a rendered widget root currently represents.
@@ -228,40 +227,13 @@ export class TableWidget extends WidgetType {
         doc: Document,
         renderer: MarkdownRenderService
     ): void {
-        const { displayText, cacheKey } = buildRenderableContent(markdown);
-
         // Create a wrapper div for the content. This matches the structure ensureCellWrapper()
         // creates on activation, ensuring CSS rules (like white-space: normal) apply consistently.
         const contentWrapper = doc.createElement('div');
         contentWrapper.className = CLASS_CELL_CONTENT;
         cell.appendChild(contentWrapper);
 
-        // Check if we have cached rendered HTML for the normalized cell content
-        const cached = renderer.getCached(cacheKey);
-        if (cached !== undefined) {
-            contentWrapper.innerHTML = cached;
-            return;
-        }
-
-        // Show content with <br> rendered as line breaks while async render runs
-        contentWrapper.innerHTML = escapeHtmlPreservingBr(displayText);
-
-        // Check if content likely contains markdown (optimization)
-        if (containsMarkdown(cacheKey)) {
-            // Request async rendering and update when ready
-            void renderer
-                .render(cacheKey)
-                .then((html) => {
-                    // Only update if the wrapper is still in the DOM.
-                    // Note: Height re-measurement is handled automatically by ResizeObserver.
-                    if (contentWrapper.isConnected) {
-                        contentWrapper.innerHTML = html;
-                    }
-                })
-                .catch((error) => {
-                    logger.error('Failed to render table cell markdown:', error);
-                });
-        }
+        renderCellMarkdownInto(contentWrapper, markdown, renderer);
     }
 
     /**


### PR DESCRIPTION
extract duplicated cell rendering logic from TableWidget and the nested editor controller into a shared module