### PR TITLE
refactor: simplify main editor guard policy

### DIFF
--- a/src/contentScript/__tests__/tableRuntimePolicies.test.ts
+++ b/src/contentScript/__tests__/tableRuntimePolicies.test.ts
@@ -409,6 +409,27 @@ describe('tableRuntimePolicies', () => {
         expect(decision.rewrite.tableFrom).toBe(8);
     });
 
+    it('does not rewrite multi-change paste transactions', () => {
+        const state = createMarkdownState(['', 'after'].join('\n'), [
+            activeCellField,
+            cellSelectionField,
+            sourceModeField,
+            searchForceSourceModeField,
+        ]);
+        const pasteText = ['|H1|H2|', '|---|---|', '|a|b|'].join('\n');
+        const tr = state.update({
+            changes: [
+                { from: 0, to: 0, insert: pasteText },
+                { from: state.doc.length, to: state.doc.length, insert: 'x' },
+            ],
+            userEvent: 'input.paste',
+        });
+
+        expect(decideMainEditorGuardTransaction(tr, { nestedEditorOpen: false })).toEqual({
+            type: 'allowTransaction',
+        });
+    });
+
     it('does not return a root-table rewrite when a cell selection is active', () => {
         let state = createMarkdownState(['before', '', 'after'].join('\n'), [
             activeCellField,

--- a/src/contentScript/__tests__/tableRuntimePolicies.test.ts
+++ b/src/contentScript/__tests__/tableRuntimePolicies.test.ts
@@ -409,7 +409,7 @@ describe('tableRuntimePolicies', () => {
         expect(decision.rewrite.tableFrom).toBe(8);
     });
 
-    it('does not rewrite multi-change paste transactions', () => {
+    it('rewrites single-change but not multi-change paste transactions', () => {
         const state = createMarkdownState(['', 'after'].join('\n'), [
             activeCellField,
             cellSelectionField,
@@ -417,7 +417,11 @@ describe('tableRuntimePolicies', () => {
             searchForceSourceModeField,
         ]);
         const pasteText = ['|H1|H2|', '|---|---|', '|a|b|'].join('\n');
-        const tr = state.update({
+        const singleChangeTr = state.update({
+            changes: { from: 0, to: 0, insert: pasteText },
+            userEvent: 'input.paste',
+        });
+        const multiChangeTr = state.update({
             changes: [
                 { from: 0, to: 0, insert: pasteText },
                 { from: state.doc.length, to: state.doc.length, insert: 'x' },
@@ -425,7 +429,10 @@ describe('tableRuntimePolicies', () => {
             userEvent: 'input.paste',
         });
 
-        expect(decideMainEditorGuardTransaction(tr, { nestedEditorOpen: false })).toEqual({
+        expect(decideMainEditorGuardTransaction(singleChangeTr, { nestedEditorOpen: false })).toMatchObject({
+            type: 'rewriteRootTablePaste',
+        });
+        expect(decideMainEditorGuardTransaction(multiChangeTr, { nestedEditorOpen: false })).toEqual({
             type: 'allowTransaction',
         });
     });

--- a/src/contentScript/editorBridge/mainEditorGuardPolicy.ts
+++ b/src/contentScript/editorBridge/mainEditorGuardPolicy.ts
@@ -36,29 +36,24 @@ interface SingleChange {
     insertedText: string;
 }
 
-function extractSingleChange(tr: Transaction): SingleChange | null {
-    let from = 0;
-    let to = 0;
-    let insertedText: string | null = null;
+function extractSinglePasteChange(tr: Transaction): SingleChange | null {
+    let singleChange: SingleChange | null = null;
+    let hasInsertedText = false;
     let changeCount = 0;
 
     tr.changes.iterChanges((fromA, toA, _fromB, _toB, inserted) => {
         changeCount++;
         if (changeCount === 1) {
-            from = fromA;
-            to = toA;
-            insertedText = inserted.toString();
+            const insertedText = inserted.toString();
+            singleChange = { from: fromA, to: toA, insertedText };
+            hasInsertedText = insertedText.length > 0;
         }
     });
 
-    return changeCount === 1 && insertedText ? { from, to, insertedText } : null;
+    return changeCount === 1 && hasInsertedText ? singleChange : null;
 }
 
-function decideNestedEditorPaste(tr: Transaction, pastedText: string, nestedEditorOpen: boolean): GuardDecision | null {
-    if (!nestedEditorOpen) {
-        return null;
-    }
-
+function decideNestedEditorPaste(tr: Transaction, pastedText: string): GuardDecision | null {
     const resolvedActiveCell = getResolvedActiveCell(tr.startState);
     if (!resolvedActiveCell) {
         return null;
@@ -82,8 +77,8 @@ function decideNestedEditorPaste(tr: Transaction, pastedText: string, nestedEdit
     return rewrite ? { type: 'rewriteTableClipboard', rewrite } : null;
 }
 
-function decideRootEditorPaste(tr: Transaction, change: SingleChange, nestedEditorOpen: boolean): GuardDecision | null {
-    if (nestedEditorOpen || getCellSelection(tr.startState) || isEffectiveRawMode(tr.startState)) {
+function decideRootEditorPaste(tr: Transaction, change: SingleChange): GuardDecision | null {
+    if (getCellSelection(tr.startState) || isEffectiveRawMode(tr.startState)) {
         return null;
     }
 
@@ -97,15 +92,12 @@ function decidePasteTransaction(tr: Transaction, nestedEditorOpen: boolean): Gua
         return null;
     }
 
-    const change = extractSingleChange(tr);
+    const change = extractSinglePasteChange(tr);
     if (!change) {
         return null;
     }
 
-    return (
-        decideNestedEditorPaste(tr, change.insertedText, nestedEditorOpen) ??
-        decideRootEditorPaste(tr, change, nestedEditorOpen)
-    );
+    return nestedEditorOpen ? decideNestedEditorPaste(tr, change.insertedText) : decideRootEditorPaste(tr, change);
 }
 
 function changesOverlapRange(tr: Transaction, from: number, to: number): boolean {

--- a/src/contentScript/editorBridge/mainEditorGuardPolicy.ts
+++ b/src/contentScript/editorBridge/mainEditorGuardPolicy.ts
@@ -30,32 +30,82 @@ export type GuardDecision =
           selection: EditorSelection;
       };
 
-function extractSingleInsertedText(tr: Transaction): string | null {
+interface SingleChange {
+    from: number;
+    to: number;
+    insertedText: string;
+}
+
+function extractSingleChange(tr: Transaction): SingleChange | null {
+    let from = 0;
+    let to = 0;
     let insertedText: string | null = null;
     let changeCount = 0;
 
-    tr.changes.iterChanges((_fromA, _toA, _fromB, _toB, inserted) => {
+    tr.changes.iterChanges((fromA, toA, _fromB, _toB, inserted) => {
         changeCount++;
         if (changeCount === 1) {
+            from = fromA;
+            to = toA;
             insertedText = inserted.toString();
         }
     });
 
-    return changeCount === 1 && insertedText ? insertedText : null;
+    return changeCount === 1 && insertedText ? { from, to, insertedText } : null;
 }
 
-function extractSingleChangeRange(tr: Transaction): { from: number; to: number } | null {
-    let changeRange: { from: number; to: number } | null = null;
-    let changeCount = 0;
+function decideNestedEditorPaste(tr: Transaction, pastedText: string, nestedEditorOpen: boolean): GuardDecision | null {
+    if (!nestedEditorOpen) {
+        return null;
+    }
 
-    tr.changes.iterChanges((fromA, toA) => {
-        changeCount++;
-        if (changeCount === 1) {
-            changeRange = { from: fromA, to: toA };
-        }
-    });
+    const resolvedActiveCell = getResolvedActiveCell(tr.startState);
+    if (!resolvedActiveCell) {
+        return null;
+    }
 
-    return changeCount === 1 ? changeRange : null;
+    const activeCell = resolvedActiveCell.activeCell;
+    const rewrite = buildMultiCellPasteRewrite(
+        tr.startState,
+        {
+            tableFrom: resolvedActiveCell.tableFrom,
+            anchor: {
+                section: activeCell.section,
+                row: activeCell.row,
+                col: activeCell.col,
+            },
+            source: 'activeCell',
+        },
+        pastedText
+    );
+
+    return rewrite ? { type: 'rewriteTableClipboard', rewrite } : null;
+}
+
+function decideRootEditorPaste(tr: Transaction, change: SingleChange, nestedEditorOpen: boolean): GuardDecision | null {
+    if (nestedEditorOpen || getCellSelection(tr.startState) || isEffectiveRawMode(tr.startState)) {
+        return null;
+    }
+
+    const rewrite = buildRootTablePasteRewrite(tr.startState, change.from, change.to, change.insertedText);
+
+    return rewrite ? { type: 'rewriteRootTablePaste', rewrite } : null;
+}
+
+function decidePasteTransaction(tr: Transaction, nestedEditorOpen: boolean): GuardDecision | null {
+    if (!tr.isUserEvent('input.paste')) {
+        return null;
+    }
+
+    const change = extractSingleChange(tr);
+    if (!change) {
+        return null;
+    }
+
+    return (
+        decideNestedEditorPaste(tr, change.insertedText, nestedEditorOpen) ??
+        decideRootEditorPaste(tr, change, nestedEditorOpen)
+    );
 }
 
 function changesOverlapRange(tr: Transaction, from: number, to: number): boolean {
@@ -87,51 +137,9 @@ export function decideMainEditorGuardTransaction(
         return { type: 'allowTransaction' };
     }
 
-    if (tr.isUserEvent('input.paste')) {
-        const pastedText = extractSingleInsertedText(tr);
-
-        if (pastedText) {
-            if (params.nestedEditorOpen) {
-                const resolvedActiveCell = getResolvedActiveCell(tr.startState);
-
-                if (resolvedActiveCell) {
-                    const activeCell = resolvedActiveCell.activeCell;
-                    const rewrite = buildMultiCellPasteRewrite(
-                        tr.startState,
-                        {
-                            tableFrom: resolvedActiveCell.tableFrom,
-                            anchor: {
-                                section: activeCell.section,
-                                row: activeCell.row,
-                                col: activeCell.col,
-                            },
-                            source: 'activeCell',
-                        },
-                        pastedText
-                    );
-
-                    if (rewrite) {
-                        return { type: 'rewriteTableClipboard', rewrite };
-                    }
-                }
-            }
-
-            if (!params.nestedEditorOpen && !getCellSelection(tr.startState) && !isEffectiveRawMode(tr.startState)) {
-                const changeRange = extractSingleChangeRange(tr);
-                if (changeRange) {
-                    const rewrite = buildRootTablePasteRewrite(
-                        tr.startState,
-                        changeRange.from,
-                        changeRange.to,
-                        pastedText
-                    );
-
-                    if (rewrite) {
-                        return { type: 'rewriteRootTablePaste', rewrite };
-                    }
-                }
-            }
-        }
+    const pasteDecision = decidePasteTransaction(tr, params.nestedEditorOpen);
+    if (pasteDecision) {
+        return pasteDecision;
     }
 
     const activeCell = getActiveCell(tr.startState);


### PR DESCRIPTION
## Summary

- extract nested-editor and root-editor paste decisions into focused helpers
- dispatch explicitly between mutually exclusive nested and root paste paths
- scan single-change paste transactions once and share the extracted range/text
- cover multi-change paste fallthrough with a regression test
- flatten `decideMainEditorGuardTransaction` while preserving decision precedence and runtime behavior

## Why

The main editor guard mixed paste classification with active-cell lifecycle and sanitization decisions. Its nested paste branch reached five levels of control-flow nesting and made the policy difficult to audit. This refactor separates those concerns without changing the public API or behavior.

## Impact

No user-facing behavior changes are intended. The guard policy is easier to reason about and maintain, particularly around paste rewrite precedence and active-table boundary enforcement.

## Validation

- `npm test` — 603 tests passed
- `npm run lint`
- `npm run dist`
- Prettier check on the changed TypeScript files
- `git diff --check`