### PR TITLE
refactor: define the initial cursor placement type in one place

### DIFF
--- a/src/contentScript/__tests__/interactiveOpenCellRequest.test.ts
+++ b/src/contentScript/__tests__/interactiveOpenCellRequest.test.ts
@@ -110,7 +110,7 @@ describe('interactive open-cell requests', () => {
             },
         });
 
-        expect(navigateCell(view, 'next', { cursorPos: 'end' })).toBe(true);
+        expect(navigateCell(view, 'next', { initialCursorPos: 'end' })).toBe(true);
         expect(view.state.doc.toString()).toBe(NON_CANONICAL_DOC);
 
         const activeCell = getActiveCell(view.state);

--- a/src/contentScript/__tests__/nestedEditorLifecycle.test.ts
+++ b/src/contentScript/__tests__/nestedEditorLifecycle.test.ts
@@ -33,6 +33,7 @@ import {
 } from '../tableRuntime/openCellRequest';
 import type { HostEditorConfig } from '../../contentScriptBridge/hostEditorConfigBridge';
 import { createActiveCellForTableText } from '../tableRuntime/activeCell/activeCellFactory';
+import type { InitialCursorPos } from '../shared/cursorPlacement';
 import { hostEditorConfigFacet } from '../services/hostEditorConfig';
 import * as nestedEditorController from '../nestedEditor/nestedEditorController';
 
@@ -114,7 +115,7 @@ function openRequestEffects(params: {
     requestId: string;
     activeCell: ActiveCell;
     normalizeIfNeeded: boolean;
-    initialCursorPos?: 'start' | 'end' | 'lastLineStart';
+    initialCursorPos?: InitialCursorPos;
 }) {
     const request: OpenCellRequest = {
         requestId: params.requestId,

--- a/src/contentScript/nestedEditor/domHandlers.ts
+++ b/src/contentScript/nestedEditor/domHandlers.ts
@@ -51,7 +51,7 @@ export function createNestedEditorKeymap(
                 const { from } = options.getSelectionBounds(nestedView);
                 if (nestedView.state.selection.main.head === from) {
                     options.syncPendingChangesToRoot();
-                    return navigateCell(mainView, 'previous', { cursorPos: 'end' });
+                    return navigateCell(mainView, 'previous', { initialCursorPos: 'end' });
                 }
                 return false;
             },
@@ -62,7 +62,7 @@ export function createNestedEditorKeymap(
                 const { to } = options.getSelectionBounds(nestedView);
                 if (nestedView.state.selection.main.head === to) {
                     options.syncPendingChangesToRoot();
-                    return navigateCell(mainView, 'next', { cursorPos: 'start' });
+                    return navigateCell(mainView, 'next', { initialCursorPos: 'start' });
                 }
                 return false;
             },
@@ -77,12 +77,12 @@ export function createNestedEditorKeymap(
 
                 if (headRect && fromRect && Math.abs(headRect.top - fromRect.top) < 2) {
                     options.syncPendingChangesToRoot();
-                    return navigateCell(mainView, 'up', { cursorPos: 'lastLineStart' });
+                    return navigateCell(mainView, 'up', { initialCursorPos: 'lastLineStart' });
                 }
 
                 if (head === from) {
                     options.syncPendingChangesToRoot();
-                    return navigateCell(mainView, 'up', { cursorPos: 'lastLineStart' });
+                    return navigateCell(mainView, 'up', { initialCursorPos: 'lastLineStart' });
                 }
 
                 return false;
@@ -98,12 +98,12 @@ export function createNestedEditorKeymap(
 
                 if (headRect && toRect && Math.abs(headRect.top - toRect.top) < 2) {
                     options.syncPendingChangesToRoot();
-                    return navigateCell(mainView, 'down', { cursorPos: 'start' });
+                    return navigateCell(mainView, 'down', { initialCursorPos: 'start' });
                 }
 
                 if (head === to) {
                     options.syncPendingChangesToRoot();
-                    return navigateCell(mainView, 'down', { cursorPos: 'start' });
+                    return navigateCell(mainView, 'down', { initialCursorPos: 'start' });
                 }
 
                 return false;

--- a/src/contentScript/nestedEditor/nestedEditorController.ts
+++ b/src/contentScript/nestedEditor/nestedEditorController.ts
@@ -31,12 +31,12 @@ import type { NestedEditorHostConfig } from '../../contentScriptBridge/hostEdito
 import { createNestedEditorFeatureExtensions } from './nestedEditorFeatureConfig';
 import { requestViewAnimationFrame } from '../shared/domContext';
 import { clamp } from '../shared/numberUtils';
+import type { InitialCursorPos } from '../shared/cursorPlacement';
 import {
     areSelectionsEqual,
     resolveInitialLocalSelection,
     toAbsoluteSelection,
     toRelativeSelection,
-    type InitialCursorPos,
 } from './nestedEditorSelection';
 
 const SYNTAX_TREE_PARSE_TIMEOUT = 50;

--- a/src/contentScript/nestedEditor/nestedEditorSelection.ts
+++ b/src/contentScript/nestedEditor/nestedEditorSelection.ts
@@ -37,8 +37,8 @@ export function areSelectionsEqual(a: LocalSelection, b: LocalSelection): boolea
  * explicit request the mirrored selection from the main editor wins; otherwise
  * the caret is collapsed to the requested edge of the cell text.
  *
- * `lastLineStart` targets the start of the final visual line, which is what
- * upward navigation into a multi-line cell expects.
+ * `lastLineStart` splits on the last newline, so a single-line cell collapses to
+ * the start and a trailing newline leaves the caret on the empty final line.
  */
 export function resolveInitialLocalSelection(
     mirroredSelection: LocalSelection,

--- a/src/contentScript/nestedEditor/nestedEditorSelection.ts
+++ b/src/contentScript/nestedEditor/nestedEditorSelection.ts
@@ -1,9 +1,7 @@
 import type { EditorSelection } from '@codemirror/state';
 import type { LocalSelection } from '../editorBridge/cellTextCodec';
+import type { InitialCursorPos } from '../shared/cursorPlacement';
 import { clamp } from '../shared/numberUtils';
-
-/** Where the caret should land when a nested editor is opened programmatically. */
-export type InitialCursorPos = 'start' | 'end' | 'lastLineStart';
 
 /** Shifts a cell-relative selection into main-document coordinates. */
 export function toAbsoluteSelection(selection: LocalSelection, editableFrom: number): LocalSelection {

--- a/src/contentScript/shared/cursorPlacement.ts
+++ b/src/contentScript/shared/cursorPlacement.ts
@@ -1,0 +1,16 @@
+/**
+ * Where the caret should land when a cell is opened programmatically.
+ *
+ * The value travels from the code that decides the placement (keyboard
+ * navigation, structural mutations) through an open-cell request to the nested
+ * editor, which applies it in `resolveInitialLocalSelection`. Each hop is a
+ * separate module, so the vocabulary is defined here once instead of being
+ * re-declared at every boundary.
+ *
+ * - `start` / `end`: collapse to the corresponding edge of the cell text.
+ * - `lastLineStart`: collapse to the start of the final line, so moving up into
+ *   a multi-line cell lands on the line nearest the cell the caret came from.
+ *
+ * Omitting the value mirrors the main editor's own selection into the cell.
+ */
+export type InitialCursorPos = 'start' | 'end' | 'lastLineStart';

--- a/src/contentScript/tableRuntime/navigation/tableNavigation.ts
+++ b/src/contentScript/tableRuntime/navigation/tableNavigation.ts
@@ -6,6 +6,7 @@ import {
 } from '../activeCell/resolvedActiveCell';
 import { insertRowAtBottom } from '../operations/structuralOperations';
 import { type CellCoords } from '../../tableModel/types';
+import type { InitialCursorPos } from '../../shared/cursorPlacement';
 import { SECTION_BODY, SECTION_HEADER } from '../../tableWidget/domHelpers';
 import { requestOpenCell, shouldSuppressNavigationKeys } from '../openCellRequest';
 
@@ -28,7 +29,7 @@ function insertRowFromKeyboardNavigation(
 export function navigateCell(
     view: EditorView,
     direction: 'next' | 'previous' | 'up' | 'down',
-    options: { cursorPos?: 'start' | 'end' | 'lastLineStart'; allowRowCreation?: boolean } = {}
+    options: { cursorPos?: InitialCursorPos; allowRowCreation?: boolean } = {}
 ): boolean {
     // Prevent race conditions from rapid key-holding
     if (shouldSuppressNavigationKeys(view.state)) {

--- a/src/contentScript/tableRuntime/navigation/tableNavigation.ts
+++ b/src/contentScript/tableRuntime/navigation/tableNavigation.ts
@@ -29,7 +29,7 @@ function insertRowFromKeyboardNavigation(
 export function navigateCell(
     view: EditorView,
     direction: 'next' | 'previous' | 'up' | 'down',
-    options: { cursorPos?: InitialCursorPos; allowRowCreation?: boolean } = {}
+    options: { initialCursorPos?: InitialCursorPos; allowRowCreation?: boolean } = {}
 ): boolean {
     // Prevent race conditions from rapid key-holding
     if (shouldSuppressNavigationKeys(view.state)) {
@@ -123,7 +123,7 @@ export function navigateCell(
     requestOpenCell(view, {
         target: { resolvedCell: nextResolvedCell },
         normalizeIfNeeded: true,
-        initialCursorPos: options.cursorPos,
+        initialCursorPos: options.initialCursorPos,
         suppressKeys: true,
     });
 

--- a/src/contentScript/tableRuntime/openCellRequest.ts
+++ b/src/contentScript/tableRuntime/openCellRequest.ts
@@ -3,6 +3,7 @@ import { keymap, EditorView, ViewPlugin, ViewUpdate } from '@codemirror/view';
 import { logger } from '../../logger';
 import { mapActiveCellThroughChanges, setActiveCellEffect, type ActiveCell } from '../tableState/activeCellState';
 import { clearCellSelectionEffect } from '../tableState/cellSelectionState';
+import type { InitialCursorPos } from '../shared/cursorPlacement';
 import type { ResolvedActiveCell } from './activeCell/resolvedActiveCell';
 
 // Explicit open requests are single-flight, may survive normalization/rebuilds,
@@ -13,7 +14,7 @@ export interface OpenCellRequest {
     requestId: string;
     activeCell: ActiveCell;
     normalizeIfNeeded: boolean;
-    initialCursorPos?: 'start' | 'end' | 'lastLineStart';
+    initialCursorPos?: InitialCursorPos;
     suppressKeys: boolean;
 }
 
@@ -38,7 +39,7 @@ export interface RequestOpenCellParams {
     target: OpenCellRequestTarget;
     clearCellSelection?: boolean;
     normalizeIfNeeded?: boolean;
-    initialCursorPos?: 'start' | 'end' | 'lastLineStart';
+    initialCursorPos?: InitialCursorPos;
     requestId?: string;
     suppressKeys?: boolean;
     scrollIntoView?: boolean;

--- a/src/contentScript/tableRuntime/operations/runStructuralMutation.ts
+++ b/src/contentScript/tableRuntime/operations/runStructuralMutation.ts
@@ -4,6 +4,7 @@ import { rebuildTableWidgetsEffect } from '../../tableState/tableWidgetEffects';
 import { applyStructuralTableCommand, type StructuralTableCommand } from '../../tableModel/structuralCommandSemantics';
 import { prepareOpenCellRequestTransaction } from '../openCellRequest';
 import { createActiveCellForTableText } from '../activeCell/activeCellFactory';
+import type { InitialCursorPos } from '../../shared/cursorPlacement';
 import type { ResolvedActiveCell } from '../activeCell/resolvedActiveCell';
 
 function isSameCellCoords(a: ActiveCell, b: ActiveCell): boolean {
@@ -11,7 +12,7 @@ function isSameCellCoords(a: ActiveCell, b: ActiveCell): boolean {
 }
 
 export interface StructuralReopenOptions {
-    initialCursorPos?: 'start' | 'end' | 'lastLineStart';
+    initialCursorPos?: InitialCursorPos;
     afterDispatch?: () => void;
     clearCellSelection?: boolean;
     suppressKeys?: boolean;


### PR DESCRIPTION
The 'start' | 'end' | 'lastLineStart' union was hand-written at six
boundaries: the open-cell request payload and its params, structural reopen
options, navigateCell's options, the nested editor controller, and a
lifecycle test helper. Every hop between the code that decides the placement
and the nested editor that applies it re-declared it.

Define InitialCursorPos once in shared/cursorPlacement.ts and import it
everywhere. It lives in shared/ rather than the nestedEditor module because
openCellRequest, runStructuralMutation, and tableNavigation had no prior
dependency on nestedEditor/, and a vocabulary type is not a reason to couple
the runtime layer to the in-cell editor implementation.

With the type in one place, two follow-ups close out the same seam:

- `navigateCell` took the value as `options.cursorPos` while every other hop
  called it `initialCursorPos`. Renamed, so the name holds from domHandlers
  through navigateCell, requestOpenCell, and OpenCellRequest to the nested
  editor. Rename only, 9 call sites.
- `resolveInitialLocalSelection`'s JSDoc restated the placement rationale the
  new type doc now owns, and described `lastLineStart` as targeting the final
  *visual* line. The implementation splits on `\n`, so it targets the last
  logical line — wrapping never factors in. Trimmed to the edge cases that are
  local to the function (single-line cells, trailing newlines), both already
  covered by nestedEditorSelection.test.ts.

No runtime behavior differs.
