### PR TITLE
refactor: extract marker tables in cellContentUtils

### DIFF
--- a/src/contentScript/shared/cellContentUtils.ts
+++ b/src/contentScript/shared/cellContentUtils.ts
@@ -17,6 +17,16 @@ function unescapePipesForRendering(text: string): string {
 }
 
 /**
+ * Block markers escaped by prefixing a backslash to the whole run.
+ * Ordered lists are handled separately: their backslash goes after the number ("1\. ").
+ */
+const LEADING_BLOCK_MARKERS = [
+    /^#{1,6}(\s|$)/, // headings: "# " / "## " ...
+    /^>/, // blockquote: "> " (space optional)
+    /^[-*+](\s|$)/, // unordered list: "- " / "* " / "+ "
+];
+
+/**
  * Escape leading block markers so cells render inline-only markdown.
  * Assumes cell content has no newlines.
  */
@@ -35,18 +45,7 @@ export function escapeLeadingBlockMarkers(text: string): string {
         return text;
     }
 
-    // Headings: "# " / "## " ...
-    if (/^#{1,6}(\s|$)/.test(rest)) {
-        return `${leading}\\${rest}`;
-    }
-
-    // Blockquote: "> " (space optional)
-    if (/^>/.test(rest)) {
-        return `${leading}\\${rest}`;
-    }
-
-    // Unordered list: "- " / "* " / "+ "
-    if (/^[-*+](\s|$)/.test(rest)) {
+    if (LEADING_BLOCK_MARKERS.some((pattern) => pattern.test(rest))) {
         return `${leading}\\${rest}`;
     }
 
@@ -92,28 +91,31 @@ export function escapeHtmlPreservingBr(text: string): string {
 }
 
 /**
+ * Substrings that suggest inline markdown formatting.
+ * Checked as an order-independent disjunction, so each entry must not be
+ * subsumed by a shorter one (e.g. '**' would be dead next to '*').
+ */
+const MARKDOWN_MARKERS = [
+    '*', // bold / italic
+    '_', // bold / italic
+    '`', // code
+    '[', // links and images
+    '~~', // strikethrough
+    '<', // HTML tags
+    '==', // highlights
+    '++', // insert
+    '\\', // escaped text
+    'mailto:', // mailto links
+    'http', // bare links
+] as const;
+
+/**
  * Quick check if content likely contains markdown formatting
  * Avoids unnecessary render requests for plain text
  */
 export function containsMarkdown(text: string): boolean {
+    // KaTeX needs a delimiter pair ($...$ / $$...$$), so a lone '$' shouldn't trigger a render.
     const hasMathDelimiterPair = text.includes('$') && text.indexOf('$') !== text.lastIndexOf('$');
 
-    // Common markdown patterns
-    return (
-        text.includes('**') || // bold
-        text.includes('__') || // bold
-        text.includes('*') || // italic (single asterisk)
-        text.includes('_') || // italic (single underscore)
-        text.includes('`') || // code
-        text.includes('[') || // links
-        text.includes('~~') || // strikethrough
-        text.includes('![') || // images
-        text.includes('<') || // HTML tags
-        text.includes('==') || // Highlights
-        text.includes('++') || // Insert (++)
-        text.includes('\\') || // Escaped Text
-        text.includes('mailto:') || // Mailto links
-        text.includes('http') || // bare links
-        hasMathDelimiterPair // KaTeX inline/display math delimiters ($...$ / $$...$$)
-    );
+    return MARKDOWN_MARKERS.some((marker) => text.includes(marker)) || hasMathDelimiterPair;
 }


### PR DESCRIPTION
Follow-up to static-analysis complexity findings on `cellContentUtils.ts`. Both flagged functions encoded their marker sets inline, which duplicated logic and inflated cyclomatic complexity without adding real branching.

## `containsMarkdown` (complexity 16 → 3)

Extracted `MARKDOWN_MARKERS` and dropped three entries that were **dead by construction** in an OR chain:

| Removed | Subsumed by |
| --- | --- |
| `'**'` | `'*'` |
| `'__'` | `'_'` |
| `'!['` | `'['` |

## `escapeLeadingBlockMarkers` (complexity 9 → 7)

Three branches shared a byte-identical body (`return \`${leading}\\${rest}\``) — one rule written three times. Collapsed into `LEADING_BLOCK_MARKERS`. Ordered lists stay on their own branch because their backslash goes *after* the number (`1\. `), not before the run.

Guard clauses were left alone. The `!match` guard in particular is not dead — the regex returns `null` on multi-line input, so it defends the documented "no newlines" precondition.

## Verification

- 652 tests pass across 61 files; no test changes were needed.
- Existing coverage in `cellContentUtils.test.ts` exercises all four marker types, the inline-code and no-space negatives, and the `$`-delimiter pair cases.
- `npm run lint` clean, prettier reports no change.

No behavior change intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)