### PR TITLE
refactor: decompose main editor guard policy

### DIFF
--- a/src/contentScript/__tests__/tableRuntimePolicies.test.ts
+++ b/src/contentScript/__tests__/tableRuntimePolicies.test.ts
@@ -358,6 +358,46 @@ describe('tableRuntimePolicies', () => {
         });
     });
 
+    it('clears the active cell on a full document replace', () => {
+        const state = createState({ activeCell: getHeaderCell() });
+        const tr = state.update({
+            changes: { from: 0, to: doc.length, insert: '# replaced' },
+            selection: { anchor: 3 },
+        });
+
+        const decision = decideMainEditorGuardTransaction(tr, { nestedEditorOpen: true });
+
+        expect(decision.type).toBe('clearActiveCell');
+        if (decision.type !== 'clearActiveCell') {
+            throw new Error('Expected clear active cell decision');
+        }
+
+        expect(decision.selection?.main.head).toBe(3);
+    });
+
+    it('allows a full document replace through when no active cell is set', () => {
+        const state = createState();
+        const tr = state.update({
+            changes: { from: 0, to: doc.length, insert: '# replaced' },
+        });
+
+        expect(decideMainEditorGuardTransaction(tr, { nestedEditorOpen: true })).toEqual({
+            type: 'allowTransaction',
+        });
+    });
+
+    it('clears an active cell that no longer resolves against the document', () => {
+        const state = createState({ activeCell: { tableFrom: 0, section: 'body', row: 9, col: 0 } });
+        const tr = state.update({
+            changes: { from: 0, to: 1, insert: '' },
+        });
+
+        expect(decideMainEditorGuardTransaction(tr, { nestedEditorOpen: true })).toEqual({
+            type: 'clearActiveCell',
+            selection: undefined,
+        });
+    });
+
     it('allows guard changes inside editable edge whitespace', () => {
         const paddedDoc = ['| H1  | H2 |', '| --- | --- |', '| a1 | a2 |'].join('\n');
         let state = createMarkdownState(paddedDoc, [

--- a/src/contentScript/editorBridge/mainEditorGuardPolicy.ts
+++ b/src/contentScript/editorBridge/mainEditorGuardPolicy.ts
@@ -4,7 +4,7 @@ import { getCellSelection } from '../tableState/cellSelectionState';
 import { rebuildTableWidgetsEffect } from '../tableState/tableWidgetEffects';
 import { sanitizeCellChanges } from './cellTextCodec';
 import { syncAnnotation } from './syncAnnotation';
-import { getResolvedActiveCell } from '../tableRuntime/activeCell/resolvedActiveCell';
+import { getResolvedActiveCell, type ResolvedActiveCell } from '../tableRuntime/activeCell/resolvedActiveCell';
 import { isFullDocumentReplace } from '../shared/transactionUtils';
 import { normalizeBeforeEditAnnotation } from '../tableRuntime/lifecycle/tableNormalization';
 import {
@@ -113,51 +113,31 @@ function changesOverlapRange(tr: Transaction, from: number, to: number): boolean
     return overlaps;
 }
 
-export function decideMainEditorGuardTransaction(
-    tr: Transaction,
-    params: { nestedEditorOpen: boolean }
-): GuardDecision {
-    if (!tr.docChanged) {
-        return { type: 'allowTransaction' };
+function clearActiveCellDecision(tr: Transaction): GuardDecision {
+    return { type: 'clearActiveCell', selection: tr.selection ?? undefined };
+}
+
+/**
+ * Transactions the guard never inspects: they either carry no document change or are
+ * already produced by the plugin itself (nested editor sync, normalize-before-edit).
+ */
+function isGuardBypassTransaction(tr: Transaction): boolean {
+    return (
+        !tr.docChanged ||
+        Boolean(tr.annotation(syncAnnotation)) ||
+        Boolean(tr.annotation(normalizeBeforeEditAnnotation))
+    );
+}
+
+function decideFullDocumentReplace(tr: Transaction): GuardDecision | null {
+    if (!isFullDocumentReplace(tr)) {
+        return null;
     }
 
-    if (tr.annotation(syncAnnotation)) {
-        return { type: 'allowTransaction' };
-    }
+    return getActiveCell(tr.startState) ? clearActiveCellDecision(tr) : { type: 'allowTransaction' };
+}
 
-    if (tr.annotation(normalizeBeforeEditAnnotation)) {
-        return { type: 'allowTransaction' };
-    }
-
-    const pasteDecision = decidePasteTransaction(tr, params.nestedEditorOpen);
-    if (pasteDecision) {
-        return pasteDecision;
-    }
-
-    const activeCell = getActiveCell(tr.startState);
-    const resolvedActiveCell = getResolvedActiveCell(tr.startState);
-    if (isFullDocumentReplace(tr)) {
-        return activeCell
-            ? { type: 'clearActiveCell', selection: tr.selection ?? undefined }
-            : { type: 'allowTransaction' };
-    }
-
-    if (!params.nestedEditorOpen || !activeCell) {
-        return { type: 'allowTransaction' };
-    }
-
-    if (!resolvedActiveCell) {
-        return { type: 'clearActiveCell', selection: tr.selection ?? undefined };
-    }
-
-    if (tr.effects.some((effect) => effect.is(rebuildTableWidgetsEffect))) {
-        return { type: 'allowTransaction' };
-    }
-
-    if (!changesOverlapRange(tr, resolvedActiveCell.tableFrom, resolvedActiveCell.tableTo)) {
-        return { type: 'allowTransaction' };
-    }
-
+function decideCellSanitization(tr: Transaction, resolvedActiveCell: ResolvedActiveCell): GuardDecision {
     const sanitized = sanitizeCellChanges(tr, resolvedActiveCell.editableFrom, resolvedActiveCell.editableTo);
     if (sanitized.rejected) {
         return { type: 'rejectTransaction' };
@@ -178,4 +158,47 @@ export function decideMainEditorGuardTransaction(
         changes: sanitized.changes,
         selection,
     };
+}
+
+/** Decides how to treat a main-editor edit while a nested cell editor holds an active cell. */
+function decideActiveCellEdit(tr: Transaction): GuardDecision {
+    const resolvedActiveCell = getResolvedActiveCell(tr.startState);
+    if (!resolvedActiveCell) {
+        return clearActiveCellDecision(tr);
+    }
+
+    if (tr.effects.some((effect) => effect.is(rebuildTableWidgetsEffect))) {
+        return { type: 'allowTransaction' };
+    }
+
+    if (!changesOverlapRange(tr, resolvedActiveCell.tableFrom, resolvedActiveCell.tableTo)) {
+        return { type: 'allowTransaction' };
+    }
+
+    return decideCellSanitization(tr, resolvedActiveCell);
+}
+
+export function decideMainEditorGuardTransaction(
+    tr: Transaction,
+    params: { nestedEditorOpen: boolean }
+): GuardDecision {
+    if (isGuardBypassTransaction(tr)) {
+        return { type: 'allowTransaction' };
+    }
+
+    const pasteDecision = decidePasteTransaction(tr, params.nestedEditorOpen);
+    if (pasteDecision) {
+        return pasteDecision;
+    }
+
+    const fullReplaceDecision = decideFullDocumentReplace(tr);
+    if (fullReplaceDecision) {
+        return fullReplaceDecision;
+    }
+
+    if (!params.nestedEditorOpen || !getActiveCell(tr.startState)) {
+        return { type: 'allowTransaction' };
+    }
+
+    return decideActiveCellEdit(tr);
 }


### PR DESCRIPTION
## Summary

`decideMainEditorGuardTransaction` was a flat ladder of eight sequential guards (cyclomatic complexity 14) mixing three unrelated concerns: transactions the guard never inspects, paste/full-replace dispatch, and the active-cell sanitization path. This splits it into single-axis helpers, leaving the exported function as a four-step dispatcher.

New private helpers in `mainEditorGuardPolicy.ts`:

- `isGuardBypassTransaction` — the three "never inspect" checks (no doc change / sync-forwarded / normalize-before-edit)
- `decideFullDocumentReplace` — returns `null` when not applicable, matching the `decidePasteTransaction` convention already used in this file
- `decideActiveCellEdit` — the resolved-cell branch (unresolved → clear, rebuild effect, table-range overlap)
- `decideCellSanitization` — the sanitize + `ChangeSet` + selection-mapping tail
- `clearActiveCellDecision` — the `clearActiveCell` literal, which now has two call sites

No exported names or signatures changed. The only other source change is adding `ResolvedActiveCell` as a `type` import.

## Behavior preservation

The one non-textual move: `getActiveCell` / `getResolvedActiveCell` were hoisted above the full-replace check in the original and are now called inside their respective branches. Both are pure state-field reads (`resolvedActiveCell.ts:120`), so the reordering is unobservable.

## Tests

The two `clearActiveCell` guard branches had no coverage before, and this refactor routes both through one new shared helper — so they're now pinned with three cases: full document replace with an active cell (asserts the selection carries through), full document replace without one, and an active cell that no longer resolves against the document.

All 45 tests in `tableRuntimePolicies.test.ts` were verified to pass against the **pre-refactor** implementation as well, confirming they characterize existing behavior rather than the refactor.

## Verification

- `npm test` — 635/635 pass across 60 files
- `npm run lint` — clean
- `npx prettier --check` — clean
- `npm run dist` — builds

## Note on the DRY finding

The static analyzer also flagged a "12-line clone" shared with `tableWidget/tableWidgetExtension.ts`. I skipped it as a false positive: the only lines the two files share are `import {`, `return {`, `};`, and `}` (verified with `grep -Fxf`). `tableWidgetExtension.ts` is a flat extension-registration list with no decision logic — there is no shared concept to consolidate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
