### PR TITLE
refactor: one parser for table cell coordinates

### DIFF
--- a/src/contentScript/__tests__/domHelpers.test.ts
+++ b/src/contentScript/__tests__/domHelpers.test.ts
@@ -1,0 +1,54 @@
+/** @vitest-environment jsdom */
+
+import { describe, expect, it } from 'vitest';
+import {
+    DATA_COL,
+    DATA_ROW,
+    DATA_SECTION,
+    SECTION_BODY,
+    SECTION_HEADER,
+    readCellCoords,
+} from '../tableWidget/domHelpers';
+
+function createCell(attributes: Partial<Record<string, string>>): HTMLElement {
+    const cell = document.createElement('td');
+    for (const [key, value] of Object.entries(attributes)) {
+        if (value !== undefined) {
+            cell.dataset[key] = value;
+        }
+    }
+    return cell;
+}
+
+describe('readCellCoords', () => {
+    it('reads coordinates from a body cell', () => {
+        const cell = createCell({ [DATA_SECTION]: SECTION_BODY, [DATA_ROW]: '2', [DATA_COL]: '3' });
+
+        expect(readCellCoords(cell)).toEqual({ section: SECTION_BODY, row: 2, col: 3 });
+    });
+
+    it('pins the header row index to 0', () => {
+        // The header is a single row, so a stale non-zero data-row must not leak through.
+        const cell = createCell({ [DATA_SECTION]: SECTION_HEADER, [DATA_ROW]: '4', [DATA_COL]: '1' });
+
+        expect(readCellCoords(cell)).toEqual({ section: SECTION_HEADER, row: 0, col: 1 });
+    });
+
+    it('rejects a section the table widget never writes', () => {
+        const cell = createCell({ [DATA_SECTION]: 'footer', [DATA_ROW]: '0', [DATA_COL]: '0' });
+
+        expect(readCellCoords(cell)).toBeNull();
+    });
+
+    it('rejects a cell with no data attributes, such as a table nested inside a cell', () => {
+        expect(readCellCoords(createCell({}))).toBeNull();
+    });
+
+    it('rejects unparseable row and column values', () => {
+        const badRow = createCell({ [DATA_SECTION]: SECTION_BODY, [DATA_ROW]: 'x', [DATA_COL]: '0' });
+        const badCol = createCell({ [DATA_SECTION]: SECTION_BODY, [DATA_ROW]: '0', [DATA_COL]: 'x' });
+
+        expect(readCellCoords(badRow)).toBeNull();
+        expect(readCellCoords(badCol)).toBeNull();
+    });
+});

--- a/src/contentScript/tableWidget/cellSelectionVisuals.ts
+++ b/src/contentScript/tableWidget/cellSelectionVisuals.ts
@@ -1,38 +1,7 @@
 import { EditorView, ViewPlugin, type ViewUpdate } from '@codemirror/view';
 import { getCellSelection, isCellInRect, toSelectionRect } from '../tableState/cellSelectionState';
-import {
-    CLASS_CELL_SELECTED,
-    DATA_COL,
-    DATA_ROW,
-    DATA_SECTION,
-    SECTION_BODY,
-    SECTION_HEADER,
-    findTableWidgetElement,
-} from './domHelpers';
-import { makeTableId, type CellCoords, type TableSection } from '../tableModel/types';
-
-/** Narrows a raw `data-section` value to a known table section. */
-function isTableSection(value: string | undefined): value is TableSection {
-    return value === SECTION_HEADER || value === SECTION_BODY;
-}
-
-/** Parses a raw `data-row`/`data-col` value, returning null when it is not a number. */
-function readIndex(value: string | undefined): number | null {
-    const index = Number(value);
-    return Number.isNaN(index) ? null : index;
-}
-
-function readCoords(cell: HTMLElement): CellCoords | null {
-    const section = cell.dataset[DATA_SECTION];
-    const row = readIndex(cell.dataset[DATA_ROW]);
-    const col = readIndex(cell.dataset[DATA_COL]);
-
-    if (!isTableSection(section) || row === null || col === null) {
-        return null;
-    }
-
-    return { section, row, col };
-}
+import { CLASS_CELL_SELECTED, findTableWidgetElement, readCellCoords } from './domHelpers';
+import { makeTableId } from '../tableModel/types';
 
 function collectSelectedCells(view: EditorView): HTMLElement[] {
     const selection = getCellSelection(view.state);
@@ -52,7 +21,7 @@ function collectSelectedCells(view: EditorView): HTMLElement[] {
     const selectedCells: HTMLElement[] = [];
 
     for (const cell of cells) {
-        const coords = readCoords(cell);
+        const coords = readCellCoords(cell);
         if (!coords || !isCellInRect(rect, coords)) {
             continue;
         }

--- a/src/contentScript/tableWidget/cellSelectionVisuals.ts
+++ b/src/contentScript/tableWidget/cellSelectionVisuals.ts
@@ -1,14 +1,33 @@
 import { EditorView, ViewPlugin, type ViewUpdate } from '@codemirror/view';
 import { getCellSelection, isCellInRect, toSelectionRect } from '../tableState/cellSelectionState';
-import { CLASS_CELL_SELECTED, findTableWidgetElement } from './domHelpers';
-import { makeTableId, type CellCoords } from '../tableModel/types';
+import {
+    CLASS_CELL_SELECTED,
+    DATA_COL,
+    DATA_ROW,
+    DATA_SECTION,
+    SECTION_BODY,
+    SECTION_HEADER,
+    findTableWidgetElement,
+} from './domHelpers';
+import { makeTableId, type CellCoords, type TableSection } from '../tableModel/types';
+
+/** Narrows a raw `data-section` value to a known table section. */
+function isTableSection(value: string | undefined): value is TableSection {
+    return value === SECTION_HEADER || value === SECTION_BODY;
+}
+
+/** Parses a raw `data-row`/`data-col` value, returning null when it is not a number. */
+function readIndex(value: string | undefined): number | null {
+    const index = Number(value);
+    return Number.isNaN(index) ? null : index;
+}
 
 function readCoords(cell: HTMLElement): CellCoords | null {
-    const section = cell.dataset.section;
-    const row = Number(cell.dataset.row);
-    const col = Number(cell.dataset.col);
+    const section = cell.dataset[DATA_SECTION];
+    const row = readIndex(cell.dataset[DATA_ROW]);
+    const col = readIndex(cell.dataset[DATA_COL]);
 
-    if ((section !== 'header' && section !== 'body') || Number.isNaN(row) || Number.isNaN(col)) {
+    if (!isTableSection(section) || row === null || col === null) {
         return null;
     }
 

--- a/src/contentScript/tableWidget/domHelpers.ts
+++ b/src/contentScript/tableWidget/domHelpers.ts
@@ -1,4 +1,4 @@
-import { type CellCoords, type TableId, makeTableId } from '../tableModel/types';
+import { type CellCoords, type TableId, type TableSection, makeTableId } from '../tableModel/types';
 import type { EditorView } from '@codemirror/view';
 
 // Main widget structure classes
@@ -47,6 +47,40 @@ export function getWidgetSelector(): string {
  */
 export function getCellSelector(coords: CellCoords): string {
     return `[data-${DATA_SECTION}="${coords.section}"][data-${DATA_ROW}="${coords.row}"][data-${DATA_COL}="${coords.col}"]`;
+}
+
+/** Narrows a raw `data-section` value to a known table section. */
+function isTableSection(value: string | undefined): value is TableSection {
+    return value === SECTION_HEADER || value === SECTION_BODY;
+}
+
+/** Parses a raw `data-row`/`data-col` value, returning null when it is not a number. */
+function readIndex(value: string | undefined): number | null {
+    const index = Number(value);
+    return Number.isNaN(index) ? null : index;
+}
+
+/**
+ * Reads cell coordinates back off a cell element's data attributes.
+ *
+ * The inverse of `getCellSelector()`, and the only supported way to turn a DOM
+ * cell into `CellCoords`: the attributes are written solely by `TableWidget`,
+ * so anything failing validation is not one of its cells.
+ *
+ * @param cell - A `td`/`th` element to read coordinates from.
+ * @returns The coordinates, or null when any attribute is missing or unparseable.
+ */
+export function readCellCoords(cell: HTMLElement): CellCoords | null {
+    const section = cell.dataset[DATA_SECTION];
+    const row = readIndex(cell.dataset[DATA_ROW]);
+    const col = readIndex(cell.dataset[DATA_COL]);
+
+    if (!isTableSection(section) || row === null || col === null) {
+        return null;
+    }
+
+    // The header is always a single row, so its row index is pinned to 0.
+    return { section, row: section === SECTION_HEADER ? 0 : row, col };
 }
 
 /**

--- a/src/contentScript/tableWidget/tableWidgetInteractions.ts
+++ b/src/contentScript/tableWidget/tableWidgetInteractions.ts
@@ -2,13 +2,12 @@ import type { EditorView } from '@codemirror/view';
 import { CLASS_CELL_EDITOR } from '../shared/tableDomClasses';
 import { slugify } from '../shared/cellContentUtils';
 import { parseFootnoteHref } from '../shared/footnoteAnchor';
-import { clearActiveCellEffect, getActiveCell, type ActiveCellSection } from '../tableState/activeCellState';
+import { clearActiveCellEffect, getActiveCell } from '../tableState/activeCellState';
 import { clearCellSelectionEffect, getCellSelection } from '../tableState/cellSelectionState';
-import type { CellCoords } from '../tableModel/types';
 import { setOrExtendCellSelectionToCoords } from '../tableRuntime/selection/cellSelectionController';
 import { resolveTableContextFromEventTarget } from '../tableRuntime/tablePositioning';
 import { linkOpenerFacet } from '../services/linkOpener';
-import { DATA_COL, DATA_ROW, DATA_SECTION, SECTION_HEADER, getWidgetSelector } from './domHelpers';
+import { getWidgetSelector, readCellCoords } from './domHelpers';
 import { requestOpenCell } from '../tableRuntime/openCellRequest';
 import { createResolvedActiveCell } from '../tableRuntime/activeCell/resolvedActiveCell';
 
@@ -123,23 +122,6 @@ function scrollToPosition(view: EditorView, pos: number): void {
 /** Escape special regex characters in a string */
 function escapeRegex(str: string): string {
     return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
-
-/**
- * Read cell coordinates from a cell element's data attributes.
- * Returns null when any attribute is missing or unparseable.
- */
-function readCellCoords(cell: HTMLElement): CellCoords | null {
-    const section = (cell.dataset[DATA_SECTION] as ActiveCellSection | undefined) ?? null;
-    const row = Number(cell.dataset[DATA_ROW]);
-    const col = Number(cell.dataset[DATA_COL]);
-
-    if (!section || Number.isNaN(row) || Number.isNaN(col)) {
-        return null;
-    }
-
-    // The header is always a single row, so its row index is pinned to 0.
-    return { section, row: section === SECTION_HEADER ? 0 : row, col };
 }
 
 /** Click events: strict link opening. */


### PR DESCRIPTION
Two commits, both behaviour preserving.

## 1. Decompose the cell coordinate guard (856d8c0)

`readCoords` in `cellSelectionVisuals` fused two policies into one three-operator condition: whether `data-section` names a known section, and whether `data-row`/`data-col` parse as numbers. Split into `isTableSection` (a type predicate, so the `CellCoords` narrowing still holds) and `readIndex`.

Also swaps the inline `'header'`/`'body'` and dataset key literals for the `DATA_*` / `SECTION_*` constants in `domHelpers` — what `TableWidget` actually writes these attributes with. The read and write sides were previously coupled by convention only.

## 2. One parser for cell coordinates (a6b4299)

`cellSelectionVisuals` and `tableWidgetInteractions` each had their own reader for a cell's `data-section`/`data-row`/`data-col`. They differed in two ways, **both inert**:

| | visuals | interactions |
|---|---|---|
| section validation | strict — must be `header`/`body` | `as ActiveCellSection` cast, only rejects `undefined`/`''` |
| header row | raw value | pinned to `0` |

`TableWidget` is the only writer of these attributes, and it writes `data-section` as `SECTION_HEADER`/`SECTION_BODY` and hardcodes `data-row = '0'` for every `th`. So no element can carry a third section value (the only input where strict and loose diverge), and the pin can never change anything. Edge inputs — `data-section=""`, missing `data-row`, `data-row=""` — already produce identical results in both.

The strict version moves to `domHelpers` as `readCellCoords`, the inverse of `getCellSelector`, keeping the header row pin from #155. The pin stays a no-op on the visuals path too, since `toUnifiedRowIndex` already collapses header rows to 0.

**The point is the removed cast.** It was the one place an unvalidated DOM string was asserted into the `TableSection` domain, and it flowed on into `createResolvedActiveCell`, the active cell state and the mutation commands, where no type would have caught a bad value. Nothing produces one today; the cast was a bet that the invariant holds forever. The deduplication is a side benefit — two ten-line functions were never the problem.

## Testing

New `domHelpers.test.ts` adds the first direct coverage for this parsing: body cell, header row pin, unknown section, no data attributes, unparseable row/col.

`npm test` 650 passed / 61 files (was 645 / 60) · `npm run lint` clean · no new `tsc` errors under `src/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)