### PR TITLE
test: cover nestedEditorController and extract selection helpers

### DIFF
--- a/src/contentScript/__tests__/nestedEditorController.test.ts
+++ b/src/contentScript/__tests__/nestedEditorController.test.ts
@@ -1,0 +1,369 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Characterization tests for the nested editor controller, driven through its
+ * exported API and the DOM it owns. The nested EditorView is reached via
+ * `EditorView.findFromDOM` on the cell's editor host rather than the
+ * controller's private session, so these tests describe observable behavior.
+ */
+
+import { markdown } from '@codemirror/lang-markdown';
+import { EditorSelection, EditorState } from '@codemirror/state';
+import { EditorView } from '@codemirror/view';
+import { GFM } from '@lezer/markdown';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { defaultHostEditorConfig } from '../../contentScriptBridge/hostEditorConfigBridge';
+import {
+    cleanupHostedNestedEditors,
+    closeNestedEditor,
+    handleMainEditorUpdate,
+    isNestedEditorOpen,
+    nestedEditorPlugin,
+    openNestedEditor,
+    refocusNestedEditor,
+} from '../nestedEditor/nestedEditorController';
+import { markdownRenderServiceFacet, type MarkdownRenderService } from '../services/markdownRenderer';
+import { resolvedActiveCellField } from '../tableRuntime/activeCell/resolvedActiveCell';
+import { activeCellField, getActiveCell, setActiveCellEffect, type ActiveCell } from '../tableState/activeCellState';
+import { CLASS_CELL_ACTIVE, CLASS_CELL_CONTENT, CLASS_CELL_EDITOR } from '../shared/tableDomClasses';
+
+// jsdom does not implement Range measurement, which CodeMirror's selection layer calls.
+if (!Range.prototype.getClientRects) {
+    Object.defineProperty(Range.prototype, 'getClientRects', { value: () => [] });
+}
+
+const FEATURE_SETTINGS = defaultHostEditorConfig().nestedEditor;
+
+function bodyCell(overrides: Partial<ActiveCell> = {}): ActiveCell {
+    return { tableFrom: 0, section: 'body', row: 0, col: 0, ...overrides };
+}
+
+/**
+ * Builds a main editor wired the way the runtime wires it: the controller only
+ * reacts to main-document changes when the host forwards its view updates.
+ */
+function createHarness(params: {
+    doc: string;
+    activeCell?: ActiveCell;
+    selection?: { anchor: number; head?: number };
+}) {
+    const renderer: MarkdownRenderService = {
+        getCached: vi.fn(() => undefined),
+        render: vi.fn(async () => ''),
+        clear: vi.fn(),
+    };
+
+    const parent = document.createElement('div');
+    document.body.appendChild(parent);
+
+    let mainView: EditorView | null = null;
+    const view = new EditorView({
+        parent,
+        state: EditorState.create({
+            doc: params.doc,
+            selection: params.selection,
+            extensions: [
+                markdown({ extensions: [GFM] }),
+                activeCellField,
+                resolvedActiveCellField,
+                markdownRenderServiceFacet.of(renderer),
+                nestedEditorPlugin,
+                EditorView.updateListener.of((update) => {
+                    if (mainView) {
+                        handleMainEditorUpdate(mainView, update);
+                    }
+                }),
+            ],
+        }),
+    });
+    mainView = view;
+
+    if (params.activeCell) {
+        view.dispatch({ effects: setActiveCellEffect.of(params.activeCell) });
+    }
+
+    const cellElement = document.createElement('td');
+    parent.appendChild(cellElement);
+
+    return { view, cellElement, renderer, parent };
+}
+
+/** The nested editor mounted inside `cellElement`, or null when none is mounted. */
+function nestedViewIn(cellElement: HTMLElement): EditorView | null {
+    const host = cellElement.querySelector(`.${CLASS_CELL_EDITOR}`);
+    return host ? EditorView.findFromDOM(host as HTMLElement) : null;
+}
+
+function requireNestedView(cellElement: HTMLElement): EditorView {
+    const nested = nestedViewIn(cellElement);
+    if (!nested) {
+        throw new Error('Expected a nested editor to be mounted in the cell');
+    }
+    return nested;
+}
+
+describe('nestedEditorController open', () => {
+    afterEach(() => {
+        document.body.innerHTML = '';
+    });
+
+    it('mounts a nested editor holding the unsanitized cell text', () => {
+        const doc = ['| H1 |', '| --- |', '| a \\| b<br>c |'].join('\n');
+        const { view, cellElement } = createHarness({ doc, activeCell: bodyCell() });
+
+        expect(openNestedEditor({ mainView: view, cellElement, featureSettings: FEATURE_SETTINGS })).toBe(true);
+        expect(isNestedEditorOpen(view)).toBe(true);
+        expect(cellElement.classList.contains(CLASS_CELL_ACTIVE)).toBe(true);
+        expect(requireNestedView(cellElement).state.doc.toString()).toBe('a | b\nc');
+
+        view.destroy();
+    });
+
+    it('returns false and mounts nothing when no active cell resolves', () => {
+        const doc = ['| H1 |', '| --- |', '| abc |'].join('\n');
+        const { view, cellElement } = createHarness({ doc });
+
+        expect(openNestedEditor({ mainView: view, cellElement, featureSettings: FEATURE_SETTINGS })).toBe(false);
+        expect(isNestedEditorOpen(view)).toBe(false);
+        expect(nestedViewIn(cellElement)).toBeNull();
+
+        view.destroy();
+    });
+
+    it('mirrors the main editor selection into the nested editor by default', () => {
+        const doc = ['| H1 |', '| --- |', '| abcdef |'].join('\n');
+        const cellStart = doc.indexOf('abcdef');
+        const { view, cellElement } = createHarness({
+            doc,
+            activeCell: bodyCell(),
+            selection: { anchor: cellStart + 2, head: cellStart + 4 },
+        });
+
+        openNestedEditor({ mainView: view, cellElement, featureSettings: FEATURE_SETTINGS });
+
+        expect(requireNestedView(cellElement).state.selection.main).toMatchObject({ from: 2, to: 4 });
+
+        view.destroy();
+    });
+
+    it.each([
+        ['start', 0],
+        ['end', 'first\nsecond'.length],
+        ['lastLineStart', 'first\n'.length],
+    ] as const)('places the caret for initialCursorPos %s', (initialCursorPos, expectedPos) => {
+        // Root text `first<br>second` unsanitizes to the two-line local text `first\nsecond`.
+        const doc = ['| H1 |', '| --- |', '| first<br>second |'].join('\n');
+        const { view, cellElement } = createHarness({ doc, activeCell: bodyCell() });
+
+        openNestedEditor({ mainView: view, cellElement, featureSettings: FEATURE_SETTINGS, initialCursorPos });
+
+        const nested = requireNestedView(cellElement);
+        expect(nested.state.selection.main).toMatchObject({ anchor: expectedPos, head: expectedPos });
+
+        view.destroy();
+    });
+
+    it('closes a previously open cell before opening the next one', () => {
+        const doc = ['| H1 | H2 |', '| --- | --- |', '| aaa | bbb |'].join('\n');
+        const { view, cellElement, parent } = createHarness({ doc, activeCell: bodyCell() });
+
+        openNestedEditor({ mainView: view, cellElement, featureSettings: FEATURE_SETTINGS });
+
+        const secondCell = document.createElement('td');
+        parent.appendChild(secondCell);
+        view.dispatch({ effects: setActiveCellEffect.of(bodyCell({ col: 1 })) });
+        openNestedEditor({ mainView: view, cellElement: secondCell, featureSettings: FEATURE_SETTINGS });
+
+        expect(nestedViewIn(cellElement)).toBeNull();
+        expect(cellElement.classList.contains(CLASS_CELL_ACTIVE)).toBe(false);
+        expect(requireNestedView(secondCell).state.doc.toString()).toBe('bbb');
+
+        view.destroy();
+    });
+});
+
+describe('nestedEditorController local-to-root forwarding', () => {
+    afterEach(() => {
+        document.body.innerHTML = '';
+    });
+
+    it('sanitizes nested edits back into the main document', () => {
+        const doc = ['| H1 |', '| --- |', '| abc |'].join('\n');
+        const { view, cellElement } = createHarness({ doc, activeCell: bodyCell() });
+
+        openNestedEditor({ mainView: view, cellElement, featureSettings: FEATURE_SETTINGS });
+        const nested = requireNestedView(cellElement);
+        nested.dispatch({ changes: { from: 0, to: nested.state.doc.length, insert: 'x | y\nz' } });
+
+        expect(view.state.doc.toString()).toContain('| x \\| y<br>z |');
+
+        view.destroy();
+    });
+
+    it('moves the main selection without editing the document when only the nested caret moves', () => {
+        const doc = ['| H1 |', '| --- |', '| abcdef |'].join('\n');
+        const cellStart = doc.indexOf('abcdef');
+        const { view, cellElement } = createHarness({ doc, activeCell: bodyCell() });
+
+        openNestedEditor({ mainView: view, cellElement, featureSettings: FEATURE_SETTINGS });
+        const nested = requireNestedView(cellElement);
+        nested.dispatch({ selection: EditorSelection.single(3) });
+
+        expect(view.state.doc.toString()).toBe(doc);
+        expect(view.state.selection.main).toMatchObject({ anchor: cellStart + 3, head: cellStart + 3 });
+
+        view.destroy();
+    });
+
+    it('maps the main selection across escaped pipes in the cell text', () => {
+        const doc = ['| H1 |', '| --- |', '| a \\| b |'].join('\n');
+        const cellStart = doc.indexOf('a \\| b');
+        const { view, cellElement } = createHarness({ doc, activeCell: bodyCell() });
+
+        openNestedEditor({ mainView: view, cellElement, featureSettings: FEATURE_SETTINGS });
+        const nested = requireNestedView(cellElement);
+        // Local text is `a | b`; the caret after the pipe sits one char later in root text.
+        nested.dispatch({ selection: EditorSelection.single(3) });
+
+        expect(view.state.selection.main.anchor).toBe(cellStart + 4);
+
+        view.destroy();
+    });
+});
+
+describe('nestedEditorController handleMainEditorUpdate', () => {
+    afterEach(() => {
+        document.body.innerHTML = '';
+    });
+
+    it('rebases the nested editor when the cell text changes in the main editor', () => {
+        const doc = ['| H1 |', '| --- |', '| abc |'].join('\n');
+        const cellStart = doc.indexOf('abc');
+        const { view, cellElement } = createHarness({ doc, activeCell: bodyCell() });
+
+        openNestedEditor({ mainView: view, cellElement, featureSettings: FEATURE_SETTINGS });
+        view.dispatch({ changes: { from: cellStart, to: cellStart + 3, insert: 'updated' } });
+
+        expect(requireNestedView(cellElement).state.doc.toString()).toBe('updated');
+
+        view.destroy();
+    });
+
+    it('keeps the session open when the change lands outside the active table', () => {
+        const doc = ['intro', '', '| H1 |', '| --- |', '| abc |'].join('\n');
+        const tableFrom = doc.indexOf('| H1 |');
+        const { view, cellElement } = createHarness({
+            doc,
+            activeCell: bodyCell({ tableFrom }),
+        });
+
+        openNestedEditor({ mainView: view, cellElement, featureSettings: FEATURE_SETTINGS });
+        view.dispatch({ changes: { from: 0, to: 0, insert: 'more ' } });
+
+        expect(isNestedEditorOpen(view)).toBe(true);
+        expect(requireNestedView(cellElement).state.doc.toString()).toBe('abc');
+
+        view.destroy();
+    });
+
+    it('closes the editor and clears the active cell when the table is deleted', () => {
+        const doc = ['| H1 |', '| --- |', '| abc |'].join('\n');
+        const { view, cellElement } = createHarness({ doc, activeCell: bodyCell() });
+
+        openNestedEditor({ mainView: view, cellElement, featureSettings: FEATURE_SETTINGS });
+        view.dispatch({ changes: { from: 0, to: view.state.doc.length, insert: 'no table here' } });
+
+        expect(isNestedEditorOpen(view)).toBe(false);
+        expect(getActiveCell(view.state)).toBeNull();
+        expect(nestedViewIn(cellElement)).toBeNull();
+
+        view.destroy();
+    });
+});
+
+describe('nestedEditorController close', () => {
+    afterEach(() => {
+        document.body.innerHTML = '';
+    });
+
+    it('tears down the nested editor and renders the cell markdown back into the content wrapper', () => {
+        const doc = ['| H1 |', '| --- |', '| **bold** |'].join('\n');
+        const { view, cellElement, renderer } = createHarness({ doc, activeCell: bodyCell() });
+        vi.mocked(renderer.getCached).mockReturnValue('<p><strong>bold</strong></p>');
+
+        openNestedEditor({ mainView: view, cellElement, featureSettings: FEATURE_SETTINGS });
+        closeNestedEditor(view);
+
+        expect(isNestedEditorOpen(view)).toBe(false);
+        expect(nestedViewIn(cellElement)).toBeNull();
+        expect(cellElement.classList.contains(CLASS_CELL_ACTIVE)).toBe(false);
+        expect(renderer.getCached).toHaveBeenCalledWith('**bold**');
+        expect(cellElement.querySelector(`.${CLASS_CELL_CONTENT}`)?.innerHTML).toBe('<p><strong>bold</strong></p>');
+
+        view.destroy();
+    });
+
+    it('renders the explicitly supplied range instead of re-resolving the cell', () => {
+        const doc = ['| H1 |', '| --- |', '| abc |'].join('\n');
+        const { view, cellElement, renderer } = createHarness({ doc, activeCell: bodyCell() });
+
+        openNestedEditor({ mainView: view, cellElement, featureSettings: FEATURE_SETTINGS });
+        closeNestedEditor(view, { contentFrom: 2, contentTo: 4 });
+
+        expect(renderer.getCached).toHaveBeenCalledWith('H1');
+
+        view.destroy();
+    });
+
+    it('is a no-op when nothing is open', () => {
+        const doc = ['| H1 |', '| --- |', '| abc |'].join('\n');
+        const { view, renderer } = createHarness({ doc, activeCell: bodyCell() });
+
+        closeNestedEditor(view);
+
+        expect(isNestedEditorOpen(view)).toBe(false);
+        expect(renderer.getCached).not.toHaveBeenCalled();
+
+        view.destroy();
+    });
+});
+
+describe('nestedEditorController host cleanup', () => {
+    afterEach(() => {
+        document.body.innerHTML = '';
+    });
+
+    it('closes the session when the container hosting the editor is torn down', () => {
+        const doc = ['| H1 |', '| --- |', '| abc |'].join('\n');
+        const { view, cellElement, parent } = createHarness({ doc, activeCell: bodyCell() });
+
+        openNestedEditor({ mainView: view, cellElement, featureSettings: FEATURE_SETTINGS });
+        cleanupHostedNestedEditors(view, parent);
+
+        expect(isNestedEditorOpen(view)).toBe(false);
+
+        view.destroy();
+    });
+
+    it('leaves the session alone for an unrelated container', () => {
+        const doc = ['| H1 |', '| --- |', '| abc |'].join('\n');
+        const { view, cellElement } = createHarness({ doc, activeCell: bodyCell() });
+
+        openNestedEditor({ mainView: view, cellElement, featureSettings: FEATURE_SETTINGS });
+        cleanupHostedNestedEditors(view, document.createElement('div'));
+
+        expect(isNestedEditorOpen(view)).toBe(true);
+
+        view.destroy();
+    });
+
+    it('tolerates refocus and cleanup calls with no open session', () => {
+        const doc = ['| H1 |', '| --- |', '| abc |'].join('\n');
+        const { view, parent } = createHarness({ doc, activeCell: bodyCell() });
+
+        expect(() => refocusNestedEditor(view)).not.toThrow();
+        expect(() => cleanupHostedNestedEditors(view, parent)).not.toThrow();
+
+        view.destroy();
+    });
+});

--- a/src/contentScript/__tests__/nestedEditorSelection.test.ts
+++ b/src/contentScript/__tests__/nestedEditorSelection.test.ts
@@ -1,0 +1,82 @@
+import { EditorSelection } from '@codemirror/state';
+import { describe, expect, it } from 'vitest';
+import {
+    areSelectionsEqual,
+    resolveInitialLocalSelection,
+    toAbsoluteSelection,
+    toRelativeSelection,
+} from '../nestedEditor/nestedEditorSelection';
+
+describe('toAbsoluteSelection', () => {
+    it('shifts a cell-relative selection by the editable start', () => {
+        expect(toAbsoluteSelection({ anchor: 2, head: 5 }, 10)).toEqual({ anchor: 12, head: 15 });
+    });
+
+    it('preserves a reversed selection', () => {
+        expect(toAbsoluteSelection({ anchor: 5, head: 2 }, 10)).toEqual({ anchor: 15, head: 12 });
+    });
+});
+
+describe('toRelativeSelection', () => {
+    it('maps a selection inside the cell to cell-relative offsets', () => {
+        expect(toRelativeSelection(EditorSelection.single(12, 15), 10, 20)).toEqual({ anchor: 2, head: 5 });
+    });
+
+    it('clamps a selection that starts before the cell', () => {
+        expect(toRelativeSelection(EditorSelection.single(3, 15), 10, 20)).toEqual({ anchor: 0, head: 5 });
+    });
+
+    it('clamps a selection that runs past the cell end', () => {
+        expect(toRelativeSelection(EditorSelection.single(12, 40), 10, 20)).toEqual({ anchor: 2, head: 10 });
+    });
+
+    it('collapses a selection entirely outside the cell to the nearest edge', () => {
+        expect(toRelativeSelection(EditorSelection.single(30, 35), 10, 20)).toEqual({ anchor: 10, head: 10 });
+    });
+
+    it('uses the main range when the selection has several ranges', () => {
+        const selection = EditorSelection.create([EditorSelection.range(1, 2), EditorSelection.range(12, 14)], 1);
+        expect(toRelativeSelection(selection, 10, 20)).toEqual({ anchor: 2, head: 4 });
+    });
+});
+
+describe('areSelectionsEqual', () => {
+    it('is true for identical anchor and head', () => {
+        expect(areSelectionsEqual({ anchor: 1, head: 4 }, { anchor: 1, head: 4 })).toBe(true);
+    });
+
+    it('distinguishes selection direction', () => {
+        expect(areSelectionsEqual({ anchor: 1, head: 4 }, { anchor: 4, head: 1 })).toBe(false);
+    });
+});
+
+describe('resolveInitialLocalSelection', () => {
+    const mirrored = { anchor: 3, head: 6 };
+
+    it('keeps the mirrored selection when no placement is requested', () => {
+        expect(resolveInitialLocalSelection(mirrored, 'hello world')).toEqual(mirrored);
+    });
+
+    it('collapses to the start of the cell text', () => {
+        expect(resolveInitialLocalSelection(mirrored, 'hello world', 'start')).toEqual({ anchor: 0, head: 0 });
+    });
+
+    it('collapses to the end of the cell text', () => {
+        expect(resolveInitialLocalSelection(mirrored, 'hello', 'end')).toEqual({ anchor: 5, head: 5 });
+    });
+
+    it('collapses to the start of the last line for multi-line cell text', () => {
+        expect(resolveInitialLocalSelection(mirrored, 'first\nsecond\nthird', 'lastLineStart')).toEqual({
+            anchor: 13,
+            head: 13,
+        });
+    });
+
+    it('collapses to the start for lastLineStart when the cell text has one line', () => {
+        expect(resolveInitialLocalSelection(mirrored, 'only line', 'lastLineStart')).toEqual({ anchor: 0, head: 0 });
+    });
+
+    it('places the caret after a trailing newline for lastLineStart', () => {
+        expect(resolveInitialLocalSelection(mirrored, 'first\n', 'lastLineStart')).toEqual({ anchor: 6, head: 6 });
+    });
+});

--- a/src/contentScript/nestedEditor/nestedEditorController.ts
+++ b/src/contentScript/nestedEditor/nestedEditorController.ts
@@ -31,6 +31,13 @@ import type { NestedEditorHostConfig } from '../../contentScriptBridge/hostEdito
 import { createNestedEditorFeatureExtensions } from './nestedEditorFeatureConfig';
 import { requestViewAnimationFrame } from '../shared/domContext';
 import { clamp } from '../shared/numberUtils';
+import {
+    areSelectionsEqual,
+    resolveInitialLocalSelection,
+    toAbsoluteSelection,
+    toRelativeSelection,
+    type InitialCursorPos,
+} from './nestedEditorSelection';
 
 const SYNTAX_TREE_PARSE_TIMEOUT = 50;
 
@@ -52,25 +59,6 @@ interface NestedEditorSession {
     applyingRootToLocal: boolean;
 }
 
-function toAbsoluteSelection(selection: LocalSelection, editableFrom: number): LocalSelection {
-    return {
-        anchor: editableFrom + selection.anchor,
-        head: editableFrom + selection.head,
-    };
-}
-
-function toRelativeSelection(selection: EditorSelection, editableFrom: number, editableTo: number): LocalSelection {
-    const main = selection.main;
-    return {
-        anchor: clamp(main.anchor, editableFrom, editableTo) - editableFrom,
-        head: clamp(main.head, editableFrom, editableTo) - editableFrom,
-    };
-}
-
-function areSelectionsEqual(a: LocalSelection, b: LocalSelection): boolean {
-    return a.anchor === b.anchor && a.head === b.head;
-}
-
 function isEditorFocused(view: EditorView | null): boolean {
     return Boolean(view?.hasFocus);
 }
@@ -86,7 +74,7 @@ class NestedEditorController {
         mainView: EditorView;
         cellElement: HTMLElement;
         featureSettings: NestedEditorHostConfig;
-        initialCursorPos?: 'start' | 'end' | 'lastLineStart';
+        initialCursorPos?: InitialCursorPos;
     }): boolean {
         this.close();
 
@@ -112,17 +100,11 @@ class NestedEditorController {
             resolved.editableFrom,
             resolved.editableTo
         );
-        let localSelection = toLocalSelection(rootSelection, rootText);
-
-        if (params.initialCursorPos === 'start') {
-            localSelection = { anchor: 0, head: 0 };
-        } else if (params.initialCursorPos === 'end') {
-            localSelection = { anchor: localText.length, head: localText.length };
-        } else if (params.initialCursorPos === 'lastLineStart') {
-            const lastNewline = localText.lastIndexOf('\n');
-            const pos = lastNewline === -1 ? 0 : lastNewline + 1;
-            localSelection = { anchor: pos, head: pos };
-        }
+        const localSelection = resolveInitialLocalSelection(
+            toLocalSelection(rootSelection, rootText),
+            localText,
+            params.initialCursorPos
+        );
 
         const session: NestedEditorSession = {
             resolvedCell: resolved,
@@ -495,7 +477,7 @@ export function openNestedEditor(params: {
     mainView: EditorView;
     cellElement: HTMLElement;
     featureSettings: NestedEditorHostConfig;
-    initialCursorPos?: 'start' | 'end' | 'lastLineStart';
+    initialCursorPos?: InitialCursorPos;
 }): boolean {
     return getController(params.mainView)?.open(params) ?? false;
 }

--- a/src/contentScript/nestedEditor/nestedEditorSelection.ts
+++ b/src/contentScript/nestedEditor/nestedEditorSelection.ts
@@ -1,0 +1,63 @@
+import type { EditorSelection } from '@codemirror/state';
+import type { LocalSelection } from '../editorBridge/cellTextCodec';
+import { clamp } from '../shared/numberUtils';
+
+/** Where the caret should land when a nested editor is opened programmatically. */
+export type InitialCursorPos = 'start' | 'end' | 'lastLineStart';
+
+/** Shifts a cell-relative selection into main-document coordinates. */
+export function toAbsoluteSelection(selection: LocalSelection, editableFrom: number): LocalSelection {
+    return {
+        anchor: editableFrom + selection.anchor,
+        head: editableFrom + selection.head,
+    };
+}
+
+/**
+ * Projects the main editor's selection onto the editable cell range, clamping
+ * endpoints that sit outside the cell so a selection spanning several cells
+ * still yields an in-range cell-relative selection.
+ */
+export function toRelativeSelection(
+    selection: EditorSelection,
+    editableFrom: number,
+    editableTo: number
+): LocalSelection {
+    const main = selection.main;
+    return {
+        anchor: clamp(main.anchor, editableFrom, editableTo) - editableFrom,
+        head: clamp(main.head, editableFrom, editableTo) - editableFrom,
+    };
+}
+
+export function areSelectionsEqual(a: LocalSelection, b: LocalSelection): boolean {
+    return a.anchor === b.anchor && a.head === b.head;
+}
+
+/**
+ * Resolves the caret placement for a freshly opened nested editor. Without an
+ * explicit request the mirrored selection from the main editor wins; otherwise
+ * the caret is collapsed to the requested edge of the cell text.
+ *
+ * `lastLineStart` targets the start of the final visual line, which is what
+ * upward navigation into a multi-line cell expects.
+ */
+export function resolveInitialLocalSelection(
+    mirroredSelection: LocalSelection,
+    localText: string,
+    initialCursorPos?: InitialCursorPos
+): LocalSelection {
+    switch (initialCursorPos) {
+        case 'start':
+            return { anchor: 0, head: 0 };
+        case 'end':
+            return { anchor: localText.length, head: localText.length };
+        case 'lastLineStart': {
+            const lastNewline = localText.lastIndexOf('\n');
+            const pos = lastNewline === -1 ? 0 : lastNewline + 1;
+            return { anchor: pos, head: pos };
+        }
+        default:
+            return mirroredSelection;
+    }
+}


### PR DESCRIPTION
The controller had no paired test file and several uncovered regions: handleMainEditorUpdate's rebase and close-and-clear paths, every initialCursorPos branch, checkAndCloseIfHostedIn, and the local/root sanitize round-trip.

Move the pure coordinate logic (toAbsoluteSelection, toRelativeSelection, areSelectionsEqual) into nestedEditorSelection.ts and extract the initialCursorPos if/else chain in open() into resolveInitialLocalSelection, so the placement rules are unit-testable without mounting an editor. The repeated 'start' | 'end' | 'lastLineStart' union becomes the named InitialCursorPos type. No exported names or signatures change.

Add nestedEditorController.test.ts, which drives the controller through its exported API and reaches the nested view via EditorView.findFromDOM rather than the private session, plus nestedEditorSelection.test.ts for the extracted helpers.