### PR TITLE
refactor: mark TableWidget constructor fields readonly

### DIFF
--- a/src/contentScript/tableWidget/TableWidget.ts
+++ b/src/contentScript/tableWidget/TableWidget.ts
@@ -79,10 +79,10 @@ function requestTableMeasurement(container: HTMLElement): void {
  */
 export class TableWidget extends WidgetType {
     constructor(
-        private tableData: MarkdownTable,
+        private readonly tableData: MarkdownTable,
         private readonly cellRanges: TableCellRanges,
-        private tableText: string,
-        private tableFrom: number
+        private readonly tableText: string,
+        private readonly tableFrom: number
     ) {
         super();
     }


### PR DESCRIPTION
tableData, tableText, and tableFrom were mutable only by accident — nothing reassigns them, and widgetDomState is the single write point for position updates. Making them readonly (matching cellRanges) lets the compiler enforce that. No behavior change.