### PR TITLE
refactor: decompose host editor config type guard

### DIFF
--- a/src/__tests__/hostEditorConfigBridge.test.ts
+++ b/src/__tests__/hostEditorConfigBridge.test.ts
@@ -4,6 +4,7 @@ import {
     AUTO_MATCHING_BRACES_SETTING_KEY,
     SPELLCHECK_ENABLED_SETTING_KEY,
     defaultHostEditorConfig,
+    isHostEditorConfig,
     readHostEditorConfig,
     TOOLBAR_SHOW_ALIGNMENT_BUTTONS_SETTING_KEY,
     TOOLBAR_SHOW_CLEAR_BUTTONS_SETTING_KEY,
@@ -119,6 +120,61 @@ describe('hostEditorConfigBridge', () => {
                 spellcheck: true,
             },
             toolbar: defaultHostEditorConfig().toolbar,
+        });
+    });
+
+    describe('isHostEditorConfig', () => {
+        it('accepts a fully populated config', () => {
+            expect(isHostEditorConfig(defaultHostEditorConfig())).toBe(true);
+        });
+
+        it('accepts a config carrying unknown extra keys', () => {
+            const config = defaultHostEditorConfig();
+
+            expect(isHostEditorConfig({ ...config, unexpected: 'value' })).toBe(true);
+        });
+
+        it.each([
+            ['null', null],
+            ['undefined', undefined],
+            ['a primitive', 'config'],
+            ['an empty object', {}],
+        ])('rejects %s', (_label, value) => {
+            expect(isHostEditorConfig(value)).toBe(false);
+        });
+
+        it('rejects a config missing a section', () => {
+            const { nestedEditor } = defaultHostEditorConfig();
+
+            expect(isHostEditorConfig({ nestedEditor })).toBe(false);
+        });
+
+        it('rejects a config whose section is null', () => {
+            const config = defaultHostEditorConfig();
+
+            expect(isHostEditorConfig({ ...config, toolbar: null })).toBe(false);
+        });
+
+        it('rejects a config missing a nested editor field', () => {
+            const config = defaultHostEditorConfig();
+
+            expect(
+                isHostEditorConfig({
+                    ...config,
+                    nestedEditor: { autoMatchingBraces: true },
+                })
+            ).toBe(false);
+        });
+
+        it('rejects a config with a non-boolean toolbar field', () => {
+            const config = defaultHostEditorConfig();
+
+            expect(
+                isHostEditorConfig({
+                    ...config,
+                    toolbar: { ...config.toolbar, showMoveButtons: 'true' },
+                })
+            ).toBe(false);
         });
     });
 });

--- a/src/contentScriptBridge/hostEditorConfigBridge.ts
+++ b/src/contentScriptBridge/hostEditorConfigBridge.ts
@@ -49,26 +49,36 @@ export function defaultHostEditorConfig(): HostEditorConfig {
     };
 }
 
+/**
+ * Checks that `value` is a non-null object carrying a boolean under every key of `shape`.
+ * Extra keys are ignored, matching the tolerant validation the bridge has always applied.
+ */
+function isBooleanShape(value: unknown, shape: Record<string, boolean>): boolean {
+    if (typeof value !== 'object' || value === null) {
+        return false;
+    }
+
+    const candidate = value as Record<string, unknown>;
+
+    return Object.keys(shape).every((key) => typeof candidate[key] === 'boolean');
+}
+
+/**
+ * The expected keys are derived from {@link defaultHostEditorConfig} so the guard stays exhaustive:
+ * adding a field to `HostEditorConfig` forces a matching default, which this check then picks up.
+ * A future non-boolean field is a compile error here rather than a silently unvalidated field.
+ */
 export function isHostEditorConfig(value: unknown): value is HostEditorConfig {
     if (typeof value !== 'object' || value === null) {
         return false;
     }
 
     const candidate = value as Partial<HostEditorConfig>;
-    const nestedEditor = candidate.nestedEditor;
-    const toolbar = candidate.toolbar;
+    const defaults = defaultHostEditorConfig();
 
     return (
-        typeof nestedEditor === 'object' &&
-        nestedEditor !== null &&
-        typeof nestedEditor.autoMatchingBraces === 'boolean' &&
-        typeof nestedEditor.spellcheck === 'boolean' &&
-        typeof toolbar === 'object' &&
-        toolbar !== null &&
-        typeof toolbar.showMoveButtons === 'boolean' &&
-        typeof toolbar.showClearButtons === 'boolean' &&
-        typeof toolbar.showAlignmentButtons === 'boolean' &&
-        typeof toolbar.showDeleteTableButton === 'boolean'
+        isBooleanShape(candidate.nestedEditor, defaults.nestedEditor) &&
+        isBooleanShape(candidate.toolbar, defaults.toolbar)
     );
 }
 


### PR DESCRIPTION
## Summary

`isHostEditorConfig` validated all six config fields through one 11-term boolean chain (cyclomatic complexity 12, flagged by static analysis at −0.85 health impact on the file).

The complexity number was borderline on its own — the chain was linear and readable, and it reflected field *count* rather than tangled control flow. What made the refactor worthwhile is that field names were written in **three** places (the `HostEditorConfig` interface, `defaultHostEditorConfig`, and the guard) with nothing keeping them in sync. A newly added toolbar flag would have been silently unvalidated.

## Changes

- Extract `isBooleanShape(value, shape)` — does the object/null check plus an `every` over the shape's keys. Collapses six per-field `typeof` branches and two per-section null checks into one loop.
- Derive the expected keys from `defaultHostEditorConfig()` instead of a parallel key list. The defaults factory is already compiler-enforced to be exhaustive, so the guard becomes exhaustive for free. The `Record<string, boolean>` parameter also turns a future non-boolean config field into a compile error here rather than an unchecked field.
- Add a direct `isHostEditorConfig` describe block (9 cases). The guard previously had **zero** direct tests — its only coverage was one incidental `{ invalid: true }` assertion in `hostEditorConfig.test.ts`.

`isHostEditorConfig` drops from 12 independent paths to 4; `isBooleanShape` sits at ~4.

## Behavior

Unchanged. Extra keys still accepted; arrays still pass (`typeof [] === 'object'`, pre-existing); missing, null, or non-boolean sections and fields still rejected. No signature or exported-name changes — `isBooleanShape` is module-private.

## Verification

- Full suite: 645 passed / 60 files
- `npm run lint` clean, `prettier --check` clean
- `npm run dist` builds (confirms typecheck)

🤖 Generated with [Claude Code](https://claude.com/claude-code)