### PR TITLE
Refactor cell selection key handling

### DIFF
--- a/src/contentScript/__tests__/cellSelectionKeymap.test.ts
+++ b/src/contentScript/__tests__/cellSelectionKeymap.test.ts
@@ -7,7 +7,7 @@ vi.mock('../tableWidget/domHelpers', async (importOriginal) => ({
     findCellElement: vi.fn(() => ({})),
 }));
 
-import { history } from '@codemirror/commands';
+import { history, undo } from '@codemirror/commands';
 import { markdown } from '@codemirror/lang-markdown';
 import { EditorView } from '@codemirror/view';
 import { GFM } from '@lezer/markdown';
@@ -21,22 +21,41 @@ const markdownExtension = markdown({
     extensions: [GFM],
 });
 
+/** Table with three columns and two body rows, so selection can move in every direction. */
+const GRID_DOC = ['| H1 | H2 | H3 |', '| --- | --- | --- |', '| a1 | a2 | a3 |', '| b1 | b2 | b3 |'].join('\n');
+
+const mountedViews: EditorView[] = [];
+
+function mountSelectionView(doc: string): EditorView {
+    const parent = document.createElement('div');
+    document.body.appendChild(parent);
+
+    const view = new EditorView({
+        parent,
+        extensions: [markdownExtension, history(), activeCellField, cellSelectionField, cellSelectionKeyCapturePlugin],
+        doc,
+    });
+    mountedViews.push(view);
+
+    return view;
+}
+
+function pressKey(init: KeyboardEventInit & { key: string }): void {
+    document.body.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, cancelable: true, ...init }));
+}
+
+afterEach(() => {
+    // Destroy here rather than per-test so a failing assertion cannot leak the
+    // plugin's document-level keydown listener into the next test.
+    while (mountedViews.length > 0) {
+        mountedViews.pop()?.destroy();
+    }
+    document.body.replaceChildren();
+});
+
 describe('cellSelectionKeymap', () => {
     it('routes undo through the main editor while a multi-cell selection is active', () => {
-        const parent = document.createElement('div');
-        document.body.appendChild(parent);
-
-        const view = new EditorView({
-            parent,
-            extensions: [
-                markdownExtension,
-                history(),
-                activeCellField,
-                cellSelectionField,
-                cellSelectionKeyCapturePlugin,
-            ],
-            doc: ['| H1 | H2 |', '| --- | --- |', '| a1 | a2 |'].join('\n'),
-        });
+        const view = mountSelectionView(['| H1 | H2 |', '| --- | --- |', '| a1 | a2 |'].join('\n'));
 
         view.dispatch({
             changes: {
@@ -54,79 +73,30 @@ describe('cellSelectionKeymap', () => {
         expect(view.state.doc.toString()).toContain('| b1 | b2 |');
         expect(getCellSelection(view.state)).not.toBeNull();
 
-        document.body.dispatchEvent(
-            new KeyboardEvent('keydown', {
-                key: 'z',
-                ctrlKey: true,
-                bubbles: true,
-                cancelable: true,
-            })
-        );
+        pressKey({ key: 'z', ctrlKey: true });
 
         expect(view.state.doc.toString()).not.toContain('| b1 | b2 |');
         expect(getCellSelection(view.state)).toBeNull();
-
-        view.destroy();
     });
 
-    it('routes Delete through selection removal while a multi-cell selection is active', () => {
-        const parent = document.createElement('div');
-        document.body.appendChild(parent);
-
-        const view = new EditorView({
-            parent,
-            extensions: [
-                markdownExtension,
-                history(),
-                activeCellField,
-                cellSelectionField,
-                cellSelectionKeyCapturePlugin,
-            ],
-            doc: ['| H1 |  | H3 |', '| --- | --- | --- |', '| A1 |  | A3 |', '| B1 |  | B3 |'].join('\n'),
-        });
+    it.each([
+        { label: 'Ctrl+Y', init: { key: 'y', ctrlKey: true } },
+        { label: 'Ctrl+Shift+Z', init: { key: 'z', ctrlKey: true, shiftKey: true } },
+    ])('routes redo through the main editor via $label', ({ init }) => {
+        const view = mountSelectionView(['| H1 | H2 |', '| --- | --- |', '| a1 | a2 |'].join('\n'));
 
         view.dispatch({
-            effects: setCellSelectionEffect.of({
-                tableFrom: 0,
-                anchor: { section: 'header', row: 0, col: 1 },
-                focus: { section: 'body', row: 1, col: 1 },
-            }),
+            changes: {
+                from: view.state.doc.length,
+                to: view.state.doc.length,
+                insert: '\n| b1 | b2 |',
+            },
         });
-
-        const event = new KeyboardEvent('keydown', {
-            key: 'Delete',
-            bubbles: true,
-            cancelable: true,
-        });
-        document.body.dispatchEvent(event);
-
-        expect(view.state.doc.toString()).toBe(
-            ['| H1 | H3 |', '| --- | --- |', '| A1 | A3 |', '| B1 | B3 |'].join('\n')
-        );
-        expect(getCellSelection(view.state)).toEqual({
-            tableFrom: 0,
-            anchor: { section: 'header', row: 0, col: 1 },
-            focus: { section: 'body', row: 1, col: 1 },
-        });
-
-        view.destroy();
-    });
-
-    it('routes Backspace through selection removal while a multi-cell selection is active', () => {
-        const parent = document.createElement('div');
-        document.body.appendChild(parent);
-
-        const view = new EditorView({
-            parent,
-            extensions: [
-                markdownExtension,
-                history(),
-                activeCellField,
-                cellSelectionField,
-                cellSelectionKeyCapturePlugin,
-            ],
-            doc: ['| H1 | H2 |', '| --- | --- |', '| a1 | a2 |'].join('\n'),
-        });
+        // Undo directly so the redo stack is primed without the keymap's refocus,
+        // which would otherwise park focus on the contenteditable and suppress the
+        // next document-level shortcut.
+        undo(view);
+        expect(view.state.doc.toString()).not.toContain('| b1 | b2 |');
 
         view.dispatch({
             effects: setCellSelectionEffect.of({
@@ -136,12 +106,48 @@ describe('cellSelectionKeymap', () => {
             }),
         });
 
-        const event = new KeyboardEvent('keydown', {
-            key: 'Backspace',
-            bubbles: true,
-            cancelable: true,
+        pressKey(init);
+
+        expect(view.state.doc.toString()).toContain('| b1 | b2 |');
+    });
+
+    it('routes Delete through selection removal while a multi-cell selection is active', () => {
+        const view = mountSelectionView(
+            ['| H1 |  | H3 |', '| --- | --- | --- |', '| A1 |  | A3 |', '| B1 |  | B3 |'].join('\n')
+        );
+
+        view.dispatch({
+            effects: setCellSelectionEffect.of({
+                tableFrom: 0,
+                anchor: { section: 'header', row: 0, col: 1 },
+                focus: { section: 'body', row: 1, col: 1 },
+            }),
         });
-        document.body.dispatchEvent(event);
+
+        pressKey({ key: 'Delete' });
+
+        expect(view.state.doc.toString()).toBe(
+            ['| H1 | H3 |', '| --- | --- |', '| A1 | A3 |', '| B1 | B3 |'].join('\n')
+        );
+        expect(getCellSelection(view.state)).toEqual({
+            tableFrom: 0,
+            anchor: { section: 'header', row: 0, col: 1 },
+            focus: { section: 'body', row: 1, col: 1 },
+        });
+    });
+
+    it('routes Backspace through selection removal while a multi-cell selection is active', () => {
+        const view = mountSelectionView(['| H1 | H2 |', '| --- | --- |', '| a1 | a2 |'].join('\n'));
+
+        view.dispatch({
+            effects: setCellSelectionEffect.of({
+                tableFrom: 0,
+                anchor: { section: 'body', row: 0, col: 0 },
+                focus: { section: 'body', row: 0, col: 1 },
+            }),
+        });
+
+        pressKey({ key: 'Backspace' });
 
         expect(view.state.doc.toString()).toBe(['| H1 | H2 |', '| --- | --- |', '|  |  |'].join('\n'));
         expect(getCellSelection(view.state)).toEqual({
@@ -149,25 +155,27 @@ describe('cellSelectionKeymap', () => {
             anchor: { section: 'body', row: 0, col: 0 },
             focus: { section: 'body', row: 0, col: 1 },
         });
+    });
 
-        view.destroy();
+    it.each(['shiftKey', 'altKey', 'ctrlKey', 'metaKey'] as const)('ignores Delete combined with %s', (modifier) => {
+        const initialDoc = ['| H1 | H2 |', '| --- | --- |', '| a1 | a2 |'].join('\n');
+        const view = mountSelectionView(initialDoc);
+
+        view.dispatch({
+            effects: setCellSelectionEffect.of({
+                tableFrom: 0,
+                anchor: { section: 'body', row: 0, col: 0 },
+                focus: { section: 'body', row: 0, col: 1 },
+            }),
+        });
+
+        pressKey({ key: 'Delete', [modifier]: true });
+
+        expect(view.state.doc.toString()).toBe(initialDoc);
     });
 
     it('focuses the main editor after deleting an emptied table via multi-cell selection', () => {
-        const parent = document.createElement('div');
-        document.body.appendChild(parent);
-
-        const view = new EditorView({
-            parent,
-            extensions: [
-                markdownExtension,
-                history(),
-                activeCellField,
-                cellSelectionField,
-                cellSelectionKeyCapturePlugin,
-            ],
-            doc: ['| H1 | H2 |', '| --- | --- |', '| a1 | a2 |'].join('\n'),
-        });
+        const view = mountSelectionView(['| H1 | H2 |', '| --- | --- |', '| a1 | a2 |'].join('\n'));
         const focusSpy = vi.spyOn(view, 'focus');
 
         view.dispatch({
@@ -178,13 +186,7 @@ describe('cellSelectionKeymap', () => {
             }),
         });
 
-        document.body.dispatchEvent(
-            new KeyboardEvent('keydown', {
-                key: 'Delete',
-                bubbles: true,
-                cancelable: true,
-            })
-        );
+        pressKey({ key: 'Delete' });
 
         expect(view.state.doc.toString()).toBe(['|  |  |', '| --- | --- |', '|  |  |'].join('\n'));
         expect(getCellSelection(view.state)).toEqual({
@@ -195,63 +197,27 @@ describe('cellSelectionKeymap', () => {
 
         focusSpy.mockClear();
 
-        document.body.dispatchEvent(
-            new KeyboardEvent('keydown', {
-                key: 'Delete',
-                bubbles: true,
-                cancelable: true,
-            })
-        );
+        pressKey({ key: 'Delete' });
 
         expect(view.state.doc.toString()).toBe('');
         expect(getCellSelection(view.state)).toBeNull();
         expect(view.state.selection.main.anchor).toBe(0);
         expect(focusSpy).toHaveBeenCalledTimes(1);
-
-        view.destroy();
     });
 
     it('ignores Delete when multi-cell selection mode is not active', () => {
-        const parent = document.createElement('div');
-        document.body.appendChild(parent);
-
         const initialDoc = ['| H1 | H2 |', '| --- | --- |', '| a1 | a2 |'].join('\n');
-        const view = new EditorView({
-            parent,
-            extensions: [
-                markdownExtension,
-                history(),
-                activeCellField,
-                cellSelectionField,
-                cellSelectionKeyCapturePlugin,
-            ],
-            doc: initialDoc,
-        });
+        const view = mountSelectionView(initialDoc);
 
-        const event = new KeyboardEvent('keydown', {
-            key: 'Delete',
-            bubbles: true,
-            cancelable: true,
-        });
-        document.body.dispatchEvent(event);
+        pressKey({ key: 'Delete' });
 
         expect(view.state.doc.toString()).toBe(initialDoc);
         expect(getCellSelection(view.state)).toBeNull();
-
-        view.destroy();
     });
 
-    it('activates the focus cell editor on Tab while multi-cell selection is active', () => {
-        const parent = document.createElement('div');
-        document.body.appendChild(parent);
+    it('clears the selection on Escape', () => {
+        const view = mountSelectionView(GRID_DOC);
 
-        const view = new EditorView({
-            parent,
-            extensions: [markdownExtension, activeCellField, cellSelectionField, cellSelectionKeyCapturePlugin],
-            doc: ['| H1 | H2 |', '| --- | --- |', '| a1 | a2 |'].join('\n'),
-        });
-
-        const dispatchSpy = vi.spyOn(view, 'dispatch');
         view.dispatch({
             effects: setCellSelectionEffect.of({
                 tableFrom: 0,
@@ -260,36 +226,96 @@ describe('cellSelectionKeymap', () => {
             }),
         });
 
-        const event = new KeyboardEvent('keydown', {
-            key: 'Tab',
-            bubbles: true,
-            cancelable: true,
-        });
-        document.body.dispatchEvent(event);
+        pressKey({ key: 'Escape' });
 
         expect(getCellSelection(view.state)).toBeNull();
-        expect(getActiveCell(view.state)).toMatchObject({
-            tableFrom: 0,
-            section: 'body',
-            row: 0,
-            col: 1,
-        });
-        const lastSpec = dispatchSpy.mock.calls[dispatchSpy.mock.calls.length - 1]?.[0];
-        const effects = Array.isArray(lastSpec?.effects) ? lastSpec.effects : [lastSpec?.effects];
-        expect(effects.some((effect) => effect?.is?.(triggerOpenCellRequestEffect))).toBe(true);
+    });
 
-        view.destroy();
+    it.each([{ key: 'Tab' as const }, { key: 'Enter' as const }])(
+        'activates the focus cell editor on $key while multi-cell selection is active',
+        ({ key }) => {
+            const view = mountSelectionView(['| H1 | H2 |', '| --- | --- |', '| a1 | a2 |'].join('\n'));
+
+            const dispatchSpy = vi.spyOn(view, 'dispatch');
+            view.dispatch({
+                effects: setCellSelectionEffect.of({
+                    tableFrom: 0,
+                    anchor: { section: 'body', row: 0, col: 0 },
+                    focus: { section: 'body', row: 0, col: 1 },
+                }),
+            });
+
+            pressKey({ key });
+
+            expect(getCellSelection(view.state)).toBeNull();
+            expect(getActiveCell(view.state)).toMatchObject({
+                tableFrom: 0,
+                section: 'body',
+                row: 0,
+                col: 1,
+            });
+            const lastSpec = dispatchSpy.mock.calls[dispatchSpy.mock.calls.length - 1]?.[0];
+            const effects = Array.isArray(lastSpec?.effects) ? lastSpec.effects : [lastSpec?.effects];
+            expect(effects.some((effect) => effect?.is?.(triggerOpenCellRequestEffect))).toBe(true);
+        }
+    );
+
+    it.each([{ key: 'Tab' as const }, { key: 'Enter' as const }])(
+        'leaves the selection untouched on Shift+$key',
+        ({ key }) => {
+            const view = mountSelectionView(['| H1 | H2 |', '| --- | --- |', '| a1 | a2 |'].join('\n'));
+
+            const selection = {
+                tableFrom: 0,
+                anchor: { section: 'body', row: 0, col: 0 },
+                focus: { section: 'body', row: 0, col: 1 },
+            } as const;
+            view.dispatch({ effects: setCellSelectionEffect.of(selection) });
+
+            pressKey({ key, shiftKey: true });
+
+            expect(getCellSelection(view.state)).toEqual(selection);
+            expect(getActiveCell(view.state)).toBeNull();
+        }
+    );
+
+    // Each direction is wired up by hand in the keymap's dispatch table, so a
+    // transposed entry would be invisible without per-direction coverage.
+    it.each([
+        { key: 'ArrowRight', expected: { section: 'body', row: 0, col: 2 } },
+        { key: 'ArrowLeft', expected: { section: 'body', row: 0, col: 0 } },
+        { key: 'ArrowDown', expected: { section: 'body', row: 1, col: 1 } },
+        { key: 'ArrowUp', expected: { section: 'header', row: 0, col: 1 } },
+    ])('extends the selection on Shift+$key', ({ key, expected }) => {
+        const view = mountSelectionView(GRID_DOC);
+
+        const anchor = { section: 'body', row: 0, col: 1 } as const;
+        view.dispatch({
+            effects: setCellSelectionEffect.of({ tableFrom: 0, anchor, focus: anchor }),
+        });
+
+        pressKey({ key, shiftKey: true });
+
+        expect(getCellSelection(view.state)).toEqual({ tableFrom: 0, anchor, focus: expected });
+    });
+
+    it.each(['ArrowRight', 'ArrowLeft', 'ArrowDown', 'ArrowUp'])('ignores %s without Shift', (key) => {
+        const view = mountSelectionView(GRID_DOC);
+
+        const selection = {
+            tableFrom: 0,
+            anchor: { section: 'body', row: 0, col: 1 },
+            focus: { section: 'body', row: 0, col: 1 },
+        } as const;
+        view.dispatch({ effects: setCellSelectionEffect.of(selection) });
+
+        pressKey({ key });
+
+        expect(getCellSelection(view.state)).toEqual(selection);
     });
 
     it('starts cell selection from a resolved active cell', () => {
-        const parent = document.createElement('div');
-        document.body.appendChild(parent);
-
-        const view = new EditorView({
-            parent,
-            extensions: [markdownExtension, activeCellField, cellSelectionField],
-            doc: ['| H1 | H2 |', '| --- | --- |', '| a1 | a2 |'].join('\n'),
-        });
+        const view = mountSelectionView(['| H1 | H2 |', '| --- | --- |', '| a1 | a2 |'].join('\n'));
         view.dispatch({
             effects: setActiveCellEffect.of({
                 tableFrom: 0,
@@ -306,19 +332,10 @@ describe('cellSelectionKeymap', () => {
             anchor: { section: 'body', row: 0, col: 0 },
             focus: { section: 'body', row: 0, col: 1 },
         });
-
-        view.destroy();
     });
 
     it('does not start cell selection from a stale active cell', () => {
-        const parent = document.createElement('div');
-        document.body.appendChild(parent);
-
-        const view = new EditorView({
-            parent,
-            extensions: [markdownExtension, activeCellField, cellSelectionField],
-            doc: ['| H1 | H2 |', '| --- | --- |', '| a1 | a2 |'].join('\n'),
-        });
+        const view = mountSelectionView(['| H1 | H2 |', '| --- | --- |', '| a1 | a2 |'].join('\n'));
         view.dispatch({
             effects: setActiveCellEffect.of({
                 tableFrom: 0,
@@ -332,7 +349,5 @@ describe('cellSelectionKeymap', () => {
         expect(startCellSelectionFromActiveCell(view, 'right')).toBe(false);
         expect(dispatchSpy).not.toHaveBeenCalled();
         expect(getCellSelection(view.state)).toBeNull();
-
-        view.destroy();
     });
 });

--- a/src/contentScript/tableRuntime/selection/cellSelectionKeymap.ts
+++ b/src/contentScript/tableRuntime/selection/cellSelectionKeymap.ts
@@ -1,6 +1,10 @@
 import { redo, undo } from '@codemirror/commands';
 import { EditorView, ViewPlugin, type Command } from '@codemirror/view';
-import { clearCellSelectionEffect, getCellSelection } from '../../tableState/cellSelectionState';
+import {
+    clearCellSelectionEffect,
+    getCellSelection,
+    type CellSelectionDirection,
+} from '../../tableState/cellSelectionState';
 import { getActiveCell } from '../../tableState/activeCellState';
 import { createActiveCellFromRanges } from '../activeCell/activeCellFactory';
 import { extendExistingCellSelection, startCellSelectionFromActiveCell } from './cellSelectionController';
@@ -11,7 +15,7 @@ import { requestOpenCell } from '../openCellRequest';
 
 type SelectionKeyHandler = (view: EditorView, event: KeyboardEvent) => boolean;
 
-function extendOrStartSelection(view: EditorView, direction: 'left' | 'right' | 'up' | 'down'): boolean {
+function extendOrStartSelection(view: EditorView, direction: CellSelectionDirection): boolean {
     if (getCellSelection(view.state)) {
         return extendExistingCellSelection(view, direction);
     }
@@ -96,16 +100,26 @@ function handleDeleteKey(view: EditorView, event: KeyboardEvent): boolean {
     return !event.shiftKey && !event.altKey && !event.ctrlKey && !event.metaKey && handleSelectionDelete(view);
 }
 
+/** Enter and Tab both open the focus cell; Shift+Enter/Tab are left to the editor. */
+function handleActivateKey(view: EditorView, event: KeyboardEvent): boolean {
+    return !event.shiftKey && activateSelectionFocus(view);
+}
+
+/** Arrow keys extend the selection only while Shift is held. */
+function arrowKeyHandler(direction: CellSelectionDirection): SelectionKeyHandler {
+    return (view, event) => event.shiftKey && extendOrStartSelection(view, direction);
+}
+
 const selectionKeyHandlers: ReadonlyMap<string, SelectionKeyHandler> = new Map([
     ['Backspace', handleDeleteKey],
     ['Delete', handleDeleteKey],
-    ['ArrowLeft', (view, event) => event.shiftKey && extendOrStartSelection(view, 'left')],
-    ['ArrowRight', (view, event) => event.shiftKey && extendOrStartSelection(view, 'right')],
-    ['ArrowUp', (view, event) => event.shiftKey && extendOrStartSelection(view, 'up')],
-    ['ArrowDown', (view, event) => event.shiftKey && extendOrStartSelection(view, 'down')],
+    ['ArrowLeft', arrowKeyHandler('left')],
+    ['ArrowRight', arrowKeyHandler('right')],
+    ['ArrowUp', arrowKeyHandler('up')],
+    ['ArrowDown', arrowKeyHandler('down')],
     ['Escape', (view) => clearSelectionIfActive(view)],
-    ['Enter', (view, event) => !event.shiftKey && activateSelectionFocus(view)],
-    ['Tab', (view, event) => !event.shiftKey && activateSelectionFocus(view)],
+    ['Enter', handleActivateKey],
+    ['Tab', handleActivateKey],
 ]);
 
 function runSelectionKeydown(view: EditorView, event: KeyboardEvent): boolean {

--- a/src/contentScript/tableRuntime/selection/cellSelectionKeymap.ts
+++ b/src/contentScript/tableRuntime/selection/cellSelectionKeymap.ts
@@ -1,5 +1,5 @@
 import { redo, undo } from '@codemirror/commands';
-import { EditorView, ViewPlugin } from '@codemirror/view';
+import { EditorView, ViewPlugin, type Command } from '@codemirror/view';
 import { clearCellSelectionEffect, getCellSelection } from '../../tableState/cellSelectionState';
 import { getActiveCell } from '../../tableState/activeCellState';
 import { createActiveCellFromRanges } from '../activeCell/activeCellFactory';
@@ -9,7 +9,6 @@ import { canHandleTableSelectionKeydown } from './cellSelectionShortcutScope';
 import { handleSelectionDelete } from './cellSelectionClipboard';
 import { requestOpenCell } from '../openCellRequest';
 
-type EditorCommand = (view: EditorView) => boolean;
 type SelectionKeyHandler = (view: EditorView, event: KeyboardEvent) => boolean;
 
 function extendOrStartSelection(view: EditorView, direction: 'left' | 'right' | 'up' | 'down'): boolean {
@@ -66,7 +65,7 @@ function activateSelectionFocus(view: EditorView): boolean {
     return true;
 }
 
-function resolveHistoryCommand(event: KeyboardEvent): EditorCommand | null {
+function resolveHistoryCommand(event: KeyboardEvent): Command | null {
     const key = event.key.toLowerCase();
     if ((event.ctrlKey || event.metaKey) && key === 'z') {
         return event.shiftKey ? redo : undo;
@@ -79,7 +78,12 @@ function resolveHistoryCommand(event: KeyboardEvent): EditorCommand | null {
     return null;
 }
 
-function runEditorCommand(view: EditorView, command: EditorCommand): boolean {
+/**
+ * Runs a history command against the main editor, moving focus there when it
+ * applies. Undo/redo rewrites the document out from under the cell selection,
+ * so leaving focus on the (now stale) table widget would strand the caret.
+ */
+function runHistoryCommand(view: EditorView, command: Command): boolean {
     const handled = command(view);
     if (handled) {
         view.focus();
@@ -111,7 +115,7 @@ function runSelectionKeydown(view: EditorView, event: KeyboardEvent): boolean {
 
     const historyCommand = resolveHistoryCommand(event);
     if (historyCommand) {
-        return runEditorCommand(view, historyCommand);
+        return runHistoryCommand(view, historyCommand);
     }
 
     return selectionKeyHandlers.get(event.key)?.(view, event) ?? false;

--- a/src/contentScript/tableRuntime/selection/cellSelectionKeymap.ts
+++ b/src/contentScript/tableRuntime/selection/cellSelectionKeymap.ts
@@ -4,11 +4,13 @@ import { clearCellSelectionEffect, getCellSelection } from '../../tableState/cel
 import { getActiveCell } from '../../tableState/activeCellState';
 import { createActiveCellFromRanges } from '../activeCell/activeCellFactory';
 import { extendExistingCellSelection, startCellSelectionFromActiveCell } from './cellSelectionController';
-import { resolveContainingTableAtPos } from '../tableResolution';
-import { buildTableContext } from '../../tableModel/tableContext';
+import { resolveTableContextAtPos } from '../tableResolution';
 import { canHandleTableSelectionKeydown } from './cellSelectionShortcutScope';
 import { handleSelectionDelete } from './cellSelectionClipboard';
 import { requestOpenCell } from '../openCellRequest';
+
+type EditorCommand = (view: EditorView) => boolean;
+type SelectionKeyHandler = (view: EditorView, event: KeyboardEvent) => boolean;
 
 function extendOrStartSelection(view: EditorView, direction: 'left' | 'right' | 'up' | 'down'): boolean {
     if (getCellSelection(view.state)) {
@@ -37,12 +39,7 @@ function activateSelectionFocus(view: EditorView): boolean {
         return false;
     }
 
-    const table = resolveContainingTableAtPos(view.state, selection.tableFrom);
-    if (!table) {
-        return false;
-    }
-
-    const ctx = buildTableContext(table);
+    const ctx = resolveTableContextAtPos(view.state, selection.tableFrom);
     if (!ctx) {
         return false;
     }
@@ -69,49 +66,55 @@ function activateSelectionFocus(view: EditorView): boolean {
     return true;
 }
 
+function resolveHistoryCommand(event: KeyboardEvent): EditorCommand | null {
+    const key = event.key.toLowerCase();
+    if ((event.ctrlKey || event.metaKey) && key === 'z') {
+        return event.shiftKey ? redo : undo;
+    }
+
+    if (event.ctrlKey && !event.metaKey && key === 'y') {
+        return redo;
+    }
+
+    return null;
+}
+
+function runEditorCommand(view: EditorView, command: EditorCommand): boolean {
+    const handled = command(view);
+    if (handled) {
+        view.focus();
+    }
+
+    return handled;
+}
+
+function handleDeleteKey(view: EditorView, event: KeyboardEvent): boolean {
+    return !event.shiftKey && !event.altKey && !event.ctrlKey && !event.metaKey && handleSelectionDelete(view);
+}
+
+const selectionKeyHandlers: ReadonlyMap<string, SelectionKeyHandler> = new Map([
+    ['Backspace', handleDeleteKey],
+    ['Delete', handleDeleteKey],
+    ['ArrowLeft', (view, event) => event.shiftKey && extendOrStartSelection(view, 'left')],
+    ['ArrowRight', (view, event) => event.shiftKey && extendOrStartSelection(view, 'right')],
+    ['ArrowUp', (view, event) => event.shiftKey && extendOrStartSelection(view, 'up')],
+    ['ArrowDown', (view, event) => event.shiftKey && extendOrStartSelection(view, 'down')],
+    ['Escape', (view) => clearSelectionIfActive(view)],
+    ['Enter', (view, event) => !event.shiftKey && activateSelectionFocus(view)],
+    ['Tab', (view, event) => !event.shiftKey && activateSelectionFocus(view)],
+]);
+
 function runSelectionKeydown(view: EditorView, event: KeyboardEvent): boolean {
     if (!canHandleTableSelectionKeydown(view)) {
         return false;
     }
 
-    const key = event.key.toLowerCase();
-    if ((event.ctrlKey || event.metaKey) && key === 'z') {
-        const command = event.shiftKey ? redo : undo;
-        const handled = command(view);
-        if (handled) {
-            view.focus();
-        }
-        return handled;
+    const historyCommand = resolveHistoryCommand(event);
+    if (historyCommand) {
+        return runEditorCommand(view, historyCommand);
     }
 
-    if (event.ctrlKey && !event.metaKey && key === 'y') {
-        const handled = redo(view);
-        if (handled) {
-            view.focus();
-        }
-        return handled;
-    }
-
-    switch (event.key) {
-        case 'Backspace':
-        case 'Delete':
-            return !event.shiftKey && !event.altKey && !event.ctrlKey && !event.metaKey && handleSelectionDelete(view);
-        case 'ArrowLeft':
-            return event.shiftKey && extendOrStartSelection(view, 'left');
-        case 'ArrowRight':
-            return event.shiftKey && extendOrStartSelection(view, 'right');
-        case 'ArrowUp':
-            return event.shiftKey && extendOrStartSelection(view, 'up');
-        case 'ArrowDown':
-            return event.shiftKey && extendOrStartSelection(view, 'down');
-        case 'Escape':
-            return clearSelectionIfActive(view);
-        case 'Enter':
-        case 'Tab':
-            return !event.shiftKey && activateSelectionFocus(view);
-        default:
-            return false;
-    }
+    return selectionKeyHandlers.get(event.key)?.(view, event) ?? false;
 }
 
 export const cellSelectionKeyCapturePlugin = ViewPlugin.fromClass(


### PR DESCRIPTION
## Summary

- replace the complex cell-selection key switch with typed handler dispatch
- separate undo/redo command resolution and editor refocusing
- reuse the shared table-context resolver when activating the selection focus
- add regression coverage for the key handlers the refactor rewrote

## Why

`runSelectionKeydown` mixed shortcut classification, modifier handling, command
execution, and ordinary key dispatch. Splitting those responsibilities reduces its
cyclomatic complexity while preserving the existing keyboard behavior. Using
`resolveTableContextAtPos` also removes duplicated table-resolution logic.

The dispatch table rewrote every branch of `runSelectionKeydown`, but only Ctrl+Z,
Delete, Backspace and Tab had coverage. The four arrow directions are wired up by
hand, so a transposed entry (`ArrowUp` mapped to `'down'`) passed the entire suite.
The new tests close that gap — that mutation now fails.

## Changes

**Source** (`cellSelectionKeymap.ts`)
- `switch` → `ReadonlyMap<string, SelectionKeyHandler>` dispatch table
- `resolveHistoryCommand` (classification) split from `runHistoryCommand`
  (execution + refocus, now documented as contract rather than incidental)
- `resolveContainingTableAtPos` + `buildTableContext` → the existing
  `resolveTableContextAtPos` wrapper
- reuse `Command` from `@codemirror/view` and `CellSelectionDirection` from
  `cellSelectionState` instead of redeclaring both locally
- `handleActivateKey` (Enter/Tab) and an `arrowKeyHandler` factory, so every
  handler family shares one shape

**Tests** (`cellSelectionKeymap.test.ts`, 8 → 26 tests)
- new coverage: shift+arrow in all four directions, Escape, Enter, Ctrl+Y,
  Ctrl+Shift+Z, and the modifier guards on Delete and Shift+Enter/Tab
- `mountSelectionView` / `pressKey` helpers replace six copies of the same setup
- views destroyed in `afterEach`, so a failed assertion cannot leak the plugin's
  document-level keydown listener into the next test

## Impact

Behavior-preserving internal refactor. Public exports and function signatures are
unchanged, and the behavior-preservation claim is now backed by coverage of every
handler in the dispatch table.

## Note for reviewers

Surfaced while writing the redo tests, pre-existing and not addressed here: after
`runHistoryCommand` refocuses the main editor, `document.activeElement` becomes the
contenteditable, which `canHandleTableSelectionKeydown` treats as interactive — so
the *next* table shortcut is ignored. Undo also clears the cell selection, so the
plugin's early return fires first and the effect is invisible in practice. It is
why the redo tests prime the history stack with `undo(view)` directly rather than
through the keymap.

## Validation

- `npm test` — 59 files, 621 tests passed
- `npm run lint`
- `npm run dist`
- Prettier check and `git diff --check`
