### PR TITLE
refactor: simplify content script message handling

### DIFF
--- a/src/__tests__/contentScriptMessageHandler.test.ts
+++ b/src/__tests__/contentScriptMessageHandler.test.ts
@@ -40,6 +40,37 @@ describe('contentScriptMessageHandler', () => {
         });
     });
 
+    it('normalizes non-object render results to strings', async () => {
+        execute.mockResolvedValueOnce('rendered text');
+
+        await expect(
+            handler({
+                type: 'renderMarkup',
+                markdown: 'Test',
+                id: 'render-2',
+            })
+        ).resolves.toEqual({
+            id: 'render-2',
+            html: 'rendered text',
+        });
+    });
+
+    it('returns the source markdown when rendering fails', async () => {
+        execute.mockRejectedValueOnce(new Error('render failed'));
+
+        await expect(
+            handler({
+                type: 'renderMarkup',
+                markdown: '# Test',
+                id: 'render-3',
+            })
+        ).resolves.toEqual({
+            id: 'render-3',
+            html: '# Test',
+            error: true,
+        });
+    });
+
     it('opens links via Joplin commands', async () => {
         execute.mockResolvedValueOnce(undefined);
 
@@ -50,6 +81,20 @@ describe('contentScriptMessageHandler', () => {
 
         expect(execute).toHaveBeenCalledWith('openItem', 'https://example.com');
         expect(result).toEqual({ success: true });
+    });
+
+    it('returns an error when opening a link fails', async () => {
+        execute.mockRejectedValueOnce(new Error('open failed'));
+
+        await expect(
+            handler({
+                type: 'openLink',
+                href: 'https://example.com',
+            })
+        ).resolves.toEqual({
+            success: false,
+            error: 'Error: open failed',
+        });
     });
 
     it('reads the host editor config', async () => {

--- a/src/contentScript/__tests__/joplinBridge.test.ts
+++ b/src/contentScript/__tests__/joplinBridge.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createJoplinBridge } from '../services/joplinBridge';
+
+describe('createJoplinBridge', () => {
+    describe('openLink', () => {
+        it('resolves when the host reports success', async () => {
+            const postMessage = vi.fn(async () => ({ success: true }));
+            const bridge = createJoplinBridge(postMessage);
+
+            await expect(bridge.openLink('https://example.com')).resolves.toBeUndefined();
+            expect(postMessage).toHaveBeenCalledWith({
+                type: 'openLink',
+                href: 'https://example.com',
+            });
+        });
+
+        it('rejects with the host error when the link cannot be opened', async () => {
+            const postMessage = vi.fn(async () => ({ success: false, error: 'Error: open failed' }));
+            const bridge = createJoplinBridge(postMessage);
+
+            await expect(bridge.openLink('https://example.com')).rejects.toThrow('Error: open failed');
+        });
+
+        it('rejects with a fallback message when the host omits the error', async () => {
+            const postMessage = vi.fn(async () => ({ success: false }));
+            const bridge = createJoplinBridge(postMessage);
+
+            await expect(bridge.openLink('https://example.com')).rejects.toThrow('Unknown error opening link');
+        });
+
+        it('resolves when the host returns no result', async () => {
+            const postMessage = vi.fn(async () => null);
+            const bridge = createJoplinBridge(postMessage);
+
+            await expect(bridge.openLink('https://example.com')).resolves.toBeUndefined();
+        });
+    });
+
+    describe('renderMarkup', () => {
+        it('forwards the markdown and id and returns the host result', async () => {
+            const postMessage = vi.fn(async () => ({ id: 'render-1', html: '<p>ok</p>' }));
+            const bridge = createJoplinBridge(postMessage);
+
+            await expect(bridge.renderMarkup('# Test', 'render-1')).resolves.toEqual({
+                id: 'render-1',
+                html: '<p>ok</p>',
+            });
+            expect(postMessage).toHaveBeenCalledWith({
+                type: 'renderMarkup',
+                markdown: '# Test',
+                id: 'render-1',
+            });
+        });
+    });
+});

--- a/src/contentScript/services/joplinBridge.ts
+++ b/src/contentScript/services/joplinBridge.ts
@@ -1,10 +1,14 @@
 import type {
     OpenLinkMessage,
+    OpenLinkResult,
     RenderMarkupMessage,
     RenderMarkupResult,
 } from '../../contentScriptBridge/contentScriptMessages';
 
 type PostMessageFn = (message: unknown) => Promise<unknown>;
+
+/** Used when the host reports a link failure without describing it. */
+const UNKNOWN_OPEN_LINK_ERROR = 'Unknown error opening link';
 
 export interface JoplinBridge {
     renderMarkup: (markdown: string, id: string) => Promise<RenderMarkupResult | null>;
@@ -29,7 +33,13 @@ export function createJoplinBridge(postMessage: PostMessageFn): JoplinBridge {
                 href,
             };
 
-            await postMessage(message);
+            const result = (await postMessage(message)) as OpenLinkResult | null;
+
+            // The host answers failures with `success: false` rather than rejecting,
+            // so reject here to surface them to the caller's error handling.
+            if (result && !result.success) {
+                throw new Error(result.error ?? UNKNOWN_OPEN_LINK_ERROR);
+            }
         },
     };
 }

--- a/src/contentScriptBridge/contentScriptMessageHandler.ts
+++ b/src/contentScriptBridge/contentScriptMessageHandler.ts
@@ -1,5 +1,11 @@
 import { logger } from '../logger';
-import type { ContentScriptMessage, OpenLinkMessage, RenderMarkupMessage } from './contentScriptMessages';
+import type {
+    ContentScriptMessage,
+    OpenLinkMessage,
+    OpenLinkResult,
+    RenderMarkupMessage,
+    RenderMarkupResult,
+} from './contentScriptMessages';
 import { readHostEditorConfig, type HostEditorConfigDeps } from './hostEditorConfigBridge';
 
 // Joplin's internal MarkupLanguage enum values
@@ -15,11 +21,14 @@ interface ContentScriptMessageHandlerDeps {
     settings: HostEditorConfigDeps['settings'];
 }
 
+/** The subset of handler dependencies needed to invoke Joplin commands. */
+type CommandDeps = Pick<ContentScriptMessageHandlerDeps, 'commands'>;
+
 function isContentScriptMessage(message: unknown): message is ContentScriptMessage {
     return typeof message === 'object' && message !== null && 'type' in message;
 }
 
-async function renderMarkup(message: RenderMarkupMessage, deps: ContentScriptMessageHandlerDeps) {
+async function renderMarkup(message: RenderMarkupMessage, deps: CommandDeps): Promise<RenderMarkupResult> {
     const { markdown, id } = message;
 
     try {
@@ -38,7 +47,7 @@ async function renderMarkup(message: RenderMarkupMessage, deps: ContentScriptMes
     }
 }
 
-async function openLink(message: OpenLinkMessage, deps: ContentScriptMessageHandlerDeps) {
+async function openLink(message: OpenLinkMessage, deps: CommandDeps): Promise<OpenLinkResult> {
     const { href } = message;
 
     try {
@@ -59,9 +68,9 @@ export function createContentScriptMessageHandler(deps: ContentScriptMessageHand
 
         switch (message.type) {
             case 'renderMarkup':
-                return renderMarkup(message as RenderMarkupMessage, deps);
+                return renderMarkup(message, deps);
             case 'openLink':
-                return openLink(message as OpenLinkMessage, deps);
+                return openLink(message, deps);
             case 'getHostEditorConfig':
                 return readHostEditorConfig(deps);
             default:

--- a/src/contentScriptBridge/contentScriptMessageHandler.ts
+++ b/src/contentScriptBridge/contentScriptMessageHandler.ts
@@ -19,6 +19,38 @@ function isContentScriptMessage(message: unknown): message is ContentScriptMessa
     return typeof message === 'object' && message !== null && 'type' in message;
 }
 
+async function renderMarkup(message: RenderMarkupMessage, deps: ContentScriptMessageHandlerDeps) {
+    const { markdown, id } = message;
+
+    try {
+        const result = await deps.commands.execute('renderMarkup', MarkupLanguage.Markdown, markdown, null, {
+            bodyOnly: true,
+        });
+        const html =
+            typeof result === 'object' && result !== null && 'html' in result
+                ? (result as { html: string }).html
+                : String(result);
+        logger.debug('Rendered markup:', { markdown, html });
+        return { id, html };
+    } catch (error) {
+        logger.error('Failed to render markup:', error);
+        return { id, html: markdown, error: true };
+    }
+}
+
+async function openLink(message: OpenLinkMessage, deps: ContentScriptMessageHandlerDeps) {
+    const { href } = message;
+
+    try {
+        await deps.commands.execute('openItem', href);
+        logger.debug('Opened link:', href);
+        return { success: true };
+    } catch (error) {
+        logger.error('Failed to open link:', error);
+        return { success: false, error: String(error) };
+    }
+}
+
 export function createContentScriptMessageHandler(deps: ContentScriptMessageHandlerDeps) {
     return async (message: unknown): Promise<unknown> => {
         if (!isContentScriptMessage(message)) {
@@ -26,38 +58,10 @@ export function createContentScriptMessageHandler(deps: ContentScriptMessageHand
         }
 
         switch (message.type) {
-            case 'renderMarkup': {
-                const { markdown, id } = message as RenderMarkupMessage;
-                try {
-                    const result = await deps.commands.execute(
-                        'renderMarkup',
-                        MarkupLanguage.Markdown,
-                        markdown,
-                        null,
-                        { bodyOnly: true }
-                    );
-                    const html =
-                        typeof result === 'object' && result !== null && 'html' in result
-                            ? (result as { html: string }).html
-                            : String(result);
-                    logger.debug('Rendered markup:', { markdown, html });
-                    return { id, html };
-                } catch (error) {
-                    logger.error('Failed to render markup:', error);
-                    return { id, html: markdown, error: true };
-                }
-            }
-            case 'openLink': {
-                const { href } = message as OpenLinkMessage;
-                try {
-                    await deps.commands.execute('openItem', href);
-                    logger.debug('Opened link:', href);
-                    return { success: true };
-                } catch (error) {
-                    logger.error('Failed to open link:', error);
-                    return { success: false, error: String(error) };
-                }
-            }
+            case 'renderMarkup':
+                return renderMarkup(message as RenderMarkupMessage, deps);
+            case 'openLink':
+                return openLink(message as OpenLinkMessage, deps);
             case 'getHostEditorConfig':
                 return readHostEditorConfig(deps);
             default:

--- a/src/contentScriptBridge/contentScriptMessages.ts
+++ b/src/contentScriptBridge/contentScriptMessages.ts
@@ -17,4 +17,9 @@ export interface OpenLinkMessage {
     href: string;
 }
 
+export interface OpenLinkResult {
+    success: boolean;
+    error?: string;
+}
+
 export type ContentScriptMessage = RenderMarkupMessage | OpenLinkMessage | GetHostEditorConfigMessage;


### PR DESCRIPTION
Simplify the message handling logic in the content script by extracting the rendering and link opening functionalities into separate functions.