### PR TITLE
refactor: define the footnote anchor format in one place

### DIFF
--- a/src/contentScript/__tests__/footnoteAnchor.test.ts
+++ b/src/contentScript/__tests__/footnoteAnchor.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { buildFootnoteHref, parseFootnoteHref } from '../shared/footnoteAnchor';
+
+describe('footnote anchor contract', () => {
+    it.each(['1', 'abc', 'my note', 'héllo', 'a/b?c#d', '100%'])(
+        'round-trips the label %j through an href',
+        (label) => {
+            expect(parseFootnoteHref(buildFootnoteHref(label))).toBe(label);
+        }
+    );
+
+    it('percent-encodes characters that are unsafe in an href', () => {
+        expect(buildFootnoteHref('my note')).toBe('#fn-my%20note');
+    });
+
+    it.each(['#heading', '#fn', '#fn-', '#fnref-1', 'https://example.com', ':/abc123', ''])(
+        'returns null for %j, which is not a footnote href',
+        (href) => {
+            expect(parseFootnoteHref(href)).toBeNull();
+        }
+    );
+
+    it('falls back to the raw text when a hand-authored href has a malformed escape', () => {
+        expect(parseFootnoteHref('#fn-50%off')).toBe('50%off');
+    });
+});

--- a/src/contentScript/__tests__/tableWidgetInteractions.test.ts
+++ b/src/contentScript/__tests__/tableWidgetInteractions.test.ts
@@ -4,6 +4,7 @@ import { getActiveCell } from '../tableState/activeCellState';
 import { getCellSelection, setCellSelectionEffect } from '../tableState/cellSelectionState';
 import { handleTableInteraction } from '../tableWidget/tableWidgetInteractions';
 import { linkOpenerFacet } from '../services/linkOpener';
+import { buildFootnoteHref } from '../shared/footnoteAnchor';
 import {
     createInteractiveTableHarness,
     getLastDispatchSpec,
@@ -122,6 +123,7 @@ describe('table widget interactions', () => {
             '## Real Heading',
             '',
             '[^1]: actual footnote',
+            '[^my note]: spaced footnote',
         ].join('\n');
 
         const posOfLine = (doc: string, line: string): number => doc.indexOf(`\n${line}`) + 1;
@@ -164,6 +166,22 @@ describe('table widget interactions', () => {
                 selection: { anchor: posOfLine(ANCHOR_DOC, '[^1]: actual footnote') },
                 scrollIntoView: true,
             });
+        });
+
+        it('decodes the label so footnotes with unsafe characters resolve', () => {
+            const { view, handled } = clickAnchorLink(buildFootnoteHref('my note'));
+
+            expect(handled).toBe(true);
+            expect(getLastDispatchSpec(view as unknown as MutableTestView)).toMatchObject({
+                selection: { anchor: posOfLine(ANCHOR_DOC, '[^my note]: spaced footnote') },
+            });
+        });
+
+        it('does not fall back to a heading when a footnote anchor has no definition', () => {
+            const { view, handled } = clickAnchorLink(buildFootnoteHref('missing'));
+
+            expect(handled).toBe(true);
+            expect((view as unknown as MutableTestView).dispatch).not.toHaveBeenCalled();
         });
 
         it('scrolls to the heading whose slug matches the anchor', () => {

--- a/src/contentScript/services/htmlPostProcessor.ts
+++ b/src/contentScript/services/htmlPostProcessor.ts
@@ -1,3 +1,5 @@
+import { buildFootnoteHref } from '../shared/footnoteAnchor';
+
 /**
  * Post-process rendered HTML to fix Joplin-specific display issues.
  * Includes KaTeX optimization and footnote reference conversion.
@@ -91,8 +93,7 @@ function processFootnotesInNode(node: Node): void {
                     sup.className = 'footnote-ref';
 
                     const a = document.createElement('a');
-                    // Encode any unsafe characters in the label for the ID
-                    a.href = `#fn-${encodeURIComponent(label)}`;
+                    a.href = buildFootnoteHref(label);
                     a.textContent = label;
 
                     sup.appendChild(a);

--- a/src/contentScript/shared/footnoteAnchor.ts
+++ b/src/contentScript/shared/footnoteAnchor.ts
@@ -1,0 +1,39 @@
+/**
+ * The footnote anchor contract between the cell renderer and the click handler.
+ *
+ * Cells are rendered in isolation, which breaks markdown-it-footnote's document-wide
+ * numbering, so the post-processor synthesizes its own links for `[^label]` text
+ * (see htmlPostProcessor). Those hrefs are never consumed by anything outside this
+ * plugin, so the format is defined here once and both sides go through it.
+ */
+
+const FOOTNOTE_HREF_PREFIX = '#fn-';
+
+/** Href for a footnote reference to `label`. */
+export function buildFootnoteHref(label: string): string {
+    return `${FOOTNOTE_HREF_PREFIX}${encodeURIComponent(label)}`;
+}
+
+/**
+ * The label a footnote href refers to, or null when `href` is not one of ours.
+ * Reverses `buildFootnoteHref`, so the label matches the `[^label]:` definition
+ * as the author wrote it — including spaces and non-ASCII characters.
+ */
+export function parseFootnoteHref(href: string): string | null {
+    if (!href.startsWith(FOOTNOTE_HREF_PREFIX)) {
+        return null;
+    }
+
+    const encoded = href.slice(FOOTNOTE_HREF_PREFIX.length);
+    if (!encoded) {
+        return null;
+    }
+
+    try {
+        return decodeURIComponent(encoded);
+    } catch {
+        // Hand-authored href with a malformed escape (e.g. `#fn-100%`); the raw
+        // text is the author's best guess at the label.
+        return encoded;
+    }
+}

--- a/src/contentScript/tableWidget/tableWidgetInteractions.ts
+++ b/src/contentScript/tableWidget/tableWidgetInteractions.ts
@@ -1,6 +1,7 @@
 import type { EditorView } from '@codemirror/view';
 import { CLASS_CELL_EDITOR } from '../shared/tableDomClasses';
 import { slugify } from '../shared/cellContentUtils';
+import { parseFootnoteHref } from '../shared/footnoteAnchor';
 import { clearActiveCellEffect, getActiveCell, type ActiveCellSection } from '../tableState/activeCellState';
 import { clearCellSelectionEffect, getCellSelection } from '../tableState/cellSelectionState';
 import type { CellCoords } from '../tableModel/types';
@@ -16,12 +17,6 @@ const FENCED_CODE_REGEX = /^(`{3,}|~{3,})/;
 
 /** Matches an ATX heading, capturing the hashes and the heading text: `## Some heading` */
 const HEADING_REGEX = /^(#{1,6})\s+(.*)/;
-
-/** Matches footnote anchors without a `ref` prefix: `#fn1`, `#fn-1` */
-const FOOTNOTE_ANCHOR_REGEX = /^#fn-?(.+)$/;
-
-/** Matches footnote back-reference anchors: `#fnref1`, `#fnref-1` */
-const FOOTNOTE_REF_ANCHOR_REGEX = /^#fnref-?(.+)$/;
 
 const ANCHOR_HREF_PREFIX = '#';
 
@@ -87,26 +82,15 @@ function isHeadingWithSlug(line: string, slug: string): boolean {
 }
 
 /**
- * Extract the footnote label from an anchor.
- *
- * NOTE: `FOOTNOTE_REF_ANCHOR_REGEX` is currently unreachable — `#fnref1` / `#fnref-1`
- * already match `FOOTNOTE_ANCHOR_REGEX`, which captures the label as `ref1` / `ref-1`.
- * Kept verbatim so this stays behaviour-preserving; correcting it is a separate change.
- */
-function extractFootnoteLabel(anchor: string): string | null {
-    const match = anchor.match(FOOTNOTE_ANCHOR_REGEX) || anchor.match(FOOTNOTE_REF_ANCHOR_REGEX);
-    return match ? match[1] : null;
-}
-
-/**
  * Resolve an internal anchor link to a document position.
- * Footnote anchors can be #fn1, #fn-1, #fnref1, #fnref-1 depending on markdown-it config;
- * anything else is treated as a heading slug.
+ * Footnote anchors are the ones this plugin renders for `[^label]` text; anything
+ * else is treated as a heading slug.
  */
 function resolveAnchorPosition(view: EditorView, anchor: string): number | null {
-    const footnoteLabel = extractFootnoteLabel(anchor);
+    const footnoteLabel = parseFootnoteHref(anchor);
     if (footnoteLabel !== null) {
-        // Search for the footnote definition [^label]: in the document
+        // Search for the footnote definition [^label]: in the document.
+        // A footnote anchor never falls back to a heading lookup.
         const pattern = new RegExp(String.raw`^\s*\[\^${escapeRegex(footnoteLabel)}\]:`, 'i');
         return findLinePosition(view, (line) => pattern.test(line));
     }
@@ -173,7 +157,7 @@ function handleWidgetClick(view: EditorView, event: MouseEvent, target: HTMLElem
     event.preventDefault();
     event.stopPropagation();
 
-    // Handle internal anchor links (e.g., footnotes #fn-1, #fnref-1)
+    // Handle internal anchor links (headings and footnotes, e.g. #fn-1)
     // Joplin's openItem doesn't support these, so we scroll manually
     if (href.startsWith(ANCHOR_HREF_PREFIX)) {
         scrollToAnchor(view, href);


### PR DESCRIPTION
The `#fn-<label>` href is a private contract: htmlPostProcessor is the only producer and tableWidgetInteractions the only consumer. Both sides hardcoded the format independently, so the parser had accumulated cases for shapes nothing emits — a `#fnref…` regex that was unreachable, and an optional hyphen the producer always writes.

Move the format into shared/footnoteAnchor.ts as buildFootnoteHref / parseFootnoteHref. Parsing is now startsWith + slice; both regexes are gone.

parseFootnoteHref also reverses the producer's encodeURIComponent, which nothing did before: `[^my note]` rendered as `#fn-my%20note` and then looked for a definition named `my%20note`, so any label with a space or non-ASCII character silently failed to resolve.

Hand-authored `#fn1` / `#fnref-1` hrefs in cells are no longer treated as footnotes. Nothing generates them, and the `#fnref` forms never resolved correctly anyway.