### PR TITLE
refactor: flatten footnote reference processing

### DIFF
--- a/src/contentScript/__tests__/htmlPostProcessor.test.ts
+++ b/src/contentScript/__tests__/htmlPostProcessor.test.ts
@@ -61,6 +61,46 @@ describe('postProcessHtml', () => {
         expect(doc.querySelector('pre')?.textContent).toBe('pre [^nope2]');
     });
 
+    test('converts every footnote ref in a text node and keeps the surrounding text', () => {
+        const html = '<div>start [^one] middle [^two] end</div>';
+
+        const result = postProcessHtml(html);
+        const doc = parseHtml(result);
+
+        const refs = Array.from(doc.querySelectorAll('sup.footnote-ref a'));
+        expect(refs.map((ref) => ref.textContent)).toEqual(['one', 'two']);
+        expect(doc.querySelector('div')?.textContent).toBe('start one middle two end');
+    });
+
+    test('converts adjacent footnote refs without inserting empty text', () => {
+        const html = '<div>[^a][^b]</div>';
+
+        const result = postProcessHtml(html);
+        const doc = parseHtml(result);
+
+        const div = doc.querySelector('div') as HTMLElement;
+        expect(Array.from(div.childNodes).map((n) => n.nodeName)).toEqual(['SUP', 'SUP']);
+    });
+
+    test('encodes labels with characters that are not URL safe', () => {
+        const html = '<div>see [^note 1]</div>';
+
+        const result = postProcessHtml(html);
+        const doc = parseHtml(result);
+
+        const ref = doc.querySelector('sup.footnote-ref a');
+        expect(ref?.getAttribute('href')).toBe('#fn-note%201');
+        expect(ref?.textContent).toBe('note 1');
+    });
+
+    test('leaves text without footnote refs untouched', () => {
+        const html = '<div>plain [not a ref] text</div>';
+
+        const result = postProcessHtml(html);
+
+        expect(result).toBe(html);
+    });
+
     test('replaces KaTeX HTML with MathML and removes annotations and direct text nodes', () => {
         const html =
             '<div>' +

--- a/src/contentScript/services/htmlPostProcessor.ts
+++ b/src/contentScript/services/htmlPostProcessor.ts
@@ -57,6 +57,16 @@ function cleanupAndOptimizeHtml(html: string): string {
 }
 
 /**
+ * A footnote reference with its label captured, e.g. `[^abc]` or `[^note 1]`.
+ * The capture group is required: `convertFootnoteRefs` splits on this pattern
+ * and reads the labels out of the resulting parts.
+ */
+const FOOTNOTE_REF_PATTERN = /\[\^([^\]]+)\]/;
+
+/** Elements whose text is literal, so `[^label]` inside them is not a reference. */
+const LITERAL_TEXT_TAGS = new Set(['CODE', 'PRE']);
+
+/**
  * Convert [^label] patterns to footnote links, but only in text nodes
  * outside of <code> and <pre> elements.
  *
@@ -74,46 +84,58 @@ function convertFootnoteRefs(html: string): string {
 /** Recursively process text nodes, skipping code/pre elements */
 function processFootnotesInNode(node: Node): void {
     for (const child of Array.from(node.childNodes)) {
-        if (child.nodeType === Node.TEXT_NODE) {
-            const text = child.textContent || '';
-            if (/\[\^[^\]]+\]/.test(text)) {
-                const fragment = document.createDocumentFragment();
-                let lastIndex = 0;
-                const regex = /\[\^([^\]]+)\]/g;
-                let match;
-
-                while ((match = regex.exec(text)) !== null) {
-                    // Add text before the footnote
-                    if (match.index > lastIndex) {
-                        fragment.appendChild(document.createTextNode(text.slice(lastIndex, match.index)));
-                    }
-
-                    const label = match[1];
-                    const sup = document.createElement('sup');
-                    sup.className = 'footnote-ref';
-
-                    const a = document.createElement('a');
-                    a.href = buildFootnoteHref(label);
-                    a.textContent = label;
-
-                    sup.appendChild(a);
-                    fragment.appendChild(sup);
-
-                    lastIndex = regex.lastIndex;
-                }
-
-                // Add remaining text
-                if (lastIndex < text.length) {
-                    fragment.appendChild(document.createTextNode(text.slice(lastIndex)));
-                }
-
-                child.replaceWith(fragment);
-            }
-        } else if (child.nodeType === Node.ELEMENT_NODE) {
+        if (child.nodeType === Node.ELEMENT_NODE) {
             const el = child as Element;
-            if (el.tagName !== 'CODE' && el.tagName !== 'PRE') {
+            if (!LITERAL_TEXT_TAGS.has(el.tagName)) {
                 processFootnotesInNode(el);
             }
+            continue;
+        }
+
+        if (child.nodeType !== Node.TEXT_NODE) {
+            continue;
+        }
+
+        const fragment = buildFootnoteFragment(child.textContent || '');
+        if (fragment) {
+            child.replaceWith(fragment);
         }
     }
+}
+
+/**
+ * The replacement for a text node containing footnote references, or null when
+ * the text has none and the node should be left as it is.
+ */
+function buildFootnoteFragment(text: string): DocumentFragment | null {
+    // Splitting on a capturing pattern interleaves the parts: even indices are
+    // the literal text between references, odd indices are the captured labels.
+    const parts = text.split(FOOTNOTE_REF_PATTERN);
+    if (parts.length === 1) {
+        return null;
+    }
+
+    const fragment = document.createDocumentFragment();
+    parts.forEach((part, index) => {
+        if (index % 2 === 1) {
+            fragment.appendChild(createFootnoteRef(part));
+        } else if (part) {
+            fragment.appendChild(document.createTextNode(part));
+        }
+    });
+
+    return fragment;
+}
+
+/** `<sup class="footnote-ref"><a href="#fn-label">label</a></sup>` */
+function createFootnoteRef(label: string): HTMLElement {
+    const sup = document.createElement('sup');
+    sup.className = 'footnote-ref';
+
+    const a = document.createElement('a');
+    a.href = buildFootnoteHref(label);
+    a.textContent = label;
+
+    sup.appendChild(a);
+    return sup;
 }


### PR DESCRIPTION
processFootnotesInNode nested five levels deep and mixed three jobs: the tree walk, the text splitting, and the DOM construction.

Split the text handling into buildFootnoteFragment, which splits on the capturing footnote pattern instead of tracking exec() lastIndex, and the element construction into createFootnoteRef. The walker keeps only the traversal, with early continues in place of the nested branches. The skipped tag names and the reference pattern move to module constants.

Behavior is unchanged, including empty gaps between adjacent references and text nodes without references being left alone; tests cover both.