### PR TITLE
refactor: decompose table decoration policy

### DIFF
--- a/src/contentScript/__tests__/tableRuntimePolicies.test.ts
+++ b/src/contentScript/__tests__/tableRuntimePolicies.test.ts
@@ -310,6 +310,28 @@ describe('tableRuntimePolicies', () => {
         expect(decideTableDecorationUpdate(tr)).toEqual({ type: 'noneDecorations' });
     });
 
+    it('prefers the full document replace decision over a rebuild effect in the same transaction', () => {
+        const activeCell = getHeaderCell();
+        const state = createState({ activeCell });
+        const tr = state.update({
+            changes: { from: 0, to: doc.length, insert: '# replaced' },
+            effects: rebuildTableWidgetsEffect.of(undefined),
+        });
+
+        expect(decideTableDecorationUpdate(tr)).toEqual({ type: 'noneDecorations' });
+    });
+
+    it('keeps decorations for sync transactions that do not change the document', () => {
+        const activeCell = getHeaderCell();
+        const state = createState({ activeCell });
+        const tr = state.update({
+            selection: { anchor: 0 },
+            annotations: syncAnnotation.of(true),
+        });
+
+        expect(decideTableDecorationUpdate(tr)).toEqual({ type: 'keepDecorations' });
+    });
+
     it('allows sync transactions through the guard untouched', () => {
         const activeCell = getHeaderCell();
         const state = createState({ activeCell });

--- a/src/contentScript/tableWidget/tableDecorationPolicy.ts
+++ b/src/contentScript/tableWidget/tableDecorationPolicy.ts
@@ -87,7 +87,7 @@ function decideDocumentEditDecoration(tr: Transaction): DecorationDecision {
  * Decides how the table decoration field reacts to a transaction.
  * The order of the checks below is significant: earlier decisions deliberately
  * win over later ones (a full document replace, for example, outranks a
- * pending rebuild effect in the same transaction).
+ * rebuildTableWidgetsEffect in the same transaction).
  */
 export function decideTableDecorationUpdate(tr: Transaction): DecorationDecision {
     return (

--- a/src/contentScript/tableWidget/tableDecorationPolicy.ts
+++ b/src/contentScript/tableWidget/tableDecorationPolicy.ts
@@ -1,4 +1,4 @@
-import { Transaction } from '@codemirror/state';
+import { Transaction, type StateEffectType } from '@codemirror/state';
 import { clearActiveCellEffect, getActiveCell } from '../tableState/activeCellState';
 import { isEffectiveRawMode, toggleSourceModeEffect } from '../tableState/sourceMode';
 import { setSearchForceSourceModeEffect } from '../tableState/searchForceSourceMode';
@@ -15,43 +15,58 @@ export type DecorationDecision =
     | { type: 'mapDecorations' }
     | { type: 'rebuildAllDecorations' };
 
-export function decideTableDecorationUpdate(tr: Transaction): DecorationDecision {
-    const rawModeToggled = tr.effects.some(
-        (effect) => effect.is(toggleSourceModeEffect) || effect.is(setSearchForceSourceModeEffect)
-    );
+function hasEffect<T>(tr: Transaction, effectType: StateEffectType<T>): boolean {
+    return tr.effects.some((effect) => effect.is(effectType));
+}
+
+/**
+ * Raw mode replaces every table widget with plain markdown, so a toggle rebuilds
+ * everything on the way out and drops all decorations on the way in.
+ */
+function decideRawModeDecoration(tr: Transaction): DecorationDecision | null {
     const effectiveRawMode = isEffectiveRawMode(tr.state);
 
-    if (rawModeToggled) {
+    if (hasEffect(tr, toggleSourceModeEffect) || hasEffect(tr, setSearchForceSourceModeEffect)) {
         return effectiveRawMode ? { type: 'noneDecorations' } : { type: 'rebuildAllDecorations' };
     }
 
-    if (effectiveRawMode) {
-        return { type: 'noneDecorations' };
+    return effectiveRawMode ? { type: 'noneDecorations' } : null;
+}
+
+/**
+ * Changes forwarded from the nested editor only move text inside a cell, so the
+ * existing widgets are still valid and just need remapping.
+ */
+function decideSyncDecoration(tr: Transaction): DecorationDecision | null {
+    if (!tr.annotation(syncAnnotation)) {
+        return null;
     }
 
-    if (tr.annotation(syncAnnotation)) {
-        return tr.docChanged ? { type: 'mapDecorations' } : { type: 'keepDecorations' };
-    }
+    return tr.docChanged ? { type: 'mapDecorations' } : { type: 'keepDecorations' };
+}
 
-    if (tr.effects.some((effect) => effect.is(rebuildAllTableWidgetsEffect))) {
+function decideRebuildRequestDecoration(tr: Transaction): DecorationDecision | null {
+    if (hasEffect(tr, rebuildAllTableWidgetsEffect) || tr.annotation(normalizeBeforeEditAnnotation)) {
         return { type: 'rebuildAllDecorations' };
     }
 
-    if (tr.annotation(normalizeBeforeEditAnnotation)) {
-        return { type: 'rebuildAllDecorations' };
+    return null;
+}
+
+/**
+ * A full replace while a cell is active (e.g. external sync) invalidates the
+ * active cell; decorations are dropped and rebuilt once the lifecycle settles.
+ */
+function decideFullDocumentReplaceDecoration(tr: Transaction): DecorationDecision | null {
+    if (!tr.docChanged || !getActiveCell(tr.startState) || !isFullDocumentReplace(tr)) {
+        return null;
     }
 
-    const prevActiveCell = getActiveCell(tr.startState);
-    const resolvedPrevActiveCell = getResolvedActiveCell(tr.startState);
-    if (tr.docChanged && prevActiveCell && isFullDocumentReplace(tr)) {
-        return { type: 'noneDecorations' };
-    }
+    return { type: 'noneDecorations' };
+}
 
-    if (tr.effects.some((effect) => effect.is(clearActiveCellEffect))) {
-        return { type: 'rebuildAllDecorations' };
-    }
-
-    if (tr.effects.some((effect) => effect.is(rebuildTableWidgetsEffect))) {
+function decideDocumentEditDecoration(tr: Transaction): DecorationDecision {
+    if (hasEffect(tr, clearActiveCellEffect) || hasEffect(tr, rebuildTableWidgetsEffect)) {
         return { type: 'rebuildAllDecorations' };
     }
 
@@ -59,12 +74,27 @@ export function decideTableDecorationUpdate(tr: Transaction): DecorationDecision
         return { type: 'keepDecorations' };
     }
 
-    const activeCell = getActiveCell(tr.state);
-    if (!activeCell) {
+    if (!getActiveCell(tr.state)) {
         return { type: 'rebuildAllDecorations' };
     }
 
-    return transactionRequiresTableRebuild(tr, resolvedPrevActiveCell)
+    return transactionRequiresTableRebuild(tr, getResolvedActiveCell(tr.startState))
         ? { type: 'rebuildAllDecorations' }
         : { type: 'mapDecorations' };
+}
+
+/**
+ * Decides how the table decoration field reacts to a transaction.
+ * The order of the checks below is significant: earlier decisions deliberately
+ * win over later ones (a full document replace, for example, outranks a
+ * pending rebuild effect in the same transaction).
+ */
+export function decideTableDecorationUpdate(tr: Transaction): DecorationDecision {
+    return (
+        decideRawModeDecoration(tr) ??
+        decideSyncDecoration(tr) ??
+        decideRebuildRequestDecoration(tr) ??
+        decideFullDocumentReplaceDecoration(tr) ??
+        decideDocumentEditDecoration(tr)
+    );
 }


### PR DESCRIPTION
## Summary

`decideTableDecorationUpdate` was a single 52-line guard ladder with cyclomatic complexity 17. This splits it into ordered decision helpers that each return `DecorationDecision | null`, matching the idiom already used in `mainEditorGuardPolicy.ts`, and reduces the entry point to a `??` chain.

```
- decideTableDecorationUpdate(tr)                  // cc 17, 52 lines
+ hasEffect<T>(tr, effectType)                     // cc 2
+ decideRawModeDecoration(tr)                      // cc 5
+ decideSyncDecoration(tr)                         // cc 3
+ decideRebuildRequestDecoration(tr)               // cc 3
+ decideFullDocumentReplaceDecoration(tr)          // cc 4
+ decideDocumentEditDecoration(tr)                 // cc 6
+ decideTableDecorationUpdate(tr)                  // cc 5, `??` chain
```

No behavior change, no public signature or export changes.

## Notes for review

- **Check order is load-bearing.** A full document replace must outrank a `rebuildTableWidgetsEffect` dispatched in the same transaction, so the `??` chain preserves the original top-to-bottom sequence exactly. That constraint was previously implicit in the ladder; it's now documented on the exported function.
- `some(e => A(e) || B(e))` became `hasEffect(A) || hasEffect(B)` — equivalent for pure predicates.
- `getResolvedActiveCell(tr.startState)` is now called only in the branch that uses it rather than eagerly. Strictly fewer calls to a pure field read.

## Tests

Two tests added to `tableRuntimePolicies.test.ts` pinning the ordering facts the refactor made explicit — neither was covered before, and both would catch a reordering mistake:

- full-replace beats a co-dispatched `rebuildTableWidgetsEffect`
- a sync transaction with no document change yields `keepDecorations`

`npm test` 631 passed, `npm run lint` clean, no new `src/` type errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)