### PR TITLE
refactor: reduce complexity in openCellRequestField update

### DIFF
--- a/src/contentScript/__tests__/openCellRequest.test.ts
+++ b/src/contentScript/__tests__/openCellRequest.test.ts
@@ -96,6 +96,22 @@ describe('openCellRequestField', () => {
         expect(getPendingOpenCellRequest(mapped)?.activeCell.tableFrom).toBe('prefix\n'.length);
     });
 
+    it('does not remap a request that begins in the same transaction as its document change', () => {
+        // Structural mutations dispatch the change and the begin effect together, with the
+        // active cell already expressed in post-change coordinates.
+        const state = createState().update({
+            changes: { from: 0, to: 0, insert: 'prefix\n' },
+            effects: beginOpenCellRequestEffect.of({
+                requestId: 'request-1',
+                activeCell,
+                normalizeIfNeeded: true,
+                suppressKeys: true,
+            }),
+        }).state;
+
+        expect(getPendingOpenCellRequest(state)?.activeCell.tableFrom).toBe(0);
+    });
+
     it('clears the request when the table start is deleted', () => {
         const state = beginRequest(createState());
 

--- a/src/contentScript/tableRuntime/openCellRequest.ts
+++ b/src/contentScript/tableRuntime/openCellRequest.ts
@@ -139,33 +139,55 @@ export function requestOpenCell(view: EditorView, params: RequestOpenCellParams)
     });
 }
 
+/** A clear only applies to the request it names, so a stale clear cannot cancel a newer request. */
+function clearsRequest(effect: StateEffect<unknown>, request: OpenCellRequest | null): boolean {
+    return request !== null && effect.is(clearOpenCellRequestEffect) && effect.value.requestId === request.requestId;
+}
+
+/**
+ * Folds a transaction's effects into the pending request. `replaced` reports whether a begin
+ * effect supplied the value, which the caller needs in order to decide about remapping.
+ */
+function applyOpenCellRequestEffects(
+    value: OpenCellRequest | null,
+    effects: readonly StateEffect<unknown>[]
+): { value: OpenCellRequest | null; replaced: boolean } {
+    let nextValue = value;
+    let replaced = false;
+
+    for (const effect of effects) {
+        if (effect.is(beginOpenCellRequestEffect)) {
+            nextValue = effect.value;
+            replaced = true;
+        } else if (clearsRequest(effect, nextValue)) {
+            nextValue = null;
+        }
+    }
+
+    return { value: nextValue, replaced };
+}
+
+/** Carries a request across a document change, dropping it when its anchor is no longer salvageable. */
+function remapOpenCellRequest(request: OpenCellRequest, changes: ChangeDesc): OpenCellRequest | null {
+    const activeCell = mapActiveCell(request.activeCell, changes);
+    return activeCell ? { ...request, activeCell } : null;
+}
+
 export const openCellRequestField = StateField.define<OpenCellRequest | null>({
     create() {
         return null;
     },
 
     update(value, tr) {
-        let nextValue = value;
-        let sawBegin = false;
+        const { value: nextValue, replaced } = applyOpenCellRequestEffects(value, tr.effects);
 
-        for (const effect of tr.effects) {
-            if (effect.is(beginOpenCellRequestEffect)) {
-                nextValue = effect.value;
-                sawBegin = true;
-                continue;
-            }
-
-            if (nextValue && effect.is(clearOpenCellRequestEffect) && effect.value.requestId === nextValue.requestId) {
-                nextValue = null;
-            }
+        // A begin effect dispatched alongside its own document change already carries
+        // post-change coordinates, so remapping it would shift the anchor a second time.
+        if (!nextValue || replaced || !tr.docChanged) {
+            return nextValue;
         }
 
-        if (tr.docChanged && nextValue && !sawBegin) {
-            const activeCell = mapActiveCell(nextValue.activeCell, tr.changes);
-            return activeCell ? { ...nextValue, activeCell } : null;
-        }
-
-        return nextValue;
+        return remapOpenCellRequest(nextValue, tr.changes);
     },
 });
 


### PR DESCRIPTION
## Summary

`openCellRequestField.update` carried every decision inline — the effect scan, the stale-clear guard, and the post-change remap — for a cyclomatic complexity of 10. This splits it into three focused helpers so `update` reads as a guard clause plus one delegated call.

- `clearsRequest(effect, request)` — the three-term stale-clear predicate
- `applyOpenCellRequestEffects(value, effects)` — folds a transaction's effects into the pending request, reporting whether a begin effect supplied the value
- `remapOpenCellRequest(request, changes)` — carries a request across a document change

`update` goes from CC 10 to 4; no extracted helper exceeds 3.

## Behavior

Unchanged. The one non-mechanical edit is swapping `continue` for `else if` in the effect loop — safe because a single effect cannot be both a begin and a clear, and a clear appearing *after* a begin in the same transaction still cancels it, exactly as before.

## Test coverage

Adds a regression test for the guard that skips remapping when a begin effect arrives in the same transaction as its own document change. `runStructuralMutation` depends on this: it dispatches the change and the begin together with the active cell already in post-change coordinates, so remapping would shift the anchor twice. That branch had no coverage. Verified the test fails when the guard is removed (`tableFrom` becomes 7 instead of 0), so it pins real behavior rather than restating the implementation.

Full suite passes (632 tests), lint clean.

## Notes

The static analyzer also flagged this file for "prior defects" (2 bug-fix commits in ~6 months). That's a history signal, not a structural one — no refactor retires it, it only ages out. Left alone deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)