### PR TITLE
refactor: extract toolbar positioning geometry

### DIFF
--- a/src/contentScript/__tests__/toolbarPositioning.test.ts
+++ b/src/contentScript/__tests__/toolbarPositioning.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, it } from 'vitest';
+import {
+    computePinnedAbsolutePlacement,
+    computePinnedFixedPlacement,
+    isFinitePoint,
+    isObscuringTopPlacement,
+    isTableOutsideViewport,
+    resolveToolbarPlacementMode,
+    resolveViewportBounds,
+    shouldPinAbove,
+    TOOLBAR_VIEWPORT_PADDING_PX,
+    type ToolbarRect,
+    type ViewportBounds,
+} from '../toolbar/toolbarPositioning';
+
+function rect(partial: Partial<ToolbarRect>): ToolbarRect {
+    return { top: 0, bottom: 0, left: 0, width: 0, height: 0, ...partial };
+}
+
+const TOOLBAR_HEIGHT = 30;
+
+describe('resolveViewportBounds', () => {
+    it('uses the scroller rect when the editor scrolls internally', () => {
+        const bounds = resolveViewportBounds(true, rect({ top: 40, bottom: 640, height: 600 }), 1000);
+
+        expect(bounds).toEqual({ top: 40, bottom: 640, height: 600 });
+    });
+
+    it('anchors to the page top when the surrounding view scrolls', () => {
+        const bounds = resolveViewportBounds(false, rect({ top: -200, bottom: 400, height: 600 }), 800);
+
+        expect(bounds).toEqual({ top: 0, bottom: 800, height: 800 });
+    });
+});
+
+describe('isTableOutsideViewport', () => {
+    const viewport: ViewportBounds = { top: 100, bottom: 500, height: 400 };
+
+    it('reports a table scrolled above the viewport', () => {
+        expect(isTableOutsideViewport(rect({ top: 20, bottom: 100 }), viewport)).toBe(true);
+    });
+
+    it('reports a table scrolled below the viewport', () => {
+        expect(isTableOutsideViewport(rect({ top: 500, bottom: 600 }), viewport)).toBe(true);
+    });
+
+    it('does not report a partially visible table', () => {
+        expect(isTableOutsideViewport(rect({ top: 20, bottom: 200 }), viewport)).toBe(false);
+    });
+});
+
+describe('resolveToolbarPlacementMode', () => {
+    const viewport: ViewportBounds = { top: 100, bottom: 500, height: 400 };
+
+    it('anchors above when the table top is visible with room for the toolbar', () => {
+        const tableRect = rect({ top: 200, bottom: 300 });
+
+        expect(resolveToolbarPlacementMode(tableRect, TOOLBAR_HEIGHT, viewport)).toBe('top-start');
+    });
+
+    it('anchors below when the table top is visible but crowded against the viewport top', () => {
+        const tableRect = rect({ top: 110, bottom: 300 });
+
+        expect(resolveToolbarPlacementMode(tableRect, TOOLBAR_HEIGHT, viewport)).toBe('bottom-start');
+    });
+
+    it('pins when neither table edge has room', () => {
+        const tableRect = rect({ top: 110, bottom: 490 });
+
+        expect(resolveToolbarPlacementMode(tableRect, TOOLBAR_HEIGHT, viewport)).toBe('pinned');
+    });
+
+    it('pins when the table top has scrolled out of view and the bottom is crowded', () => {
+        const tableRect = rect({ top: -50, bottom: 495 });
+
+        expect(resolveToolbarPlacementMode(tableRect, TOOLBAR_HEIGHT, viewport)).toBe('pinned');
+    });
+
+    it('anchors below when the table top is out of view but the bottom has room', () => {
+        const tableRect = rect({ top: -50, bottom: 300 });
+
+        expect(resolveToolbarPlacementMode(tableRect, TOOLBAR_HEIGHT, viewport)).toBe('bottom-start');
+    });
+});
+
+describe('shouldPinAbove', () => {
+    const viewport: ViewportBounds = { top: 100, bottom: 500, height: 400 };
+
+    it('pins to the top edge when the table midpoint is below the viewport midpoint', () => {
+        expect(shouldPinAbove(rect({ top: 350, bottom: 900 }), viewport)).toBe(true);
+    });
+
+    it('pins to the bottom edge when the table midpoint is above the viewport midpoint', () => {
+        expect(shouldPinAbove(rect({ top: -400, bottom: 200 }), viewport)).toBe(false);
+    });
+});
+
+describe('computePinnedAbsolutePlacement', () => {
+    const base = {
+        toolbarRect: rect({ width: 200, height: TOOLBAR_HEIGHT }),
+        viewport: { top: 100, bottom: 500, height: 400 } as ViewportBounds,
+        viewRect: rect({ top: 100, left: 50, width: 600, height: 400 }),
+        offsetParentTop: 80,
+    };
+
+    it('positions against the top edge relative to the offset parent', () => {
+        const placement = computePinnedAbsolutePlacement({
+            ...base,
+            tableRect: rect({ top: 350, bottom: 900, left: 120 }),
+            pinAbove: true,
+        });
+
+        expect(placement).toEqual({ x: 70, y: 25, strategy: 'absolute' });
+    });
+
+    it('positions against the bottom edge when pinning below', () => {
+        const placement = computePinnedAbsolutePlacement({
+            ...base,
+            tableRect: rect({ top: -400, bottom: 200, left: 120 }),
+            pinAbove: false,
+        });
+
+        expect(placement).toEqual({ x: 70, y: 385, strategy: 'absolute' });
+    });
+
+    it('clamps the toolbar inside the editor panel', () => {
+        const placement = computePinnedAbsolutePlacement({
+            ...base,
+            tableRect: rect({ top: 350, bottom: 900, left: 5000 }),
+            pinAbove: true,
+        });
+
+        expect(placement.x).toBe(600 - 200 - TOOLBAR_VIEWPORT_PADDING_PX);
+    });
+
+    it('falls back to the padding when the panel is narrower than the toolbar', () => {
+        const placement = computePinnedAbsolutePlacement({
+            ...base,
+            viewRect: rect({ top: 100, left: 50, width: 100, height: 400 }),
+            tableRect: rect({ top: 350, bottom: 900, left: 5000 }),
+            pinAbove: true,
+        });
+
+        expect(placement.x).toBe(TOOLBAR_VIEWPORT_PADDING_PX);
+    });
+
+    it('never pins above the viewport top when the bottom edge would be higher', () => {
+        const placement = computePinnedAbsolutePlacement({
+            ...base,
+            viewport: { top: 100, bottom: 110, height: 10 },
+            tableRect: rect({ top: -400, bottom: 105, left: 120 }),
+            pinAbove: false,
+        });
+
+        // bottomInParent would be 110 - 80 - 30 - 5 = -5, so the top edge wins.
+        expect(placement.y).toBe(25);
+    });
+});
+
+describe('computePinnedFixedPlacement', () => {
+    const base = {
+        toolbarRect: rect({ width: 200, height: TOOLBAR_HEIGHT }),
+        viewport: { top: 0, bottom: 800, height: 800 } as ViewportBounds,
+        viewportWidth: 400,
+    };
+
+    it('uses viewport-relative coordinates when pinning above', () => {
+        const placement = computePinnedFixedPlacement({
+            ...base,
+            tableRect: rect({ top: 500, bottom: 1200, left: 30 }),
+            pinAbove: true,
+        });
+
+        expect(placement).toEqual({ x: 30, y: 5, strategy: 'fixed' });
+    });
+
+    it('uses viewport-relative coordinates when pinning below', () => {
+        const placement = computePinnedFixedPlacement({
+            ...base,
+            tableRect: rect({ top: -500, bottom: 300, left: 30 }),
+            pinAbove: false,
+        });
+
+        expect(placement).toEqual({ x: 30, y: 765, strategy: 'fixed' });
+    });
+
+    it('clamps the toolbar inside the viewport width', () => {
+        const placement = computePinnedFixedPlacement({
+            ...base,
+            tableRect: rect({ top: 500, bottom: 1200, left: 380 }),
+            pinAbove: true,
+        });
+
+        expect(placement.x).toBe(400 - 200 - TOOLBAR_VIEWPORT_PADDING_PX);
+    });
+});
+
+describe('isFinitePoint', () => {
+    it('accepts finite coordinates', () => {
+        expect(isFinitePoint({ x: 0, y: -12.5 })).toBe(true);
+    });
+
+    it('rejects NaN and Infinity coordinates', () => {
+        expect(isFinitePoint({ x: Number.NaN, y: 0 })).toBe(false);
+        expect(isFinitePoint({ x: 0, y: Number.POSITIVE_INFINITY })).toBe(false);
+    });
+});
+
+describe('isObscuringTopPlacement', () => {
+    it('flags a top placement pushed against the viewport top', () => {
+        expect(isObscuringTopPlacement('top-start', 2)).toBe(true);
+    });
+
+    it('ignores a top placement with clearance', () => {
+        expect(isObscuringTopPlacement('top-start', 40)).toBe(false);
+    });
+
+    it('ignores bottom placements', () => {
+        expect(isObscuringTopPlacement('bottom-start', 0)).toBe(false);
+    });
+});

--- a/src/contentScript/toolbar/tableToolbarPlugin.ts
+++ b/src/contentScript/toolbar/tableToolbarPlugin.ts
@@ -1,6 +1,6 @@
 import { ViewPlugin, ViewUpdate, EditorView } from '@codemirror/view';
 import { activeCellField, type ActiveCell } from '../tableState/activeCellState';
-import { computePosition, autoUpdate, offset, shift, hide } from '@floating-ui/dom';
+import { computePosition, autoUpdate, offset, shift, hide, type Middleware } from '@floating-ui/dom';
 import { syncAnnotation } from '../editorBridge/syncAnnotation';
 import { rebuildTableWidgetsEffect } from '../tableState/tableWidgetEffects';
 import { CLASS_FLOATING_TOOLBAR } from '../tableWidget/domHelpers';
@@ -8,11 +8,41 @@ import { findTableWidgetElement } from '../tableWidget/domHelpers';
 import { makeTableId } from '../tableModel/types';
 import { getToolbarButtonGroups, renderToolbarButtonGroups, type ToolbarActionId } from './toolbarLayout';
 import { getDocumentWindow, getViewDocument } from '../shared/domContext';
-import { clamp } from '../shared/numberUtils';
 import { isNestedEditorOpen, refocusNestedEditor } from '../nestedEditor/nestedEditorController';
 import { getResolvedActiveCell } from '../tableRuntime/activeCell/resolvedActiveCell';
 import { runStructuralAction } from '../tableRuntime/operations/structuralActions';
 import { hostEditorConfigFacet } from '../services/hostEditorConfig';
+import {
+    computePinnedAbsolutePlacement,
+    computePinnedFixedPlacement,
+    isFinitePoint,
+    isObscuringTopPlacement,
+    isTableOutsideViewport,
+    resolveToolbarPlacementMode,
+    resolveViewportBounds,
+    shouldPinAbove,
+    TOOLBAR_OFFSET_PX,
+    TOOLBAR_VIEWPORT_PADDING_PX,
+    type ToolbarPlacement,
+    type ViewportBounds,
+} from './toolbarPositioning';
+
+/** Everything resolved once per `autoUpdate` registration and reused by every reposition. */
+interface PositioningContext {
+    referenceElement: HTMLElement;
+    scrollDOM: HTMLElement;
+    doc: Document;
+    viewWindow: Window;
+    /** Desktop scrolls inside CodeMirror; mobile scrolls the surrounding WebView. */
+    isInternalScroll: boolean;
+}
+
+/** Measurements taken fresh on every reposition. */
+interface ToolbarGeometry {
+    toolbarRect: DOMRect;
+    tableRect: DOMRect;
+    viewport: ViewportBounds;
+}
 
 export class TableToolbarPlugin {
     dom: HTMLElement;
@@ -34,11 +64,12 @@ export class TableToolbarPlugin {
 
     update(update: ViewUpdate) {
         const prevActiveCell = this.currentActiveCell;
-        this.currentActiveCell = update.state.field(activeCellField);
+        const activeCell = update.state.field(activeCellField);
+        this.currentActiveCell = activeCell;
 
-        // Active cell state changed
-        if (!!prevActiveCell !== !!this.currentActiveCell) {
-            if (this.currentActiveCell) {
+        // Active cell appeared or disappeared
+        if (!!prevActiveCell !== !!activeCell) {
+            if (activeCell) {
                 // Defer until widget DOM is ready (runs in CM's measure cycle after DOM update)
                 this.schedulePositionUpdate();
             } else {
@@ -48,25 +79,13 @@ export class TableToolbarPlugin {
             return;
         }
 
-        // Active cell changed to different table
-        if (this.currentActiveCell && prevActiveCell && this.currentActiveCell.tableFrom !== prevActiveCell.tableFrom) {
-            // Defer until new table widget DOM is ready
-            this.schedulePositionUpdate();
+        if (!activeCell) {
             return;
         }
 
-        // Check for conditions that usually imply the widget DOM was replaced/rebuilt:
-        // 1. rebuildTableWidgetsEffect (explicit structural edit)
-        // 2. Doc changes that are NOT sync (e.g. Undo/Redo, external edits).
-        //    Non-sync changes cause `tableDecorationField` to rebuild decorations,
-        //    which leads to CodeMirror replacing the widget DOM if content changed.
-        const isNonSyncDocChange = update.transactions.some((tr) => tr.docChanged && !tr.annotation(syncAnnotation));
-        const hasRebuildEffect = update.transactions.some((tr) =>
-            tr.effects.some((e) => e.is(rebuildTableWidgetsEffect))
-        );
-
-        if (this.currentActiveCell && (hasRebuildEffect || isNonSyncDocChange)) {
-            // Defer until rebuilt widget DOM is ready
+        const movedToDifferentTable = prevActiveCell !== null && prevActiveCell.tableFrom !== activeCell.tableFrom;
+        if (movedToDifferentTable || hasRebuiltWidgetDom(update)) {
+            // Defer until the new/rebuilt widget DOM is ready
             this.schedulePositionUpdate();
         }
 
@@ -232,9 +251,15 @@ export class TableToolbarPlugin {
 
         const scrollDOM = this.view.scrollDOM;
         const doc = getViewDocument(this.view);
-        const viewWindow = getDocumentWindow(doc);
-        const isInternalScroll = scrollDOM.scrollHeight > scrollDOM.clientHeight + 1;
-        if (!isInternalScroll) {
+        const ctx: PositioningContext = {
+            referenceElement,
+            scrollDOM,
+            doc,
+            viewWindow: getDocumentWindow(doc),
+            isInternalScroll: scrollDOM.scrollHeight > scrollDOM.clientHeight + 1,
+        };
+
+        if (!ctx.isInternalScroll) {
             // External scroll (mobile) doesn't reliably trigger autoUpdate's ancestor scroll handlers.
             this.cleanupViewportListeners = this.attachViewportListeners();
         }
@@ -242,151 +267,8 @@ export class TableToolbarPlugin {
         this.cleanupAutoUpdate = autoUpdate(
             referenceElement,
             this.dom,
-            async () => {
-                // Ensure element is measurable (display:flex) but hidden (visibility:hidden)
-                // before asking Floating UI to compute position.
-                this.prepareToolbarForPositioning();
-
-                // Check if reference element is still in the DOM
-                if (!referenceElement.isConnected) {
-                    // Don't cleanup here - just hide and let the next update() call handle cleanup
-                    this.hideToolbar();
-                    return;
-                }
-
-                const toolbarRect = this.dom.getBoundingClientRect();
-                const tableRect = referenceElement.getBoundingClientRect();
-                const scrollDOMRect = scrollDOM.getBoundingClientRect();
-                // Desktop uses internal CM scrolling; mobile uses external WebView scrolling.
-                // For internal scroll, the visible viewport is the scrollDOM rect.
-                // For external scroll, use visualViewport/window dimensions anchored to the page.
-                const visualViewport = viewWindow.visualViewport;
-                const viewportHeight = isInternalScroll
-                    ? scrollDOMRect.height
-                    : (visualViewport?.height ?? viewWindow.innerHeight);
-                const viewportTop = isInternalScroll ? scrollDOMRect.top : 0;
-                const viewportBottom = isInternalScroll ? scrollDOMRect.bottom : viewportHeight;
-
-                const tableAboveViewport = tableRect.bottom <= viewportTop;
-                const tableBelowViewport = tableRect.top >= viewportBottom;
-
-                if (tableAboveViewport || tableBelowViewport) {
-                    this.hideToolbar();
-                    return;
-                }
-
-                const topVisible = tableRect.top >= viewportTop && tableRect.top <= viewportBottom;
-                const bottomVisible = tableRect.bottom >= viewportTop && tableRect.bottom <= viewportBottom;
-                const hasRoomAbove =
-                    tableRect.top - toolbarRect.height - TOOLBAR_OFFSET_PX >= viewportTop + TOOLBAR_VIEWPORT_PADDING_PX;
-                const hasRoomBelow =
-                    viewportBottom - tableRect.bottom - toolbarRect.height - TOOLBAR_OFFSET_PX >=
-                    TOOLBAR_VIEWPORT_PADDING_PX;
-
-                let result = null as Awaited<ReturnType<typeof computePosition>> | null;
-                let manualPosition = null as { x: number; y: number; fixed?: boolean } | null;
-
-                const middleware = [offset(TOOLBAR_OFFSET_PX), shift({ padding: TOOLBAR_VIEWPORT_PADDING_PX }), hide()];
-
-                if (topVisible && hasRoomAbove) {
-                    result = await computePosition(referenceElement, this.dom, {
-                        placement: 'top-start',
-                        middleware,
-                    });
-                } else if (bottomVisible && hasRoomBelow) {
-                    result = await computePosition(referenceElement, this.dom, {
-                        placement: 'bottom-start',
-                        middleware,
-                    });
-                } else {
-                    // Pinned mode: toolbar sticks to viewport edge when table top/bottom is out of view.
-                    const placeAbove = (tableRect.top + tableRect.bottom) / 2 > viewportTop + viewportHeight / 2;
-
-                    if (isInternalScroll) {
-                        // Desktop (internal scroll): use position: absolute with offset parent calculations
-                        // to keep the toolbar within the editor panel bounds.
-                        const viewRect = this.view.dom.getBoundingClientRect();
-                        const offsetParent = (this.dom.offsetParent ?? doc.body) as HTMLElement;
-                        const offsetParentRect = offsetParent.getBoundingClientRect();
-
-                        const minX = TOOLBAR_VIEWPORT_PADDING_PX;
-                        const maxX = Math.max(
-                            TOOLBAR_VIEWPORT_PADDING_PX,
-                            viewRect.width - toolbarRect.width - TOOLBAR_VIEWPORT_PADDING_PX
-                        );
-                        const x = clamp(tableRect.left - viewRect.left, minX, maxX);
-
-                        const topInParent = viewportTop - offsetParentRect.top + TOOLBAR_VIEWPORT_PADDING_PX;
-                        const bottomInParent =
-                            viewportBottom - offsetParentRect.top - toolbarRect.height - TOOLBAR_VIEWPORT_PADDING_PX;
-                        const y = placeAbove ? topInParent : Math.max(topInParent, bottomInParent);
-                        manualPosition = { x, y, fixed: false };
-                    } else {
-                        // Mobile (external scroll): use position: fixed with viewport-relative coordinates
-                        // to avoid jitter caused by offset parent recalculations during scroll.
-                        // Mobile editor disables pinch-zoom (maximum-scale=1), so pageLeft should be 0.
-                        const viewportWidth = visualViewport?.width ?? viewWindow.innerWidth;
-                        const minX = TOOLBAR_VIEWPORT_PADDING_PX;
-                        const maxX = Math.max(
-                            TOOLBAR_VIEWPORT_PADDING_PX,
-                            viewportWidth - toolbarRect.width - TOOLBAR_VIEWPORT_PADDING_PX
-                        );
-                        const x = clamp(tableRect.left, minX, maxX);
-
-                        const y = placeAbove
-                            ? viewportTop + TOOLBAR_VIEWPORT_PADDING_PX
-                            : viewportBottom - toolbarRect.height - TOOLBAR_VIEWPORT_PADDING_PX;
-
-                        manualPosition = { x, y, fixed: true };
-                    }
-                }
-
-                if (result?.middlewareData.hide?.referenceHidden) {
-                    this.hideToolbar();
-                    return;
-                }
-
-                // Avoid rendering if we somehow produced a non-finite position.
-                if (
-                    (result && (!Number.isFinite(result.x) || !Number.isFinite(result.y))) ||
-                    (manualPosition && (!Number.isFinite(manualPosition.x) || !Number.isFinite(manualPosition.y)))
-                ) {
-                    this.hideToolbar();
-                    return;
-                }
-
-                // If we positioned relative to the table, keep the existing obscuration guard.
-                if (result && result.placement.startsWith('top') && result.y < TOOLBAR_OBSCURATION_THRESHOLD_PX) {
-                    const fallback = await computePosition(referenceElement, this.dom, {
-                        placement: 'bottom-start',
-                        middleware,
-                    });
-                    if (!fallback.middlewareData.hide?.referenceHidden) {
-                        result = fallback;
-                    }
-                }
-
-                this.showToolbar();
-                if (manualPosition) {
-                    Object.assign(this.dom.style, {
-                        position: manualPosition.fixed ? 'fixed' : 'absolute',
-                        left: `${manualPosition.x}px`,
-                        top: `${manualPosition.y}px`,
-                    });
-                    return;
-                }
-
-                if (!result) {
-                    this.hideToolbar();
-                    return;
-                }
-
-                // Reset to absolute positioning for Floating UI results
-                this.dom.style.position = 'absolute';
-                Object.assign(this.dom.style, {
-                    left: `${result.x}px`,
-                    top: `${result.y}px`,
-                });
+            () => {
+                void this.positionToolbar(ctx);
             },
             {
                 ancestorScroll: true,
@@ -396,6 +278,121 @@ export class TableToolbarPlugin {
                 animationFrame: false,
             }
         );
+    }
+
+    /** Measures the current layout and moves the toolbar, or hides it when it cannot be placed. */
+    private async positionToolbar(ctx: PositioningContext) {
+        // Ensure element is measurable (display:flex) but hidden (visibility:hidden)
+        // before asking Floating UI to compute position.
+        this.prepareToolbarForPositioning();
+
+        // Check if reference element is still in the DOM
+        if (!ctx.referenceElement.isConnected) {
+            // Don't cleanup here - just hide and let the next update() call handle cleanup
+            this.hideToolbar();
+            return;
+        }
+
+        const geometry = this.readGeometry(ctx);
+        if (isTableOutsideViewport(geometry.tableRect, geometry.viewport)) {
+            this.hideToolbar();
+            return;
+        }
+
+        const mode = resolveToolbarPlacementMode(geometry.tableRect, geometry.toolbarRect.height, geometry.viewport);
+        const placement =
+            mode === 'pinned'
+                ? this.resolvePinnedPlacement(ctx, geometry)
+                : await this.resolveAnchoredPlacement(ctx, mode);
+
+        if (!placement) {
+            this.hideToolbar();
+            return;
+        }
+
+        this.showToolbar();
+        this.applyPlacement(placement);
+    }
+
+    private readGeometry(ctx: PositioningContext): ToolbarGeometry {
+        const visualViewport = ctx.viewWindow.visualViewport;
+
+        return {
+            toolbarRect: this.dom.getBoundingClientRect(),
+            tableRect: ctx.referenceElement.getBoundingClientRect(),
+            viewport: resolveViewportBounds(
+                ctx.isInternalScroll,
+                ctx.scrollDOM.getBoundingClientRect(),
+                visualViewport?.height ?? ctx.viewWindow.innerHeight
+            ),
+        };
+    }
+
+    /**
+     * Asks Floating UI to anchor the toolbar to the table, retrying below when a top placement
+     * would obscure the table. Returns `null` when the toolbar should stay hidden.
+     */
+    private async resolveAnchoredPlacement(
+        ctx: PositioningContext,
+        mode: 'top-start' | 'bottom-start'
+    ): Promise<ToolbarPlacement | null> {
+        const middleware = createPositioningMiddleware();
+        const result = await computePosition(ctx.referenceElement, this.dom, { placement: mode, middleware });
+
+        if (result.middlewareData.hide?.referenceHidden) {
+            return null;
+        }
+
+        // Avoid rendering if we somehow produced a non-finite position.
+        if (!isFinitePoint(result)) {
+            return null;
+        }
+
+        if (isObscuringTopPlacement(result.placement, result.y)) {
+            const fallback = await computePosition(ctx.referenceElement, this.dom, {
+                placement: 'bottom-start',
+                middleware,
+            });
+            if (!fallback.middlewareData.hide?.referenceHidden) {
+                return { x: fallback.x, y: fallback.y, strategy: 'absolute' };
+            }
+        }
+
+        return { x: result.x, y: result.y, strategy: 'absolute' };
+    }
+
+    /** Pinned mode: toolbar sticks to the viewport edge when the table top/bottom is out of view. */
+    private resolvePinnedPlacement(ctx: PositioningContext, geometry: ToolbarGeometry): ToolbarPlacement | null {
+        const { tableRect, toolbarRect, viewport } = geometry;
+        const pinAbove = shouldPinAbove(tableRect, viewport);
+
+        const placement = ctx.isInternalScroll
+            ? computePinnedAbsolutePlacement({
+                  tableRect,
+                  toolbarRect,
+                  viewport,
+                  viewRect: this.view.dom.getBoundingClientRect(),
+                  offsetParentTop: ((this.dom.offsetParent ?? ctx.doc.body) as HTMLElement).getBoundingClientRect().top,
+                  pinAbove,
+              })
+            : computePinnedFixedPlacement({
+                  tableRect,
+                  toolbarRect,
+                  viewport,
+                  viewportWidth: ctx.viewWindow.visualViewport?.width ?? ctx.viewWindow.innerWidth,
+                  pinAbove,
+              });
+
+        // Avoid rendering if we somehow produced a non-finite position.
+        return isFinitePoint(placement) ? placement : null;
+    }
+
+    private applyPlacement(placement: ToolbarPlacement) {
+        Object.assign(this.dom.style, {
+            position: placement.strategy,
+            left: `${placement.x}px`,
+            top: `${placement.y}px`,
+        });
     }
 
     private attachViewportListeners() {
@@ -419,9 +416,23 @@ export class TableToolbarPlugin {
     }
 }
 
-const TOOLBAR_OFFSET_PX = 5;
-const TOOLBAR_VIEWPORT_PADDING_PX = 5;
-const TOOLBAR_OBSCURATION_THRESHOLD_PX = 5;
+function createPositioningMiddleware(): Middleware[] {
+    return [offset(TOOLBAR_OFFSET_PX), shift({ padding: TOOLBAR_VIEWPORT_PADDING_PX }), hide()];
+}
+
+/**
+ * Conditions that usually imply the widget DOM was replaced/rebuilt:
+ * 1. rebuildTableWidgetsEffect (explicit structural edit)
+ * 2. Doc changes that are NOT sync (e.g. Undo/Redo, external edits).
+ *    Non-sync changes cause `tableDecorationField` to rebuild decorations,
+ *    which leads to CodeMirror replacing the widget DOM if content changed.
+ */
+function hasRebuiltWidgetDom(update: ViewUpdate): boolean {
+    const hasRebuildEffect = update.transactions.some((tr) => tr.effects.some((e) => e.is(rebuildTableWidgetsEffect)));
+    const isNonSyncDocChange = update.transactions.some((tr) => tr.docChanged && !tr.annotation(syncAnnotation));
+
+    return hasRebuildEffect || isNonSyncDocChange;
+}
 
 export const tableToolbarPlugin = ViewPlugin.fromClass(TableToolbarPlugin);
 

--- a/src/contentScript/toolbar/toolbarPositioning.ts
+++ b/src/contentScript/toolbar/toolbarPositioning.ts
@@ -1,0 +1,157 @@
+import { clamp } from '../shared/numberUtils';
+
+export const TOOLBAR_OFFSET_PX = 5;
+export const TOOLBAR_VIEWPORT_PADDING_PX = 5;
+const TOOLBAR_OBSCURATION_THRESHOLD_PX = 5;
+
+/** Subset of `DOMRect` used by the toolbar geometry. `DOMRect` is assignable to it. */
+export interface ToolbarRect {
+    top: number;
+    bottom: number;
+    left: number;
+    width: number;
+    height: number;
+}
+
+/** Vertical bounds of the area the toolbar must stay inside, in viewport coordinates. */
+export interface ViewportBounds {
+    top: number;
+    bottom: number;
+    height: number;
+}
+
+export interface ToolbarPoint {
+    x: number;
+    y: number;
+}
+
+/** Where the toolbar ends up, plus the CSS positioning strategy required to render it there. */
+export interface ToolbarPlacement extends ToolbarPoint {
+    strategy: 'absolute' | 'fixed';
+}
+
+/**
+ * Anchored placements are handed to Floating UI; `pinned` means the table edge we would
+ * anchor to is off-screen, so the toolbar sticks to the viewport edge instead.
+ */
+export type ToolbarPlacementMode = 'top-start' | 'bottom-start' | 'pinned';
+
+/**
+ * Desktop uses internal CodeMirror scrolling, so the visible area is the scroller rect.
+ * Mobile scrolls the surrounding WebView, so the visible area is the window/visual viewport
+ * anchored to the top of the page.
+ */
+export function resolveViewportBounds(
+    isInternalScroll: boolean,
+    scrollDOMRect: ToolbarRect,
+    externalViewportHeight: number
+): ViewportBounds {
+    if (isInternalScroll) {
+        return { top: scrollDOMRect.top, bottom: scrollDOMRect.bottom, height: scrollDOMRect.height };
+    }
+
+    return { top: 0, bottom: externalViewportHeight, height: externalViewportHeight };
+}
+
+/** True when the table has scrolled entirely past either viewport edge. */
+export function isTableOutsideViewport(tableRect: ToolbarRect, viewport: ViewportBounds): boolean {
+    const tableAboveViewport = tableRect.bottom <= viewport.top;
+    const tableBelowViewport = tableRect.top >= viewport.bottom;
+
+    return tableAboveViewport || tableBelowViewport;
+}
+
+/**
+ * Prefers anchoring above the table, then below it, and falls back to pinning when neither
+ * table edge is both visible and has room for the toolbar.
+ */
+export function resolveToolbarPlacementMode(
+    tableRect: ToolbarRect,
+    toolbarHeight: number,
+    viewport: ViewportBounds
+): ToolbarPlacementMode {
+    const topVisible = tableRect.top >= viewport.top && tableRect.top <= viewport.bottom;
+    const hasRoomAbove =
+        tableRect.top - toolbarHeight - TOOLBAR_OFFSET_PX >= viewport.top + TOOLBAR_VIEWPORT_PADDING_PX;
+    if (topVisible && hasRoomAbove) {
+        return 'top-start';
+    }
+
+    const bottomVisible = tableRect.bottom >= viewport.top && tableRect.bottom <= viewport.bottom;
+    const hasRoomBelow =
+        viewport.bottom - tableRect.bottom - toolbarHeight - TOOLBAR_OFFSET_PX >= TOOLBAR_VIEWPORT_PADDING_PX;
+    if (bottomVisible && hasRoomBelow) {
+        return 'bottom-start';
+    }
+
+    return 'pinned';
+}
+
+/** Pins to whichever viewport edge the table's midpoint has scrolled away from. */
+export function shouldPinAbove(tableRect: ToolbarRect, viewport: ViewportBounds): boolean {
+    return (tableRect.top + tableRect.bottom) / 2 > viewport.top + viewport.height / 2;
+}
+
+/**
+ * Desktop (internal scroll) pinning: `position: absolute` coordinates relative to the toolbar's
+ * offset parent, kept within the editor panel bounds.
+ */
+export function computePinnedAbsolutePlacement(params: {
+    tableRect: ToolbarRect;
+    toolbarRect: ToolbarRect;
+    viewport: ViewportBounds;
+    viewRect: ToolbarRect;
+    offsetParentTop: number;
+    pinAbove: boolean;
+}): ToolbarPlacement {
+    const { tableRect, toolbarRect, viewport, viewRect, offsetParentTop, pinAbove } = params;
+
+    const maxX = Math.max(
+        TOOLBAR_VIEWPORT_PADDING_PX,
+        viewRect.width - toolbarRect.width - TOOLBAR_VIEWPORT_PADDING_PX
+    );
+    const x = clamp(tableRect.left - viewRect.left, TOOLBAR_VIEWPORT_PADDING_PX, maxX);
+
+    const topInParent = viewport.top - offsetParentTop + TOOLBAR_VIEWPORT_PADDING_PX;
+    const bottomInParent = viewport.bottom - offsetParentTop - toolbarRect.height - TOOLBAR_VIEWPORT_PADDING_PX;
+    const y = pinAbove ? topInParent : Math.max(topInParent, bottomInParent);
+
+    return { x, y, strategy: 'absolute' };
+}
+
+/**
+ * Mobile (external scroll) pinning: `position: fixed` viewport-relative coordinates, which avoid
+ * the jitter caused by offset parent recalculations during scroll.
+ * The mobile editor disables pinch-zoom (maximum-scale=1), so the page offset is always 0.
+ */
+export function computePinnedFixedPlacement(params: {
+    tableRect: ToolbarRect;
+    toolbarRect: ToolbarRect;
+    viewport: ViewportBounds;
+    viewportWidth: number;
+    pinAbove: boolean;
+}): ToolbarPlacement {
+    const { tableRect, toolbarRect, viewport, viewportWidth, pinAbove } = params;
+
+    const maxX = Math.max(TOOLBAR_VIEWPORT_PADDING_PX, viewportWidth - toolbarRect.width - TOOLBAR_VIEWPORT_PADDING_PX);
+    const x = clamp(tableRect.left, TOOLBAR_VIEWPORT_PADDING_PX, maxX);
+
+    const y = pinAbove
+        ? viewport.top + TOOLBAR_VIEWPORT_PADDING_PX
+        : viewport.bottom - toolbarRect.height - TOOLBAR_VIEWPORT_PADDING_PX;
+
+    return { x, y, strategy: 'fixed' };
+}
+
+/** Guards against rendering a `NaN`/`Infinity` position produced by degenerate measurements. */
+export function isFinitePoint(point: ToolbarPoint): boolean {
+    return Number.isFinite(point.x) && Number.isFinite(point.y);
+}
+
+/**
+ * A toolbar anchored to the top of a table that lands within a few pixels of the viewport top
+ * obscures the table; the caller retries below in that case.
+ */
+export function isObscuringTopPlacement(placement: string, y: number): boolean {
+    return placement.startsWith('top') && y < TOOLBAR_OBSCURATION_THRESHOLD_PX;
+}


### PR DESCRIPTION
`updatePosition` had grown to 150 lines with a cyclomatic complexity of 35, mixing DOM measurement, viewport math, Floating UI calls and style writes in a single `autoUpdate` callback.

Move the geometry into a new pure `toolbarPositioning` module (viewport bounds, off-screen test, placement mode, pinned x/y math, finite-point guard) and split the callback into `positionToolbar`, `readGeometry`, `resolveAnchoredPlacement`, `resolvePinnedPlacement` and `applyPlacement`. Both resolvers return `ToolbarPlacement | null`, so the 5-operator non-finite check collapses to a single `isFinitePoint` predicate per branch and the unreachable `if (!result)` branch after `showToolbar()` disappears.

Also hoist the two transaction scans in `update()` into a module-level `hasRebuiltWidgetDom` predicate and merge the "different table" and "widget rebuilt" branches, which both call the measure-key-deduped `schedulePositionUpdate`.

Guard ordering is preserved exactly: referenceHidden, then the finite check, then the obscuration fallback whose own coordinates stay unchecked as before.

The extracted geometry had no test coverage; add tests for it.