### PR TITLE
refactor: extract keyboard navigation geometry

### DIFF
--- a/src/contentScript/__tests__/navigationTarget.test.ts
+++ b/src/contentScript/__tests__/navigationTarget.test.ts
@@ -1,0 +1,109 @@
+import { resolveNavigationTarget, type NavigationDirection } from '../tableRuntime/navigation/navigationTarget';
+import { SECTION_BODY, SECTION_HEADER } from '../tableWidget/domHelpers';
+import type { CellCoords, TableGridBounds } from '../tableModel/types';
+
+/** 1 header row + `bodyRows` body rows. */
+const gridOf = (bodyRows: number, cols: number): TableGridBounds => ({
+    totalRows: 1 + bodyRows,
+    totalCols: cols,
+});
+
+const header = (col: number): CellCoords => ({ section: SECTION_HEADER, row: 0, col });
+const body = (row: number, col: number): CellCoords => ({ section: SECTION_BODY, row, col });
+
+const resolve = (from: CellCoords, direction: NavigationDirection, bounds: TableGridBounds, allowRowCreation = false) =>
+    resolveNavigationTarget({ from, bounds, direction, allowRowCreation });
+
+describe('resolveNavigationTarget', () => {
+    describe('next', () => {
+        it('moves to the following column within the same row', () => {
+            expect(resolve(header(0), 'next', gridOf(1, 2))).toEqual({
+                kind: 'cell',
+                coords: header(1),
+            });
+        });
+
+        it('wraps from the last header column into the first body cell', () => {
+            expect(resolve(header(1), 'next', gridOf(1, 2))).toEqual({
+                kind: 'cell',
+                coords: body(0, 0),
+            });
+        });
+
+        it('wraps from the last body column into the next body row', () => {
+            expect(resolve(body(0, 1), 'next', gridOf(2, 2))).toEqual({
+                kind: 'cell',
+                coords: body(1, 0),
+            });
+        });
+    });
+
+    describe('previous', () => {
+        it('moves to the preceding column within the same row', () => {
+            expect(resolve(body(0, 1), 'previous', gridOf(1, 2))).toEqual({
+                kind: 'cell',
+                coords: body(0, 0),
+            });
+        });
+
+        it('wraps from the first body column back to the last header column', () => {
+            expect(resolve(body(0, 0), 'previous', gridOf(1, 2))).toEqual({
+                kind: 'cell',
+                coords: header(1),
+            });
+        });
+
+        it('blocks at the first header cell instead of wrapping around', () => {
+            expect(resolve(header(0), 'previous', gridOf(1, 2))).toEqual({ kind: 'blocked' });
+        });
+    });
+
+    describe('up and down', () => {
+        it('moves down from the header into the body, keeping the column', () => {
+            expect(resolve(header(1), 'down', gridOf(1, 2))).toEqual({
+                kind: 'cell',
+                coords: body(0, 1),
+            });
+        });
+
+        it('moves up from the body into the header, keeping the column', () => {
+            expect(resolve(body(0, 1), 'up', gridOf(1, 2))).toEqual({
+                kind: 'cell',
+                coords: header(1),
+            });
+        });
+
+        it('blocks above the header row', () => {
+            expect(resolve(header(0), 'up', gridOf(1, 2))).toEqual({ kind: 'blocked' });
+        });
+    });
+
+    describe('past the last row', () => {
+        it('blocks when row creation is not allowed', () => {
+            expect(resolve(body(0, 1), 'next', gridOf(1, 2))).toEqual({ kind: 'blocked' });
+            expect(resolve(body(0, 1), 'down', gridOf(1, 2))).toEqual({ kind: 'blocked' });
+        });
+
+        it('starts a new row at the first column for next (Tab)', () => {
+            expect(resolve(body(0, 1), 'next', gridOf(1, 2), true)).toEqual({
+                kind: 'newRow',
+                targetCol: 0,
+            });
+        });
+
+        it('keeps the current column for down (Enter)', () => {
+            expect(resolve(body(0, 1), 'down', gridOf(1, 2), true)).toEqual({
+                kind: 'newRow',
+                targetCol: 1,
+            });
+        });
+    });
+
+    it('treats a single-column header-only table as a one-cell grid', () => {
+        expect(resolve(header(0), 'next', gridOf(0, 1))).toEqual({ kind: 'blocked' });
+        expect(resolve(header(0), 'next', gridOf(0, 1), true)).toEqual({
+            kind: 'newRow',
+            targetCol: 0,
+        });
+    });
+});

--- a/src/contentScript/tableModel/tableContext.ts
+++ b/src/contentScript/tableModel/tableContext.ts
@@ -8,11 +8,22 @@
  */
 import { MarkdownTable } from './MarkdownTable';
 import { computeMarkdownTableCellRanges, type TableCellRanges } from './markdownTableCellRanges';
-import type { ResolvedTable } from './types';
+import type { ResolvedTable, TableGridBounds } from './types';
 
 export interface TableContext extends ResolvedTable {
     table: MarkdownTable;
     cellRanges: TableCellRanges;
+}
+
+/** The header occupies unified row 0, so it contributes one row to the grid. */
+const HEADER_ROW_COUNT = 1;
+
+/** Grid size in unified coordinates; column count is taken from the header row. */
+export function getTableGridBounds(ctx: TableContext): TableGridBounds {
+    return {
+        totalRows: HEADER_ROW_COUNT + ctx.cellRanges.rows.length,
+        totalCols: ctx.cellRanges.headers.length,
+    };
 }
 
 interface CacheEntry {

--- a/src/contentScript/tableModel/types.ts
+++ b/src/contentScript/tableModel/types.ts
@@ -31,6 +31,12 @@ export interface TableRect {
     maxCol: number;
 }
 
+/** Size of a table's unified grid, where the header counts as one row. */
+export interface TableGridBounds {
+    totalRows: number;
+    totalCols: number;
+}
+
 export function toUnifiedRowIndex(section: TableSection, row: number): number {
     return section === 'header' ? 0 : row + 1;
 }

--- a/src/contentScript/tableRuntime/navigation/navigationTarget.ts
+++ b/src/contentScript/tableRuntime/navigation/navigationTarget.ts
@@ -1,0 +1,75 @@
+/**
+ * Pure keyboard-navigation geometry: given the active cell, the table's grid bounds and a
+ * direction, decide where the keypress lands.
+ *
+ * Kept free of EditorView/EditorState so the branching that keyboard navigation keeps
+ * accumulating stays directly unit-testable; `navigateCell` owns the editor-facing effects.
+ */
+import { fromUnifiedRow, toUnifiedRow } from '../../tableState/cellSelectionState';
+import type { CellCoords, TableGridBounds } from '../../tableModel/types';
+
+export type NavigationDirection = 'next' | 'previous' | 'up' | 'down';
+
+/**
+ * - `blocked`: the keypress is consumed but nothing moves (walked off a table edge).
+ * - `cell`: activate `coords`.
+ * - `newRow`: append a row and land in `targetCol`.
+ */
+export type NavigationTarget =
+    { kind: 'blocked' } | { kind: 'cell'; coords: CellCoords } | { kind: 'newRow'; targetCol: number };
+
+interface UnifiedPosition {
+    row: number;
+    col: number;
+}
+
+/**
+ * Moves one step in unified coordinates. `next`/`previous` wrap across row boundaries;
+ * `up`/`down` keep the column. The result may sit outside the table - callers handle bounds.
+ */
+function stepUnifiedPosition(
+    position: UnifiedPosition,
+    direction: NavigationDirection,
+    totalCols: number
+): UnifiedPosition {
+    switch (direction) {
+        case 'next': {
+            const col = position.col + 1;
+            return col >= totalCols ? { row: position.row + 1, col: 0 } : { row: position.row, col };
+        }
+        case 'previous': {
+            const col = position.col - 1;
+            return col < 0 ? { row: position.row - 1, col: totalCols - 1 } : { row: position.row, col };
+        }
+        case 'up':
+            return { row: position.row - 1, col: position.col };
+        case 'down':
+            return { row: position.row + 1, col: position.col };
+    }
+}
+
+export function resolveNavigationTarget(params: {
+    from: CellCoords;
+    bounds: TableGridBounds;
+    direction: NavigationDirection;
+    allowRowCreation: boolean;
+}): NavigationTarget {
+    const { from, bounds, direction, allowRowCreation } = params;
+
+    const next = stepUnifiedPosition({ row: toUnifiedRow(from), col: from.col }, direction, bounds.totalCols);
+
+    // Walked off the top: stop at the table start rather than wrapping around.
+    if (next.row < 0) {
+        return { kind: 'blocked' };
+    }
+
+    if (next.row >= bounds.totalRows) {
+        if (!allowRowCreation) {
+            return { kind: 'blocked' };
+        }
+        // Tab ('next') starts the new row at its first column; Enter/down keeps the column.
+        return { kind: 'newRow', targetCol: direction === 'next' ? 0 : from.col };
+    }
+
+    return { kind: 'cell', coords: fromUnifiedRow(next.row, next.col) };
+}

--- a/src/contentScript/tableRuntime/navigation/tableNavigation.ts
+++ b/src/contentScript/tableRuntime/navigation/tableNavigation.ts
@@ -1,34 +1,14 @@
 import { EditorView } from '@codemirror/view';
-import {
-    getResolvedActiveCell,
-    resolveCellWithinResolvedTable,
-    type ResolvedActiveCell,
-} from '../activeCell/resolvedActiveCell';
+import { getResolvedActiveCell, resolveCellWithinResolvedTable } from '../activeCell/resolvedActiveCell';
 import { insertRowAtBottom } from '../operations/structuralOperations';
-import { type CellCoords } from '../../tableModel/types';
 import type { InitialCursorPos } from '../../shared/cursorPlacement';
-import { SECTION_BODY, SECTION_HEADER } from '../../tableWidget/domHelpers';
+import { getTableGridBounds } from '../../tableModel/tableContext';
 import { requestOpenCell, shouldSuppressNavigationKeys } from '../openCellRequest';
-
-function insertRowFromKeyboardNavigation(
-    view: EditorView,
-    resolvedActiveCell: ResolvedActiveCell,
-    targetCol: number
-): boolean {
-    if (shouldSuppressNavigationKeys(view.state)) {
-        return true; // Already locked
-    }
-
-    insertRowAtBottom(view, resolvedActiveCell, targetCol, {
-        suppressKeys: true,
-    });
-
-    return true;
-}
+import { resolveNavigationTarget, type NavigationDirection } from './navigationTarget';
 
 export function navigateCell(
     view: EditorView,
-    direction: 'next' | 'previous' | 'up' | 'down',
+    direction: NavigationDirection,
     options: { initialCursorPos?: InitialCursorPos; allowRowCreation?: boolean } = {}
 ): boolean {
     // Prevent race conditions from rapid key-holding
@@ -36,86 +16,28 @@ export function navigateCell(
         return true; // Swallow keypress, navigation already in progress
     }
 
-    const state = view.state;
-    const resolvedActiveCell = getResolvedActiveCell(state);
+    const resolvedActiveCell = getResolvedActiveCell(view.state);
     if (!resolvedActiveCell) {
         return false;
     }
-    const activeCell = resolvedActiveCell.activeCell;
-    const ctx = resolvedActiveCell.ctx;
 
-    const numBodyRows = ctx.cellRanges.rows.length;
-    // Assuming uniform column count for now, based on header
-    const numCols = ctx.cellRanges.headers.length;
+    const target = resolveNavigationTarget({
+        from: resolvedActiveCell.activeCell,
+        bounds: getTableGridBounds(resolvedActiveCell.ctx),
+        direction,
+        allowRowCreation: options.allowRowCreation === true,
+    });
 
-    // Convert to unified grid coordinates:
-    // Header row = 0
-    // Body row i = i + 1
-    let unifiedRow = activeCell.section === SECTION_HEADER ? 0 : activeCell.row + 1;
-    let unifiedCol = activeCell.col;
-
-    // Total rows = header (1) + body rows
-    const totalRows = 1 + numBodyRows;
-
-    // --- Core Navigation Logic ---
-
-    if (direction === 'next') {
-        unifiedCol++;
-        if (unifiedCol >= numCols) {
-            unifiedCol = 0;
-            unifiedRow++;
-        }
-    } else if (direction === 'previous') {
-        unifiedCol--;
-        if (unifiedCol < 0) {
-            unifiedCol = numCols - 1;
-            unifiedRow--;
-        }
-    } else if (direction === 'down') {
-        unifiedRow++;
-    } else if (direction === 'up') {
-        unifiedRow--;
-    }
-
-    // --- Boundary Handling ---
-
-    // Check if we walked off the table (top or bottom)
-    if (unifiedRow < 0) {
-        // Navigation stopped at table start - don't wrap around or move cursor
+    if (target.kind === 'blocked') {
         return true;
     }
 
-    if (unifiedRow >= totalRows) {
-        if (options.allowRowCreation) {
-            // Tab ('next') goes to first col, Enter/down stays in same col
-            const targetCol = direction === 'next' ? 0 : activeCell.col;
-            return insertRowFromKeyboardNavigation(view, resolvedActiveCell, targetCol);
-        }
-        // Walked off end of table
+    if (target.kind === 'newRow') {
+        insertRowAtBottom(view, resolvedActiveCell, target.targetCol, { suppressKeys: true });
         return true;
     }
 
-    // --- Convert back to Section/Row ---
-
-    let targetSection: 'header' | 'body';
-    let targetRow: number;
-
-    if (unifiedRow === 0) {
-        targetSection = SECTION_HEADER;
-        targetRow = 0;
-    } else {
-        targetSection = SECTION_BODY;
-        targetRow = unifiedRow - 1;
-    }
-
-    const target: CellCoords = {
-        section: targetSection,
-        row: targetRow,
-        col: unifiedCol,
-    };
-
-    // Activate target cell
-    const nextResolvedCell = resolveCellWithinResolvedTable(resolvedActiveCell, target);
+    const nextResolvedCell = resolveCellWithinResolvedTable(resolvedActiveCell, target.coords);
     if (!nextResolvedCell) {
         return false;
     }

--- a/src/contentScript/tableRuntime/selection/cellSelectionController.ts
+++ b/src/contentScript/tableRuntime/selection/cellSelectionController.ts
@@ -12,22 +12,15 @@ import {
     type CellSelection,
     type CellSelectionDirection,
 } from '../../tableState/cellSelectionState';
-import type { TableContext } from '../../tableModel/tableContext';
+import { getTableGridBounds, type TableContext } from '../../tableModel/tableContext';
 import { clamp } from '../../shared/numberUtils';
 import { resolveCellDocRange, resolveTableContextAtPos } from '../tableResolution';
 import { makeTableId, type CellCoords } from '../../tableModel/types';
 import { findCellElement } from '../../tableWidget/domHelpers';
 import { getResolvedActiveCell } from '../activeCell/resolvedActiveCell';
 
-function getTableBoundsFromContext(ctx: TableContext): { totalRows: number; totalCols: number } {
-    return {
-        totalRows: 1 + ctx.cellRanges.rows.length,
-        totalCols: ctx.cellRanges.headers.length,
-    };
-}
-
 function clampSelectionFocusWithinContext(ctx: TableContext, focus: CellCoords): CellCoords | null {
-    const bounds = getTableBoundsFromContext(ctx);
+    const bounds = getTableGridBounds(ctx);
     if (bounds.totalCols <= 0) {
         return null;
     }


### PR DESCRIPTION
`navigateCell` had grown to 69 lines with a cyclomatic complexity of 16, mixing unified-grid coordinate math, boundary handling and editor dispatch in one function. The grid math was also a hand-rolled copy of the `toUnifiedRow` / `fromUnifiedRow` helpers that already existed in `cellSelectionState`.

Move the decision into a new pure `navigationTarget` module: `stepUnifiedPosition` does the one-step move and `resolveNavigationTarget` returns a `NavigationTarget` union (`blocked` | `cell` | `newRow`), reusing the existing unified-row helpers instead of re-deriving the header offset. `navigateCell` reduces to a suppression guard, active-cell resolution and one branch per target kind (CCN 6, 33 lines).

Hoist the duplicated `1 + rows.length` bounds derivation into `getTableGridBounds` in `tableContext`, shared with `cellSelectionController`, and add a `TableGridBounds` type alongside the other table coordinate types.

Drop the second `shouldSuppressNavigationKeys` check in the row-insert path. It has been unreachable since 29c0f66 converted it from a side-effecting `acquireNavigationLock()` to a pure state read that `navigateCell` already performs against the same undispatched state.

Behaviour is unchanged: the existing `tableNavigation` tests pass untouched, and `navigationTarget.test.ts` covers the geometry directly - both wrap edges, the top-of-table block and Tab-vs-Enter row creation.