### PR TITLE
refactor: rename setForwardDomSelection params to start/end

### DIFF
--- a/src/contentScript/editorBridge/rootDomSelection.ts
+++ b/src/contentScript/editorBridge/rootDomSelection.ts
@@ -25,15 +25,20 @@ function isSelectionEndpointInView(view: EditorView, endpoint: DomSelectionEndpo
     return view.contentDOM.contains(endpoint.node);
 }
 
-function setForwardDomSelection(
+/**
+ * Fallback for browsers without `Selection.setBaseAndExtent`. A DOM Range has no
+ * direction, so callers must pass the endpoints in document order: for a backward
+ * selection that means `head` first.
+ */
+function setDomSelectionRange(
     documentSelection: Selection,
     doc: Document,
-    anchor: DomSelectionEndpoint,
-    head: DomSelectionEndpoint
+    start: DomSelectionEndpoint,
+    end: DomSelectionEndpoint
 ): void {
     const range = doc.createRange();
-    range.setStart(anchor.node, anchor.offset);
-    range.setEnd(head.node, head.offset);
+    range.setStart(start.node, start.offset);
+    range.setEnd(end.node, end.offset);
     documentSelection.removeAllRanges();
     documentSelection.addRange(range);
 }
@@ -66,9 +71,9 @@ export function forceRootDomSelection(view: EditorView, selection: { anchor: num
         if (documentSelection.setBaseAndExtent) {
             documentSelection.setBaseAndExtent(anchor.node, anchor.offset, head.node, head.offset);
         } else if (forward) {
-            setForwardDomSelection(documentSelection, doc, anchor, head);
+            setDomSelectionRange(documentSelection, doc, anchor, head);
         } else {
-            setForwardDomSelection(documentSelection, doc, head, anchor);
+            setDomSelectionRange(documentSelection, doc, head, anchor);
         }
         return true;
     } catch {


### PR DESCRIPTION
## Summary

Fixes a `sonarjs/arguments-order` lint error in `src/contentScript/editorBridge/rootDomSelection.ts`.

A DOM `Range` has no direction — it must be given endpoints in document order. The backward-selection branch therefore correctly passes `head` as the range start. The problem was the `anchor`/`head` parameter names, which implied a direction the helper doesn't have (and made the deliberate swap look like a bug to both the linter and readers).

- Renamed `setForwardDomSelection` → `setDomSelectionRange`
- Renamed params `anchor`/`head` → `start`/`end`
- Added a JSDoc note explaining the document-order requirement

No behavior change.

## Test plan

- `npm run lint` — the `rootDomSelection.ts` error is gone. Five unrelated pre-existing sonarjs errors remain (4 in test files, 1 cognitive-complexity in `lifecyclePolicy.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)