### PR TITLE
refactor: single exit for nested editor keydown handler

### DIFF
--- a/src/contentScript/nestedEditor/domHandlers.ts
+++ b/src/contentScript/nestedEditor/domHandlers.ts
@@ -11,6 +11,18 @@ function runHistoryCommand(mainView: EditorView, command: StateCommand): boolean
     return command(mainView);
 }
 
+/**
+ * Mod-shortcuts that run as root editor commands (bold, italic, underline, code, link).
+ * They need a root selection mirroring the nested editor before they bubble out.
+ */
+const ROOT_COMMAND_KEYS: readonly string[] = ['b', 'i', 'u', '`', 'e', 'k'];
+
+/**
+ * Mod-shortcuts handled entirely by Joplin/the host (save, print, paste).
+ * They bubble untouched with no extra nested-editor bookkeeping.
+ */
+const HOST_PASSTHROUGH_KEYS: readonly string[] = ['s', 'p', 'v'];
+
 export function createNestedEditorKeymap(
     mainView: EditorView,
     options: {
@@ -224,28 +236,25 @@ export function createNestedEditorDomHandlers(
                 e.stopPropagation();
                 return false;
             },
+            // Never marks the event as handled; the branches only decide whether the
+            // keydown is allowed to bubble to the main editor and what to prepare first.
             keydown: (e) => {
                 const isMod = e.ctrlKey || e.metaKey;
                 const key = e.key.toLowerCase();
 
                 if (isMod && key === 'f') {
+                    // Search replaces the nested editor, so tear it down before the event bubbles.
                     options.closeEditor();
                     if (getActiveCell(mainView.state)) {
                         mainView.dispatch({ effects: clearActiveCellEffect.of(undefined) });
                     }
-                    return false;
-                }
-
-                if (isMod && ['b', 'i', 'u', '`', 'e', 'k'].includes(key)) {
+                } else if (isMod && ROOT_COMMAND_KEYS.includes(key)) {
                     options.ensureRootSelectionForCommand();
-                    return false;
+                } else if (!(isMod && HOST_PASSTHROUGH_KEYS.includes(key))) {
+                    // Everything else stays inside the nested editor.
+                    e.stopPropagation();
                 }
 
-                if (isMod && ['s', 'p', 'v'].includes(key)) {
-                    return false;
-                }
-
-                e.stopPropagation();
                 return false;
             },
             mousedown: (e, view) => {


### PR DESCRIPTION
## Summary

Fixes the `sonarjs/no-invariant-returns` error in `src/contentScript/nestedEditor/domHandlers.ts`.

All four exits of the nested editor's `keydown` handler returned `false`, so the return value carried no information — the event was never marked as handled. Only the side effects differed: whether `stopPropagation()` runs, and what needs preparing before the event bubbles to the main editor. Collapsed to an if/else chain with a single trailing `return false`, which is what the branching actually meant.

## Changes

- `keydown` now has one exit; the branches only decide side effects.
- The passthrough case inverted into `else if (!(isMod && HOST_PASSTHROUGH_KEYS.includes(key)))`, making "stay inside the nested editor" the explicit default rather than a fallthrough.
- Extracted the inline mod-key arrays to `ROOT_COMMAND_KEYS` and `HOST_PASSTHROUGH_KEYS` with JSDoc on what each set is for (no-magic-literals).

Behavior is unchanged for every key combination.

## Testing

- `npx eslint` clean on the file
- `npx prettier --check` clean
- `npm test` — 61 files, 652 tests pass

## Note

The sibling handlers (`beforeinput`, `input`, `compositionstart`, …) share the same invariant-return shape but aren't flagged, since a single `return false` doesn't trip the rule. This is a local fix, not a pattern change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)