### PR TITLE
chore: fix sonarjs lint errors in tests

### DIFF
--- a/src/contentScript/__tests__/domContext.test.ts
+++ b/src/contentScript/__tests__/domContext.test.ts
@@ -5,10 +5,7 @@ import { getDocumentWindow, requestViewAnimationFrame } from '../shared/domConte
 describe('domContext', () => {
     it('prefers the document defaultView over the ambient window', () => {
         const callback = vi.fn();
-        const rafSpy = vi.fn((frameCallback: FrameRequestCallback) => {
-            void frameCallback;
-            return 42;
-        });
+        const rafSpy = vi.fn((_frameCallback: FrameRequestCallback) => 42);
         const fakeWindow = { requestAnimationFrame: rafSpy } as unknown as Window;
         const fakeDocument = { defaultView: fakeWindow } as Document;
         const fakeView = {

--- a/src/contentScript/__tests__/markdownTableCellRanges.test.ts
+++ b/src/contentScript/__tests__/markdownTableCellRanges.test.ts
@@ -66,48 +66,24 @@ describe('computeMarkdownTableCellRanges', () => {
         expect(sliceRange(text, r.from, r.to)).toBe('');
     });
 
-    it('hides canonical delimiter padding from editable bounds', () => {
-        const text = ['| foo |', '| --- |'].join('\n');
+    it.each([
+        { case: 'hides canonical delimiter padding', headerLine: '| foo |', editable: 'foo' },
+        { case: 'preserves user-entered trailing whitespace', headerLine: '| foo  |', editable: 'foo ' },
+        { case: 'preserves user-entered leading whitespace', headerLine: '|  foo |', editable: ' foo' },
+        {
+            case: 'preserves user-entered leading and trailing whitespace',
+            headerLine: '|  foo  |',
+            editable: ' foo ',
+        },
+    ])('$case in editable bounds', ({ headerLine, editable }) => {
+        const text = [headerLine, '| --- |'].join('\n');
         const ranges = computeMarkdownTableCellRanges(text);
         expect(ranges).not.toBeNull();
         if (!ranges) return;
 
         const header = ranges.headers[0];
         expect(sliceRange(text, header.from, header.to)).toBe('foo');
-        expect(sliceRange(text, header.editableFrom, header.editableTo)).toBe('foo');
-    });
-
-    it('preserves user-entered trailing whitespace in editable bounds', () => {
-        const text = ['| foo  |', '| --- |'].join('\n');
-        const ranges = computeMarkdownTableCellRanges(text);
-        expect(ranges).not.toBeNull();
-        if (!ranges) return;
-
-        const header = ranges.headers[0];
-        expect(sliceRange(text, header.from, header.to)).toBe('foo');
-        expect(sliceRange(text, header.editableFrom, header.editableTo)).toBe('foo ');
-    });
-
-    it('preserves user-entered leading whitespace in editable bounds', () => {
-        const text = ['|  foo |', '| --- |'].join('\n');
-        const ranges = computeMarkdownTableCellRanges(text);
-        expect(ranges).not.toBeNull();
-        if (!ranges) return;
-
-        const header = ranges.headers[0];
-        expect(sliceRange(text, header.from, header.to)).toBe('foo');
-        expect(sliceRange(text, header.editableFrom, header.editableTo)).toBe(' foo');
-    });
-
-    it('preserves user-entered leading and trailing whitespace in editable bounds', () => {
-        const text = ['|  foo  |', '| --- |'].join('\n');
-        const ranges = computeMarkdownTableCellRanges(text);
-        expect(ranges).not.toBeNull();
-        if (!ranges) return;
-
-        const header = ranges.headers[0];
-        expect(sliceRange(text, header.from, header.to)).toBe('foo');
-        expect(sliceRange(text, header.editableFrom, header.editableTo)).toBe(' foo ');
+        expect(sliceRange(text, header.editableFrom, header.editableTo)).toBe(editable);
     });
 
     it('uses a zero-width editable span for canonical empty cells', () => {

--- a/src/contentScript/__tests__/tableInsertCommand.test.ts
+++ b/src/contentScript/__tests__/tableInsertCommand.test.ts
@@ -12,6 +12,11 @@ interface CapturedDispatch {
     effects: StateEffect<unknown>[];
 }
 
+function toEffectArray(effects: TransactionSpec['effects']): StateEffect<unknown>[] {
+    if (!effects) return [];
+    return Array.isArray(effects) ? [...(effects as StateEffect<unknown>[])] : [effects as StateEffect<unknown>];
+}
+
 function createMockView(doc: string, cursorPos: number): EditorView & { state: EditorState } {
     const dispatches: CapturedDispatch[] = [];
     const view = {
@@ -20,12 +25,7 @@ function createMockView(doc: string, cursorPos: number): EditorView & { state: E
             return dispatches;
         },
         dispatch(spec: TransactionSpec) {
-            const effects: StateEffect<unknown>[] = Array.isArray(spec.effects)
-                ? (spec.effects as StateEffect<unknown>[])
-                : spec.effects
-                  ? [spec.effects as StateEffect<unknown>]
-                  : [];
-            dispatches.push({ spec, effects });
+            dispatches.push({ spec, effects: toEffectArray(spec.effects) });
             this.state = this.state.update(spec).state;
         },
     };

--- a/src/contentScript/__tests__/tableNavigation.test.ts
+++ b/src/contentScript/__tests__/tableNavigation.test.ts
@@ -64,9 +64,9 @@ describe('navigateCell', () => {
     });
 
     const getEffects = () => {
-        const spec = mockDispatch.mock.calls[0]?.[0];
-        const effects = spec?.effects;
-        return Array.isArray(effects) ? effects : effects ? [effects] : [];
+        const effects = mockDispatch.mock.calls[0]?.[0]?.effects;
+        if (!effects) return [];
+        return Array.isArray(effects) ? effects : [effects];
     };
 
     const getSetActiveCellValue = () => getEffects().find((effect) => effect.is?.(setActiveCellEffect))?.value;


### PR DESCRIPTION
Fixes the four test-file lint errors reported by `npm run lint`.

## Changes

| File | Rule | Fix |
| --- | --- | --- |
| `domContext.test.ts` | `sonarjs/void-use` | Dropped the `void` statement; the unused param is now underscore-prefixed (matches the `argsIgnorePattern` in the ESLint config). |
| `markdownTableCellRanges.test.ts` | `sonarjs/parameterized-tests` | Collapsed the four editable-bounds whitespace tests into a single `it.each` table. |
| `tableInsertCommand.test.ts` | `sonarjs/no-nested-conditional` | Extracted the nested ternary into a `toEffectArray` helper. |
| `tableNavigation.test.ts` | `sonarjs/no-nested-conditional` | Replaced the nested ternary in `getEffects` with an early return. |

No behavior changes — same assertions, same cases.

## Verification

- `npm test` — 652 tests / 61 files passing
- `npm run lint` — all four errors gone. One pre-existing error remains, unrelated and out of scope: `sonarjs/cognitive-complexity` on `lifecyclePolicy.ts:83`.
- `prettier --check` clean on the touched files; `tsc --noEmit` reports nothing for them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)