### PR TITLE
refactor: reduce complexity in canHandleTableClipboardShortcut

### DIFF
--- a/src/contentScript/__tests__/cellSelectionShortcutScope.test.ts
+++ b/src/contentScript/__tests__/cellSelectionShortcutScope.test.ts
@@ -13,21 +13,30 @@ import {
 import { CLASS_CELL_EDITOR } from '../shared/tableDomClasses';
 import { CLASS_FLOATING_TOOLBAR, CLASS_TABLE_WIDGET } from '../tableWidget/domHelpers';
 
-function createViewHarness() {
+function createViewHarness(options: { activeCell?: boolean; selection?: boolean } = {}) {
+    const { activeCell = true, selection = true } = options;
     let state = createMarkdownState('| H1 |\n| --- |\n| a |', [activeCellField, cellSelectionField]);
     state = state.update({
         effects: [
-            setActiveCellEffect.of({
-                tableFrom: 0,
-                section: 'header',
-                row: 0,
-                col: 0,
-            }),
-            setCellSelectionEffect.of({
-                tableFrom: 0,
-                anchor: { section: 'header', row: 0, col: 0 },
-                focus: { section: 'body', row: 0, col: 0 },
-            }),
+            ...(activeCell
+                ? [
+                      setActiveCellEffect.of({
+                          tableFrom: 0,
+                          section: 'header' as const,
+                          row: 0,
+                          col: 0,
+                      }),
+                  ]
+                : []),
+            ...(selection
+                ? [
+                      setCellSelectionEffect.of({
+                          tableFrom: 0,
+                          anchor: { section: 'header' as const, row: 0, col: 0 },
+                          focus: { section: 'body' as const, row: 0, col: 0 },
+                      }),
+                  ]
+                : []),
         ],
     }).state;
 
@@ -113,5 +122,71 @@ describe('cellSelectionShortcutScope', () => {
         setActiveElement(nestedContent);
 
         expect(canHandleTableClipboardShortcut(view)).toBe(true);
+    });
+
+    it('rejects shortcuts when there is no table interaction state', () => {
+        const { view } = createViewHarness({ activeCell: false, selection: false });
+        setActiveElement(document.body);
+
+        expect(canHandleTableClipboardShortcut(view)).toBe(false);
+    });
+
+    it('allows shortcuts when nothing is focused but a selection exists', () => {
+        const { view } = createViewHarness();
+        setActiveElement(null);
+
+        expect(canHandleTableSelectionKeydown(view)).toBe(true);
+    });
+
+    it('rejects shortcuts when nothing is focused and only an active cell exists', () => {
+        const { view } = createViewHarness({ selection: false });
+        setActiveElement(null);
+
+        expect(canHandleTableClipboardShortcut(view)).toBe(false);
+    });
+
+    it.each([
+        ['editor root', (harness: ReturnType<typeof createViewHarness>) => harness.root],
+        ['scroll container', (harness: ReturnType<typeof createViewHarness>) => harness.scrollDOM],
+        ['content container', (harness: ReturnType<typeof createViewHarness>) => harness.contentDOM],
+    ])('allows shortcuts when focus is on the CodeMirror %s', (_label, pickElement) => {
+        const harness = createViewHarness();
+        setActiveElement(pickElement(harness));
+
+        expect(canHandleTableSelectionKeydown(harness.view)).toBe(true);
+    });
+
+    it('rejects shortcuts when focus is on a CodeMirror container without a selection', () => {
+        const { view, contentDOM } = createViewHarness({ selection: false });
+        setActiveElement(contentDOM);
+
+        expect(canHandleTableClipboardShortcut(view)).toBe(false);
+    });
+
+    it('allows shortcuts when focus is on a non-interactive element elsewhere in the editor', () => {
+        const { view, contentDOM } = createViewHarness();
+        const sibling = document.createElement('span');
+        contentDOM.appendChild(sibling);
+        setActiveElement(sibling);
+
+        expect(canHandleTableSelectionKeydown(view)).toBe(true);
+    });
+
+    it('rejects shortcuts when focus is on a non-interactive element outside the editor', () => {
+        const { view } = createViewHarness();
+        const outside = document.createElement('span');
+        document.body.appendChild(outside);
+        setActiveElement(outside);
+
+        expect(canHandleTableSelectionKeydown(view)).toBe(false);
+    });
+
+    it('rejects shortcuts when focus is outside the editor and only an active cell exists', () => {
+        const { view } = createViewHarness({ selection: false });
+        const outside = document.createElement('span');
+        document.body.appendChild(outside);
+        setActiveElement(outside);
+
+        expect(canHandleTableClipboardShortcut(view)).toBe(false);
     });
 });

--- a/src/contentScript/tableRuntime/selection/cellSelectionShortcutScope.ts
+++ b/src/contentScript/tableRuntime/selection/cellSelectionShortcutScope.ts
@@ -1,7 +1,7 @@
 import type { EditorView } from '@codemirror/view';
 import { CLASS_CELL_EDITOR } from '../../shared/tableDomClasses';
 import { getActiveCell } from '../../tableState/activeCellState';
-import { getCellSelection } from '../../tableState/cellSelectionState';
+import { getCellSelection, type CellSelection } from '../../tableState/cellSelectionState';
 import { makeTableId } from '../../tableModel/types';
 import { CLASS_FLOATING_TOOLBAR, findTableWidgetElement } from '../../tableWidget/domHelpers';
 
@@ -56,6 +56,33 @@ function isNestedEditorElement(element: Element): boolean {
 }
 
 /**
+ * Structural/container elements that can hold focus without being interactive:
+ * body and documentElement receive focus after a blur (or in Electron when no
+ * element is focused); the CM containers receive focus during programmatic
+ * focus shifts.
+ */
+function isStructuralFocusHost(view: EditorView, element: Element): boolean {
+    const doc = view.dom.ownerDocument;
+    const structuralHosts: Array<Element | null> = [
+        doc.body,
+        doc.documentElement,
+        view.dom,
+        view.contentDOM,
+        view.scrollDOM,
+    ];
+
+    return structuralHosts.includes(element);
+}
+
+/** True when `element` is the widget rendering `selection`'s table, or lives inside it. */
+function isInsideSelectedTableWidget(view: EditorView, selection: CellSelection, element: Element): boolean {
+    const selectedWidget = findTableWidgetElement(view, makeTableId(selection.tableFrom));
+
+    // `contains()` is self-inclusive, so this also covers the widget root itself.
+    return Boolean(selectedWidget?.contains(element));
+}
+
+/**
  * Determines whether document-level capture-phase event listeners should handle
  * a clipboard event (copy/cut/paste) or a keyboard shortcut that applies to both
  * cell selections and active cells. Returns true when focus is in a location where
@@ -88,34 +115,25 @@ export function canHandleTableClipboardShortcut(view: EditorView): boolean {
         return false;
     }
 
-    // Focus is on a structural/container element: body or documentElement can receive
-    // focus after a blur (or in Electron when no element is focused); CM containers
-    // (dom, contentDOM, scrollDOM) receive focus during programmatic focus shifts.
-    // In these cases handle if we have a selection that the user can act on.
-    if (
-        activeElement === doc.body ||
-        activeElement === doc.documentElement ||
-        activeElement === view.dom ||
-        activeElement === view.contentDOM ||
-        activeElement === view.scrollDOM
-    ) {
+    // Focus is parked on a container rather than a real control — handle if we have
+    // a selection that the user can act on.
+    if (isStructuralFocusHost(view, activeElement)) {
         return Boolean(selection);
     }
 
-    if (selection) {
-        // Focus is on a non-interactive element inside the selected table widget —
-        // handle to keep table shortcuts working while the widget has soft focus.
-        const selectedWidget = findTableWidgetElement(view, makeTableId(selection.tableFrom));
-        if (selectedWidget && (activeElement === selectedWidget || selectedWidget.contains(activeElement))) {
-            return true;
-        }
-
-        // Focus is somewhere else inside the CM editor — handle to prevent the event
-        // from reaching unrelated handlers outside the table context.
-        return view.dom.contains(activeElement);
+    if (!selection) {
+        return false;
     }
 
-    return false;
+    // Focus is on a non-interactive element inside the selected table widget —
+    // handle to keep table shortcuts working while the widget has soft focus.
+    if (isInsideSelectedTableWidget(view, selection, activeElement)) {
+        return true;
+    }
+
+    // Focus is somewhere else inside the CM editor — handle to prevent the event
+    // from reaching unrelated handlers outside the table context.
+    return view.dom.contains(activeElement);
 }
 
 /**


### PR DESCRIPTION
Extract two helpers from canHandleTableClipboardShortcut, which had cyclomatic complexity 16:

- isStructuralFocusHost() replaces the five-way equality chain over body/documentElement/dom/contentDOM/scrollDOM with membership in a named array.
- isInsideSelectedTableWidget() takes over the widget lookup and containment test, letting the tail of the function flatten into the same guard-clause ladder as the rest of it.

Node.contains() is self-inclusive, so the redundant `activeElement === selectedWidget` disjunct is dropped; behaviour is unchanged.

Parameterize the test harness so active-cell-without-selection states are reachable, and cover the branches that had none: the no-state early return, a null activeElement, focus on each CodeMirror container, and focus on non-interactive elements inside and outside the editor.