### PR TITLE
test: cover tableNormalization and extract boundary padding

### DIFF
--- a/src/contentScript/__tests__/tableNormalization.test.ts
+++ b/src/contentScript/__tests__/tableNormalization.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it } from 'vitest';
+import type { EditorState } from '@codemirror/state';
+import { activeCellField, getActiveCell, setActiveCellEffect, type ActiveCell } from '../tableState/activeCellState';
+import { rebuildTableWidgetsEffect } from '../tableState/tableWidgetEffects';
+import { resolveActiveCell } from '../tableRuntime/activeCell/resolvedActiveCell';
+import {
+    beginOpenCellRequestEffect,
+    openCellRequestField,
+    triggerOpenCellRequestEffect,
+    type OpenCellRequest,
+} from '../tableRuntime/openCellRequest';
+import {
+    normalizeBeforeEditAnnotation,
+    planNormalizeTableBeforeOpen,
+    type NormalizeTableBeforeOpenPlan,
+} from '../tableRuntime/lifecycle/tableNormalization';
+import { createMarkdownState } from './testMarkdownState';
+
+const canonicalTable = ['| H1 | H2 |', '| --- | --- |', '| a1 | a2 |'].join('\n');
+const nonCanonicalTable = ['|H1|H2|', '|---|---|', '|a1|a2|'].join('\n');
+
+function createOpenRequest(params: { activeCell: ActiveCell; normalizeIfNeeded: boolean }): OpenCellRequest {
+    return {
+        requestId: 'test-open-request',
+        activeCell: params.activeCell,
+        normalizeIfNeeded: params.normalizeIfNeeded,
+        initialCursorPos: 'end',
+        suppressKeys: false,
+    };
+}
+
+function addPendingOpenRequest(state: EditorState, request: OpenCellRequest): EditorState {
+    return state.update({ effects: beginOpenCellRequestEffect.of(request) }).state;
+}
+
+function requireResolvedActiveCell(state: EditorState) {
+    const resolved = resolveActiveCell(state, getActiveCell(state));
+    if (!resolved) {
+        throw new Error('Expected resolved active cell');
+    }
+    return resolved;
+}
+
+function headerCellAt(tableFrom: number): ActiveCell {
+    return {
+        tableFrom,
+        section: 'header',
+        row: 0,
+        col: 0,
+    };
+}
+
+/**
+ * Builds a document containing `table` at `tableFrom`, points the active cell at it,
+ * registers a pending open request, and plans normalization for that request.
+ */
+function planFor(params: {
+    doc: string;
+    tableFrom: number;
+    activeCell?: ActiveCell;
+    normalizeIfNeeded?: boolean;
+    registerRequest?: boolean;
+}): { state: EditorState; plan: NormalizeTableBeforeOpenPlan } {
+    const activeCell = params.activeCell ?? headerCellAt(params.tableFrom);
+    let state = createMarkdownState(params.doc, [activeCellField, openCellRequestField]);
+    state = state.update({ effects: setActiveCellEffect.of(activeCell) }).state;
+
+    const request = createOpenRequest({ activeCell, normalizeIfNeeded: params.normalizeIfNeeded ?? true });
+    if (params.registerRequest ?? true) {
+        state = addPendingOpenRequest(state, request);
+    }
+
+    return {
+        state,
+        plan: planNormalizeTableBeforeOpen({
+            state,
+            resolvedActiveCell: requireResolvedActiveCell(state),
+            request,
+        }),
+    };
+}
+
+function requireDispatchPlan(plan: NormalizeTableBeforeOpenPlan) {
+    if (plan.type !== 'dispatch') {
+        throw new Error(`Expected normalization dispatch plan, got ${plan.type}`);
+    }
+    return plan;
+}
+
+describe('planNormalizeTableBeforeOpen', () => {
+    it('aborts when the open request is no longer pending', () => {
+        const { plan } = planFor({
+            doc: nonCanonicalTable,
+            tableFrom: 0,
+            registerRequest: false,
+        });
+
+        expect(plan).toEqual({ type: 'aborted' });
+    });
+
+    it('skips normalization when the request opted out', () => {
+        const { plan } = planFor({
+            doc: nonCanonicalTable,
+            tableFrom: 0,
+            normalizeIfNeeded: false,
+        });
+
+        expect(plan).toEqual({ type: 'not-needed' });
+    });
+
+    it('skips normalization when the table is already canonical and spaced', () => {
+        const { plan } = planFor({
+            doc: `\n${canonicalTable}\n`,
+            tableFrom: 1,
+        });
+
+        expect(plan).toEqual({ type: 'not-needed' });
+    });
+
+    it('remaps the active cell and retriggers the open request when it normalizes', () => {
+        const activeCell: ActiveCell = {
+            tableFrom: 0,
+            section: 'body',
+            row: 0,
+            col: 1,
+        };
+        const { state, plan } = planFor({
+            doc: nonCanonicalTable,
+            tableFrom: 0,
+            activeCell,
+        });
+
+        const tr = state.update(requireDispatchPlan(plan).spec);
+        expect(tr.state.doc.toString()).toBe(`\n${canonicalTable}\n`);
+        expect(getActiveCell(tr.state)).toEqual({
+            tableFrom: 1,
+            section: 'body',
+            row: 0,
+            col: 1,
+        });
+        expect(tr.state.selection.main.anchor).toBeGreaterThan(0);
+        expect(tr.annotation(normalizeBeforeEditAnnotation)).toBe(true);
+        expect(tr.effects.some((effect) => effect.is(rebuildTableWidgetsEffect))).toBe(true);
+        expect(
+            tr.effects.some(
+                (effect) =>
+                    effect.is(beginOpenCellRequestEffect) &&
+                    effect.value.requestId === 'test-open-request' &&
+                    effect.value.normalizeIfNeeded === false &&
+                    effect.value.activeCell.tableFrom === 1
+            )
+        ).toBe(true);
+        expect(
+            tr.effects.some(
+                (effect) => effect.is(triggerOpenCellRequestEffect) && effect.value.requestId === 'test-open-request'
+            )
+        ).toBe(true);
+    });
+
+    describe('boundary spacing', () => {
+        it('adds a blank line above a table that follows text directly', () => {
+            const doc = `intro\n${canonicalTable}\n\nafter`;
+            const { state, plan } = planFor({ doc, tableFrom: 'intro\n'.length });
+
+            const tr = state.update(requireDispatchPlan(plan).spec);
+            expect(tr.state.doc.toString()).toBe(`intro\n\n${canonicalTable}\n\nafter`);
+            expect(getActiveCell(tr.state)?.tableFrom).toBe('intro\n\n'.length);
+        });
+
+        it('adds a blank line below a table that precedes text directly', () => {
+            const doc = `intro\n\n${canonicalTable}\nafter`;
+            const tableFrom = 'intro\n\n'.length;
+            const { state, plan } = planFor({ doc, tableFrom });
+
+            const tr = state.update(requireDispatchPlan(plan).spec);
+            expect(tr.state.doc.toString()).toBe(`intro\n\n${canonicalTable}\n\nafter`);
+            // Padding is appended, so the table start is unchanged.
+            expect(getActiveCell(tr.state)?.tableFrom).toBe(tableFrom);
+        });
+
+        it('adds blank lines on both sides when neither boundary is separated', () => {
+            const doc = `intro\n${canonicalTable}\nafter`;
+            const { state, plan } = planFor({ doc, tableFrom: 'intro\n'.length });
+
+            const tr = state.update(requireDispatchPlan(plan).spec);
+            expect(tr.state.doc.toString()).toBe(`intro\n\n${canonicalTable}\n\nafter`);
+        });
+
+        it('leaves an already separated mid-document table alone', () => {
+            const doc = `intro\n\n${canonicalTable}\n\nafter`;
+            const { plan } = planFor({ doc, tableFrom: 'intro\n\n'.length });
+
+            expect(plan).toEqual({ type: 'not-needed' });
+        });
+
+        it('treats the document edges as unseparated boundaries', () => {
+            // Intended: a table flush against the document start is padded so there is
+            // always a newline before it, and the same applies at the document end.
+            const { state, plan } = planFor({ doc: canonicalTable, tableFrom: 0 });
+
+            const tr = state.update(requireDispatchPlan(plan).spec);
+            expect(tr.state.doc.toString()).toBe(`\n${canonicalTable}\n`);
+        });
+
+        it('normalizes markdown and boundaries in a single replacement', () => {
+            const doc = `intro\n${nonCanonicalTable}\nafter`;
+            const { state, plan } = planFor({ doc, tableFrom: 'intro\n'.length });
+
+            const tr = state.update(requireDispatchPlan(plan).spec);
+            expect(tr.state.doc.toString()).toBe(`intro\n\n${canonicalTable}\n\nafter`);
+            expect(tr.state.doc.toString().startsWith('intro\n\n')).toBe(true);
+        });
+    });
+});

--- a/src/contentScript/__tests__/tableRuntimePolicies.test.ts
+++ b/src/contentScript/__tests__/tableRuntimePolicies.test.ts
@@ -22,17 +22,8 @@ import { decideMainEditorGuardTransaction } from '../editorBridge/mainEditorGuar
 import { decideTableDecorationUpdate } from '../tableWidget/tableDecorationPolicy';
 import { syncAnnotation } from '../editorBridge/syncAnnotation';
 import { createMarkdownState } from './testMarkdownState';
-import {
-    normalizeBeforeEditAnnotation,
-    planNormalizeTableBeforeOpen,
-} from '../tableRuntime/lifecycle/tableNormalization';
+import { normalizeBeforeEditAnnotation } from '../tableRuntime/lifecycle/tableNormalization';
 import { createActiveCellForTableText } from '../tableRuntime/activeCell/activeCellFactory';
-import {
-    beginOpenCellRequestEffect,
-    openCellRequestField,
-    triggerOpenCellRequestEffect,
-    type OpenCellRequest,
-} from '../tableRuntime/openCellRequest';
 
 const doc = ['| H1 | H2 |', '| --- | --- |', '| a1 | a2 |'].join('\n');
 
@@ -58,20 +49,6 @@ function getHeaderCell(): ActiveCell {
         row: 0,
         col: 0,
     };
-}
-
-function createOpenRequest(params: { activeCell: ActiveCell; normalizeIfNeeded: boolean }): OpenCellRequest {
-    return {
-        requestId: 'test-open-request',
-        activeCell: params.activeCell,
-        normalizeIfNeeded: params.normalizeIfNeeded,
-        initialCursorPos: 'end',
-        suppressKeys: false,
-    };
-}
-
-function addPendingOpenRequest(state: EditorState, request: OpenCellRequest): EditorState {
-    return state.update({ effects: beginOpenCellRequestEffect.of(request) }).state;
 }
 
 function requireResolvedActiveCell(state: EditorState) {
@@ -620,110 +597,6 @@ describe('tableRuntimePolicies', () => {
             type: 'allowTransaction',
         });
         expect(reduceTableRuntime(facts)).toEqual([{ type: 'openRequestedCell', requestId: 'normalize-request' }]);
-    });
-
-    it('does not plan normalization when disabled or already canonical', () => {
-        const activeCell = getHeaderCell();
-        const nonCanonicalState = createMarkdownState(['|H1|H2|', '|---|---|', '|a1|a2|'].join('\n'), [
-            activeCellField,
-            openCellRequestField,
-        ]).update({ effects: setActiveCellEffect.of(activeCell) }).state;
-        const disabledRequest = createOpenRequest({ activeCell, normalizeIfNeeded: false });
-        const nonCanonicalStateWithRequest = addPendingOpenRequest(nonCanonicalState, disabledRequest);
-        const nonCanonicalResolved = requireResolvedActiveCell(nonCanonicalStateWithRequest);
-
-        expect(
-            planNormalizeTableBeforeOpen({
-                state: nonCanonicalStateWithRequest,
-                resolvedActiveCell: nonCanonicalResolved,
-                request: disabledRequest,
-            })
-        ).toEqual({ type: 'not-needed' });
-
-        const canonicalActiveCell = { ...activeCell, tableFrom: 1 };
-        let canonicalState = createMarkdownState(`\n${doc}\n`, [activeCellField, openCellRequestField]);
-        canonicalState = canonicalState.update({ effects: setActiveCellEffect.of(canonicalActiveCell) }).state;
-        const canonicalRequest = createOpenRequest({ activeCell: canonicalActiveCell, normalizeIfNeeded: true });
-        canonicalState = addPendingOpenRequest(canonicalState, canonicalRequest);
-        const canonicalResolved = requireResolvedActiveCell(canonicalState);
-
-        expect(
-            planNormalizeTableBeforeOpen({
-                state: canonicalState,
-                resolvedActiveCell: canonicalResolved,
-                request: canonicalRequest,
-            })
-        ).toEqual({ type: 'not-needed' });
-    });
-
-    it('plans a normalization dispatch that remaps active cell and retriggers open request', () => {
-        const nonCanonicalDoc = ['|H1|H2|', '|---|---|', '|a1|a2|'].join('\n');
-        const activeCell: ActiveCell = {
-            tableFrom: 0,
-            section: 'body',
-            row: 0,
-            col: 1,
-        };
-        let state = createMarkdownState(nonCanonicalDoc, [activeCellField, openCellRequestField]);
-        state = state.update({ effects: setActiveCellEffect.of(activeCell) }).state;
-        const request = createOpenRequest({ activeCell, normalizeIfNeeded: true });
-        state = addPendingOpenRequest(state, request);
-        const resolved = requireResolvedActiveCell(state);
-
-        const plan = planNormalizeTableBeforeOpen({
-            state,
-            resolvedActiveCell: resolved,
-            request,
-        });
-
-        expect(plan.type).toBe('dispatch');
-        if (plan.type !== 'dispatch') {
-            throw new Error('Expected normalization dispatch plan');
-        }
-
-        const tr = state.update(plan.spec);
-        expect(tr.state.doc.toString()).toBe(`\n${doc}\n`);
-        expect(getActiveCell(tr.state)).toEqual({
-            tableFrom: 1,
-            section: 'body',
-            row: 0,
-            col: 1,
-        });
-        expect(tr.state.selection.main.anchor).toBeGreaterThan(0);
-        expect(tr.annotation(normalizeBeforeEditAnnotation)).toBe(true);
-        expect(tr.effects.some((effect) => effect.is(rebuildTableWidgetsEffect))).toBe(true);
-        expect(
-            tr.effects.some(
-                (effect) =>
-                    effect.is(beginOpenCellRequestEffect) &&
-                    effect.value.requestId === 'test-open-request' &&
-                    effect.value.normalizeIfNeeded === false &&
-                    effect.value.activeCell.tableFrom === 1
-            )
-        ).toBe(true);
-        expect(
-            tr.effects.some(
-                (effect) => effect.is(triggerOpenCellRequestEffect) && effect.value.requestId === 'test-open-request'
-            )
-        ).toBe(true);
-    });
-
-    it('aborts normalization when the open request is stale', () => {
-        const activeCell = getHeaderCell();
-        let state = createMarkdownState(['|H1|H2|', '|---|---|', '|a1|a2|'].join('\n'), [
-            activeCellField,
-            openCellRequestField,
-        ]);
-        state = state.update({ effects: setActiveCellEffect.of(activeCell) }).state;
-        const resolved = requireResolvedActiveCell(state);
-
-        expect(
-            planNormalizeTableBeforeOpen({
-                state,
-                resolvedActiveCell: resolved,
-                request: createOpenRequest({ activeCell, normalizeIfNeeded: true }),
-            })
-        ).toEqual({ type: 'aborted' });
     });
 
     it('does not plan a generic reopen for rebuild-only transactions', () => {

--- a/src/contentScript/tableRuntime/lifecycle/tableNormalization.ts
+++ b/src/contentScript/tableRuntime/lifecycle/tableNormalization.ts
@@ -20,13 +20,43 @@ import {
 export const normalizeBeforeEditAnnotation = Annotation.define<boolean>();
 
 interface NormalizedTableReplacement {
+    /** Document range `insert` replaces. */
+    from: number;
+    to: number;
     insert: string;
     tableText: string;
     tableFrom: number;
 }
 
+interface TableBoundaryPadding {
+    prefix: string;
+    suffix: string;
+}
+
 export type NormalizeTableBeforeOpenPlan =
     { type: 'not-needed' } | { type: 'aborted' } | { type: 'dispatch'; spec: TransactionSpec };
+
+/**
+ * Blank-line padding the table needs to stay separated from its surroundings.
+ * A single newline per side is enough: the replaced range is line-bounded, so the
+ * neighbouring line breaks already outside it combine with the padding to form the blank line.
+ *
+ * Document edges count as unseparated, so a table at the very start or end of the note is
+ * padded too. That is intended: a table flush against the document start is kept off the
+ * first line so there is always a newline before it.
+ */
+function resolveBoundaryPadding(state: EditorState, ctx: Pick<TableContext, 'from' | 'to'>): TableBoundaryPadding {
+    const beforeText = state.doc.sliceString(0, ctx.from);
+    const afterText = state.doc.sliceString(ctx.to);
+    const needsLeadingSeparator =
+        countTrailingBlankLinesBeforeBoundary(beforeText) < REQUIRED_TABLE_BOUNDARY_BLANK_LINES;
+    const needsTrailingSeparator = countLeadingBlankLinesAfterBoundary(afterText) < REQUIRED_TABLE_BOUNDARY_BLANK_LINES;
+
+    return {
+        prefix: needsLeadingSeparator ? '\n' : '',
+        suffix: needsTrailingSeparator ? '\n' : '',
+    };
+}
 
 /**
  * Returns canonical table markdown plus missing blank-line boundaries when needed.
@@ -37,13 +67,7 @@ function getNormalizedTableReplacementIfChanged(
     ctx: Pick<TableContext, 'from' | 'to' | 'table' | 'text'>
 ): NormalizedTableReplacement | null {
     const tableText = ctx.table.serialize();
-    const beforeText = state.doc.sliceString(0, ctx.from);
-    const afterText = state.doc.sliceString(ctx.to);
-    const needsLeadingSeparator =
-        countTrailingBlankLinesBeforeBoundary(beforeText) < REQUIRED_TABLE_BOUNDARY_BLANK_LINES;
-    const needsTrailingSeparator = countLeadingBlankLinesAfterBoundary(afterText) < REQUIRED_TABLE_BOUNDARY_BLANK_LINES;
-    const prefix = needsLeadingSeparator ? '\n' : '';
-    const suffix = needsTrailingSeparator ? '\n' : '';
+    const { prefix, suffix } = resolveBoundaryPadding(state, ctx);
     const insert = prefix + tableText + suffix;
 
     if (insert === ctx.text) {
@@ -51,6 +75,8 @@ function getNormalizedTableReplacementIfChanged(
     }
 
     return {
+        from: ctx.from,
+        to: ctx.to,
         insert,
         tableText,
         tableFrom: ctx.from + prefix.length,
@@ -89,8 +115,8 @@ export function planNormalizeTableBeforeOpen(params: {
         type: 'dispatch',
         spec: {
             changes: {
-                from: params.resolvedActiveCell.tableFrom,
-                to: params.resolvedActiveCell.tableTo,
+                from: replacement.from,
+                to: replacement.to,
                 insert: replacement.insert,
             },
             selection: { anchor: nextActiveCell.selectionAnchor },


### PR DESCRIPTION
Add a paired test file for tableNormalization. The three planNormalizeTableBeforeOpen tests move out of the policy suite, which is about the runtime reducer, guard, and decoration policy rather than this module.

Boundary spacing was only exercised for a table alone in the document, where both sides always need padding. Add cases for text above, text below, both, an already separated mid-document table, and the document edges, and document that padding at the document start is intended.

Extract resolveBoundaryPadding so the replacement builder reads at one level of abstraction, and let NormalizedTableReplacement carry the range it was computed against instead of the dispatch spec re-reading resolvedActiveCell. Those are the same values today, so behaviour is unchanged.