### PR TITLE
refactor: table shortcut scope

### DIFF
--- a/src/contentScript/tableRuntime/selection/cellSelectionShortcutScope.ts
+++ b/src/contentScript/tableRuntime/selection/cellSelectionShortcutScope.ts
@@ -82,6 +82,28 @@ function isInsideSelectedTableWidget(view: EditorView, selection: CellSelection,
     return Boolean(selectedWidget?.contains(element));
 }
 
+function canHandleFocusedShortcut(view: EditorView, selection: CellSelection | null, activeElement: Element): boolean {
+    // Nested cell editors belong to this table runtime, even though their editable
+    // content would otherwise be classified as an interactive element.
+    if (isNestedEditorElement(activeElement) && view.dom.contains(activeElement)) {
+        return true;
+    }
+
+    if (isInteractiveElement(activeElement)) {
+        return false;
+    }
+
+    if (!selection) {
+        return false;
+    }
+
+    return (
+        isStructuralFocusHost(view, activeElement) ||
+        isInsideSelectedTableWidget(view, selection, activeElement) ||
+        view.dom.contains(activeElement)
+    );
+}
+
 /**
  * Determines whether document-level capture-phase event listeners should handle
  * a clipboard event (copy/cut/paste) or a keyboard shortcut that applies to both
@@ -90,9 +112,10 @@ function isInsideSelectedTableWidget(view: EditorView, selection: CellSelection,
  */
 export function canHandleTableClipboardShortcut(view: EditorView): boolean {
     const selection = getCellSelection(view.state);
-    const activeCell = getActiveCell(view.state);
+    const hasTableInteraction = Boolean(selection ?? getActiveCell(view.state));
+
     // No table interaction state at all — nothing to handle.
-    if (!selection && !activeCell) {
+    if (!hasTableInteraction) {
         return false;
     }
 
@@ -104,36 +127,7 @@ export function canHandleTableClipboardShortcut(view: EditorView): boolean {
         return Boolean(selection);
     }
 
-    // Focus is inside a nested cell editor within this CM instance — always handle.
-    if (isNestedEditorElement(activeElement) && view.dom.contains(activeElement)) {
-        return true;
-    }
-
-    // Focus is on a genuinely interactive element (toolbar button, dialog, input, etc.).
-    // Yield to that element's own event handling.
-    if (isInteractiveElement(activeElement)) {
-        return false;
-    }
-
-    // Focus is parked on a container rather than a real control — handle if we have
-    // a selection that the user can act on.
-    if (isStructuralFocusHost(view, activeElement)) {
-        return Boolean(selection);
-    }
-
-    if (!selection) {
-        return false;
-    }
-
-    // Focus is on a non-interactive element inside the selected table widget —
-    // handle to keep table shortcuts working while the widget has soft focus.
-    if (isInsideSelectedTableWidget(view, selection, activeElement)) {
-        return true;
-    }
-
-    // Focus is somewhere else inside the CM editor — handle to prevent the event
-    // from reaching unrelated handlers outside the table context.
-    return view.dom.contains(activeElement);
+    return canHandleFocusedShortcut(view, selection, activeElement);
 }
 
 /**

--- a/src/contentScript/tableRuntime/selection/cellSelectionShortcutScope.ts
+++ b/src/contentScript/tableRuntime/selection/cellSelectionShortcutScope.ts
@@ -82,9 +82,28 @@ function isInsideSelectedTableWidget(view: EditorView, selection: CellSelection,
     return Boolean(selectedWidget?.contains(element));
 }
 
-function canHandleFocusedShortcut(view: EditorView, selection: CellSelection | null, activeElement: Element): boolean {
-    // Nested cell editors belong to this table runtime, even though their editable
-    // content would otherwise be classified as an interactive element.
+/**
+ * Classifies whether the table runtime owns an event based on the focused element.
+ *
+ * Branch order is significant:
+ * 1. Nested cell editors belong to this table runtime, even though their editable
+ *    content would otherwise be classified as an interactive element — so they are
+ *    checked before the interactive gate.
+ * 2. Genuinely interactive elements (toolbar buttons, dialogs, inputs) handle their
+ *    own events, so yield to them.
+ * 3. Everything below requires a selection the user can act on:
+ *    - a structural focus host means focus is parked on a container rather than a
+ *      real control;
+ *    - a non-interactive element inside the selected widget keeps table shortcuts
+ *      working while the widget has soft focus;
+ *    - anywhere else inside this CM instance is handled to prevent the event from
+ *      reaching unrelated handlers outside the table context.
+ */
+function canHandleShortcutForFocusedElement(
+    view: EditorView,
+    selection: CellSelection | null,
+    activeElement: Element
+): boolean {
     if (isNestedEditorElement(activeElement) && view.dom.contains(activeElement)) {
         return true;
     }
@@ -127,7 +146,7 @@ export function canHandleTableClipboardShortcut(view: EditorView): boolean {
         return Boolean(selection);
     }
 
-    return canHandleFocusedShortcut(view, selection, activeElement);
+    return canHandleShortcutForFocusedElement(view, selection, activeElement);
 }
 
 /**

--- a/src/contentScript/tableRuntime/selection/cellSelectionShortcutScope.ts
+++ b/src/contentScript/tableRuntime/selection/cellSelectionShortcutScope.ts
@@ -131,10 +131,9 @@ function canHandleShortcutForFocusedElement(
  */
 export function canHandleTableClipboardShortcut(view: EditorView): boolean {
     const selection = getCellSelection(view.state);
-    const hasTableInteraction = Boolean(selection ?? getActiveCell(view.state));
 
     // No table interaction state at all — nothing to handle.
-    if (!hasTableInteraction) {
+    if (!selection && !getActiveCell(view.state)) {
         return false;
     }
 


### PR DESCRIPTION
## Summary

- extract focused-element ownership decisions into a private helper
- simplify `canHandleTableClipboardShortcut` to interaction-state and missing-focus gates
- preserve existing shortcut behavior and public APIs

## Why

`canHandleTableClipboardShortcut` mixed table state, focus availability, nested-editor precedence, interactive controls, and selection ownership in one function. Separating focused-element classification reduces its cyclomatic complexity without changing runtime behavior.

The analyzer's reported duplication with `toolbarLayout.test.ts` is unrelated test scaffolding rather than shared domain logic, so no cross-module abstraction was introduced.

## Impact

No user-facing behavior or public API changes. The shortcut ownership policy is easier to read and maintain.

## Validation

- `npm test` — 60 test files and 629 tests passed
- `npm run lint -- --no-cache` — passed
- `npm run dist` — passed
- `git diff --check` — passed
