### PR TITLE
perf: read live coordsAt ranges from state instead of reparsing

### DIFF
--- a/docs/Architecture/Interaction-and-Navigation.md
+++ b/docs/Architecture/Interaction-and-Navigation.md
@@ -15,10 +15,10 @@ Cells are separate editor instances (or `<td>` when inactive). Key events are in
 ### Scrolling
 
 Primary cell navigation opens the target nested editor, then focuses its `contentDOM`. The browser scrolls that focused
-cell into view as needed, which works more reliably on mobile than explicitely calling `scrollIntoView`.
+cell into view as needed, which works more reliably on mobile than explicitly calling `scrollIntoView`.
 
-The plugin still uses explicit `scrollIntoView` for other paths such as anchor jumps, source/raw-mode cursor
-visibility, and multi-cell selection focus.
+The plugin still uses explicit `scrollIntoView` for other paths such as anchor jumps and source/raw-mode cursor
+visibility.
 
 ### Open-Cell Request State
 

--- a/docs/Architecture/Table-Display.md
+++ b/docs/Architecture/Table-Display.md
@@ -78,7 +78,9 @@ is deleted.
 nested editor is open the widget's own cell ranges are frozen (see `mapDecorations` in
 `tableDecorationPolicy.ts`), so it reads live ranges from `resolvedActiveCellField` instead — a cached
 state-field read, since `coordsAt()` runs in CodeMirror's synchronous measure phase and must not
-re-parse the document.
+re-parse the document. The field only covers the active table, so switching activation to a different
+table rebuilds all widgets — otherwise the previous table's widget would keep frozen pre-edit ranges
+with no live coverage.
 
 ## Display Modes
 

--- a/docs/Architecture/Table-Display.md
+++ b/docs/Architecture/Table-Display.md
@@ -74,7 +74,11 @@ table (text unchanged). Text is consulted first: a text hit is the table's own m
 position hit only reports whatever was last measured at that offset and goes stale when a table above
 is deleted.
 
-**`coordsAt()`**: Returns cell bounding rectangle for precise scroll-to-cell during navigation.
+**`coordsAt()`**: Returns cell bounding rectangle for precise scroll-to-cell during navigation. While a
+nested editor is open the widget's own cell ranges are frozen (see `mapDecorations` in
+`tableDecorationPolicy.ts`), so it reads live ranges from `resolvedActiveCellField` instead — a cached
+state-field read, since `coordsAt()` runs in CodeMirror's synchronous measure phase and must not
+re-parse the document.
 
 ## Display Modes
 

--- a/docs/Architecture/Table-Display.md
+++ b/docs/Architecture/Table-Display.md
@@ -74,13 +74,9 @@ table (text unchanged). Text is consulted first: a text hit is the table's own m
 position hit only reports whatever was last measured at that offset and goes stale when a table above
 is deleted.
 
-**`coordsAt()`**: Returns cell bounding rectangle for precise scroll-to-cell during navigation. While a
-nested editor is open the widget's own cell ranges are frozen (see `mapDecorations` in
-`tableDecorationPolicy.ts`), so it reads live ranges from `resolvedActiveCellField` instead — a cached
-state-field read, since `coordsAt()` runs in CodeMirror's synchronous measure phase and must not
-re-parse the document. The field only covers the active table, so switching activation to a different
-table rebuilds all widgets — otherwise the previous table's widget would keep frozen pre-edit ranges
-with no live coverage.
+**`coordsAt()`**: Maps positions in replaced table source to rendered cell rectangles for
+CodeMirror coordinate consumers, notably cursor-positioned tooltips. Keyboard cell navigation
+scrolls through nested-editor focus and does not depend on it.
 
 ## Display Modes
 

--- a/src/contentScript/__tests__/tableRuntimePolicies.test.ts
+++ b/src/contentScript/__tests__/tableRuntimePolicies.test.ts
@@ -327,6 +327,26 @@ describe('tableRuntimePolicies', () => {
         expect(decideTableDecorationUpdate(tr)).toEqual({ type: 'rebuildAllDecorations' });
     });
 
+    it('rebuilds all decorations when activation switches to a different table', () => {
+        // The previous table's widget may hold cell ranges frozen by mapDecorations; once the
+        // resolved active cell moves to another table, only a rebuild keeps coordsAt() accurate.
+        const state = createState({ activeCell: getHeaderCell() });
+        const tr = state.update({
+            effects: setActiveCellEffect.of({ tableFrom: 50, section: 'body', row: 0, col: 0 }),
+        });
+
+        expect(decideTableDecorationUpdate(tr)).toEqual({ type: 'rebuildAllDecorations' });
+    });
+
+    it('keeps decorations when activation moves within the same table', () => {
+        const state = createState({ activeCell: getHeaderCell() });
+        const tr = state.update({
+            effects: setActiveCellEffect.of({ tableFrom: 0, section: 'body', row: 0, col: 0 }),
+        });
+
+        expect(decideTableDecorationUpdate(tr)).toEqual({ type: 'keepDecorations' });
+    });
+
     it('returns none decorations in raw mode', () => {
         const state = createState();
         const tr = state.update({ effects: toggleSourceModeEffect.of(true) });

--- a/src/contentScript/__tests__/tableWidgetCoordsAt.test.ts
+++ b/src/contentScript/__tests__/tableWidgetCoordsAt.test.ts
@@ -9,6 +9,8 @@ import { syncAnnotation } from '../editorBridge/syncAnnotation';
 import { markdownRenderServiceFacet } from '../services/markdownRenderer';
 import { MarkdownTable } from '../tableModel/MarkdownTable';
 import { computeMarkdownTableCellRanges, findCellForPos } from '../tableModel/markdownTableCellRanges';
+import { activeCellField, setActiveCellEffect } from '../tableState/activeCellState';
+import { resolvedActiveCellField } from '../tableRuntime/activeCell/resolvedActiveCell';
 import { TableWidget } from '../tableWidget/TableWidget';
 import { tableDecorationField } from '../tableWidget/tableDecorationField';
 
@@ -31,6 +33,8 @@ function createRealView(doc: string): { parent: HTMLElement; view: EditorView } 
                 render: vi.fn(async () => ''),
                 clear: vi.fn(),
             }),
+            activeCellField,
+            resolvedActiveCellField,
             tableDecorationField,
         ],
     });
@@ -95,7 +99,11 @@ describe('TableWidget coordsAt', () => {
         // widget's own `cellRanges` stay frozen at pre-edit offsets even though the live document
         // has changed underneath it. coordsAt must still resolve positions correctly in that state.
         const TABLE_TEXT = ['| H1 | H2 |', '| --- | --- |', '| a | b |'].join('\n');
+        const TABLE_FROM = 0;
 
+        // A sync transaction only ever originates from an open nested editor, so the active cell
+        // is always set alongside it. Reproducing that here matters: coordsAt reads the live cell
+        // ranges from resolvedActiveCellField, which is only populated while a cell is active.
         function editCellAWithoutRebuild(view: EditorView, insertText: string): void {
             const cellARanges = computeMarkdownTableCellRanges(view.state.doc.toString());
             if (!cellARanges) {
@@ -103,6 +111,9 @@ describe('TableWidget coordsAt', () => {
             }
             const cellAFrom = cellARanges.rows[0][0].editableFrom;
             const cellATo = cellARanges.rows[0][0].editableTo;
+            view.dispatch({
+                effects: setActiveCellEffect.of({ tableFrom: TABLE_FROM, section: 'body', row: 0, col: 0 }),
+            });
             view.dispatch({
                 changes: { from: cellAFrom, to: cellATo, insert: insertText },
                 annotations: [syncAnnotation.of(true)],

--- a/src/contentScript/__tests__/tableWidgetCoordsAt.test.ts
+++ b/src/contentScript/__tests__/tableWidgetCoordsAt.test.ts
@@ -221,6 +221,65 @@ describe('TableWidget coordsAt', () => {
         });
     });
 
+    it('resolves coords in a previously edited table after activation switches to another table', () => {
+        // Regression test: editing table A freezes its widget via mapDecorations, and a bare
+        // setActiveCellEffect switch to table B (no doc change, no normalization needed) moves
+        // resolvedActiveCellField to B — so A's frozen widget is no longer covered by the live
+        // ranges. The decoration policy must rebuild on the switch so A's widget picks up
+        // post-edit cellRanges; otherwise coordsAt() resolves A against pre-edit offsets.
+        const tableA = ['| H1 | H2 |', '| --- | --- |', '| a | b |'].join('\n');
+        const tableB = ['| X1 | X2 |', '| --- | --- |', '| x | y |'].join('\n');
+
+        const { parent, view } = createRealView(`${tableA}\n\n${tableB}`);
+        try {
+            // Activate cell A[0][0] and grow it via a sync edit (nested-editor forwarding path).
+            const preRanges = computeMarkdownTableCellRanges(tableA);
+            if (!preRanges) throw new Error('Expected table A to parse');
+            view.dispatch({
+                effects: setActiveCellEffect.of({ tableFrom: 0, section: 'body', row: 0, col: 0 }),
+            });
+            view.dispatch({
+                changes: {
+                    from: preRanges.rows[0][0].editableFrom,
+                    to: preRanges.rows[0][0].editableTo,
+                    insert: 'aaaaaaaaaa',
+                },
+                annotations: [syncAnnotation.of(true)],
+            });
+
+            // Switch activation to table B the way requestOpenCell does: bare effect, no doc
+            // change. Production resolves B at its current (post-edit) position at click time.
+            const tableBFrom = view.state.doc.toString().indexOf('| X1');
+            view.dispatch({
+                effects: setActiveCellEffect.of({ tableFrom: tableBFrom, section: 'body', row: 0, col: 0 }),
+            });
+
+            const liveDocText = view.state.doc.toString();
+            const liveARanges = computeMarkdownTableCellRanges(liveDocText.slice(0, liveDocText.indexOf('\n\n')));
+            if (!liveARanges) throw new Error('Expected edited table A to parse');
+            // Tail of the grown cell A: past where A's pre-edit ranges said the cell ended.
+            const posInGrownCellA = liveARanges.rows[0][0].editableTo;
+
+            const tableABody = view.contentDOM.querySelectorAll('tbody')[0];
+            const cellA = tableABody?.querySelector('td:nth-child(1)') as HTMLElement | null;
+            const cellB = tableABody?.querySelector('td:nth-child(2)') as HTMLElement | null;
+            if (!cellA || !cellB) throw new Error('Expected table A cells to render');
+            const rect = { top: 1, bottom: 2, left: 3, right: 4 } as DOMRect;
+            const wrongRect = { top: 999, bottom: 999, left: 999, right: 999 } as DOMRect;
+            vi.spyOn(cellA, 'getBoundingClientRect').mockReturnValue(rect);
+            vi.spyOn(cellB, 'getBoundingClientRect').mockReturnValue(wrongRect);
+
+            expect(view.coordsAtPos(posInGrownCellA)).toMatchObject({
+                top: rect.top,
+                bottom: rect.bottom,
+                left: rect.left,
+            });
+        } finally {
+            view.destroy();
+            parent.remove();
+        }
+    });
+
     it('falls back to cached cellRanges when the DOM has no live view registered', () => {
         // toDOM() was called directly (as in the test above), bypassing the widgetDomState entry
         // that resolveLiveCellCoords() needs -- coordsAt must still resolve via the constructor's

--- a/src/contentScript/tableWidget/TableWidget.ts
+++ b/src/contentScript/tableWidget/TableWidget.ts
@@ -250,8 +250,9 @@ export class TableWidget extends WidgetType {
     }
 
     /**
-     * Returns the bounding rectangle of the cell containing the given widget-relative position.
-     * This helps CodeMirror scroll precisely to specific cells rather than just the table bounds.
+     * Returns cell-level geometry for a position hidden by the table widget. CodeMirror coordinate
+     * consumers, such as cursor-positioned tooltips, use this to anchor UI to the corresponding
+     * rendered cell rather than the whole table.
      *
      * CodeMirror subtracts the widget's document start offset before calling this, so `pos` is
      * already relative to the widget — do not subtract `tableFrom` here.

--- a/src/contentScript/tableWidget/TableWidget.ts
+++ b/src/contentScript/tableWidget/TableWidget.ts
@@ -3,9 +3,8 @@ import { markdownRenderServiceFacet, type MarkdownRenderService } from '../servi
 import { cleanupHostedNestedEditors } from '../nestedEditor/nestedEditorController';
 import { MarkdownTable } from '../tableModel/MarkdownTable';
 import { findCellForPos, type TableCellRanges } from '../tableModel/markdownTableCellRanges';
-import { buildTableContext } from '../tableModel/tableContext';
 import type { CellCoords } from '../tableModel/types';
-import { resolveContainingTableAtPos } from '../tableRuntime/tableResolution';
+import { resolvedActiveCellField } from '../tableRuntime/activeCell/resolvedActiveCell';
 import { CLASS_CELL_CONTENT } from '../shared/tableDomClasses';
 import { tableHeightCache } from './tableHeightCache';
 import {
@@ -261,9 +260,9 @@ export class TableWidget extends WidgetType {
      * forwarded through the `mapDecorations` path (see tableDecorationPolicy.ts) precisely so the
      * widget is *not* rebuilt while a nested editor is open, which leaves `cellRanges` stale for
      * the whole editing session — long enough for `pos` to resolve to the wrong cell once the
-     * edited cell's length changes. `resolveLiveCellCoords()` recomputes ranges from the current
-     * document instead, so it takes priority whenever it succeeds; the cached ranges remain as a
-     * fallback for DOM not yet registered in `widgetDomState` (e.g. direct `toDOM()` use in tests).
+     * edited cell's length changes. `resolveLiveCellCoords()` reads the live ranges instead, so it
+     * takes priority whenever it succeeds; the cached ranges remain as the fallback for every
+     * widget it does not cover (see there).
      */
     coordsAt(
         dom: HTMLElement,
@@ -285,26 +284,37 @@ export class TableWidget extends WidgetType {
     }
 
     /**
-     * Resolves `pos` against the table's live document text rather than the `cellRanges`
-     * snapshot captured at the last full rebuild. `state.view` is the same long-lived
-     * `EditorView` instance across the widget's life — `.state` always reflects the latest
-     * transaction even when `updateDOM()` hasn't run — so this stays accurate through the
-     * `mapDecorations` path that keeps `this.tableFrom`/`this.cellRanges` frozen.
+     * Resolves `pos` against the live cell ranges held in `resolvedActiveCellField` rather than
+     * the `cellRanges` snapshot captured at the last full rebuild.
      *
-     * `undefined` means live resolution was unavailable and the caller may use cached ranges.
-     * `null` is an authoritative result that the live position does not belong to a cell.
+     * That field is the right source precisely because the two situations coincide: both
+     * `mapDecorations` branches require an active cell (a sync transaction only exists while a
+     * nested editor is open, and the document-edit branch checks `getActiveCell()` outright), and
+     * the field re-derives a full `TableContext` on every `docChanged`. So for the whole window in
+     * which `cellRanges` is frozen, the current ranges have already been computed once in the
+     * transaction that froze them — this runs inside CodeMirror's synchronous measure phase, and
+     * re-deriving them from the syntax tree here would parse and slice the document again per call.
      *
-     * The distinction is imperfect: `resolveContainingTableAtPos()` returns `null` both when
-     * the syntax tree is unavailable (timeout) and when the position genuinely isn't in a
-     * table, so the latter also maps to `undefined` here and falls back to cached ranges.
-     * This is deliberate: the "no longer a table" case is nearly unreachable (structural
-     * edits rebuild the widget via `eq()`; the `mapDecorations` window only spans in-cell
-     * edits, which keep the table intact), and a slightly stale cell rect scrolls better
-     * than the `null` alternative of no coordinates at all.
+     * `state.view` is the same long-lived `EditorView` instance across the widget's life, so
+     * `.state` reflects the latest transaction even when `updateDOM()` has not run.
+     *
+     * `undefined` means the live ranges do not cover this widget and the caller should use its
+     * cached ranges; `null` is an authoritative result that the live position is not in a cell.
+     * The `undefined` cases are all ones where the snapshot is trustworthy: no active cell means
+     * no `mapDecorations` window, and a widget outside the active table's span was never subject
+     * to the in-cell edits that go stale.
      */
     private resolveLiveCellCoords(dom: HTMLElement, pos: number): CellCoords | null | undefined {
         const state = widgetDomState.get(dom);
         if (!state) {
+            return undefined;
+        }
+
+        // Read the field directly rather than through getResolvedActiveCell(): its fallback for
+        // states without the field recomputes the context from the syntax tree, which is the
+        // measure-phase work this exists to avoid.
+        const resolved = state.view.state.field(resolvedActiveCellField, false);
+        if (!resolved) {
             return undefined;
         }
 
@@ -317,17 +327,16 @@ export class TableWidget extends WidgetType {
             return undefined;
         }
 
-        const table = resolveContainingTableAtPos(state.view.state, liveTableFrom + pos);
-        if (!table) {
+        // Containment rather than `liveTableFrom === ctx.from`: the widget may be a different
+        // table than the active one, and comparing spans tolerates any drift between the mapped
+        // decoration start and the freshly resolved table start.
+        const { ctx } = resolved;
+        const docPos = liveTableFrom + pos;
+        if (docPos < ctx.from || docPos > ctx.to) {
             return undefined;
         }
 
-        const ctx = buildTableContext(table);
-        if (!ctx) {
-            return undefined;
-        }
-
-        return findCellForPos(ctx.cellRanges, liveTableFrom + pos - ctx.from);
+        return findCellForPos(ctx.cellRanges, docPos - ctx.from);
     }
 
     ignoreEvent(): boolean {

--- a/src/contentScript/tableWidget/TableWidget.ts
+++ b/src/contentScript/tableWidget/TableWidget.ts
@@ -287,22 +287,15 @@ export class TableWidget extends WidgetType {
      * Resolves `pos` against the live cell ranges held in `resolvedActiveCellField` rather than
      * the `cellRanges` snapshot captured at the last full rebuild.
      *
-     * That field is the right source precisely because the two situations coincide: both
-     * `mapDecorations` branches require an active cell (a sync transaction only exists while a
-     * nested editor is open, and the document-edit branch checks `getActiveCell()` outright), and
-     * the field re-derives a full `TableContext` on every `docChanged`. So for the whole window in
-     * which `cellRanges` is frozen, the current ranges have already been computed once in the
-     * transaction that froze them — this runs inside CodeMirror's synchronous measure phase, and
-     * re-deriving them from the syntax tree here would parse and slice the document again per call.
+     * The field covers exactly the window in which `cellRanges` is frozen: both `mapDecorations`
+     * branches require an active cell, and the field re-derives the table's `TableContext` on
+     * every `docChanged` — so the current ranges were already computed in the transaction that
+     * froze them. This runs inside CodeMirror's synchronous measure phase; re-deriving them from
+     * the syntax tree here would parse and slice the document again per call.
      *
-     * `state.view` is the same long-lived `EditorView` instance across the widget's life, so
-     * `.state` reflects the latest transaction even when `updateDOM()` has not run.
-     *
-     * `undefined` means the live ranges do not cover this widget and the caller should use its
-     * cached ranges; `null` is an authoritative result that the live position is not in a cell.
-     * The `undefined` cases are all ones where the snapshot is trustworthy: no active cell means
-     * no `mapDecorations` window, and a widget outside the active table's span was never subject
-     * to the in-cell edits that go stale.
+     * `undefined` means the live ranges do not cover this widget and the cached ranges are
+     * trustworthy (no active cell means no `mapDecorations` window; a widget outside the active
+     * table's span never goes stale). `null` is authoritative: the live position is not in a cell.
      */
     private resolveLiveCellCoords(dom: HTMLElement, pos: number): CellCoords | null | undefined {
         const state = widgetDomState.get(dom);

--- a/src/contentScript/tableWidget/tableDecorationPolicy.ts
+++ b/src/contentScript/tableWidget/tableDecorationPolicy.ts
@@ -1,5 +1,5 @@
 import { Transaction, type StateEffectType } from '@codemirror/state';
-import { clearActiveCellEffect, getActiveCell } from '../tableState/activeCellState';
+import { clearActiveCellEffect, getActiveCell, setActiveCellEffect } from '../tableState/activeCellState';
 import { isEffectiveRawMode, toggleSourceModeEffect } from '../tableState/sourceMode';
 import { setSearchForceSourceModeEffect } from '../tableState/searchForceSourceMode';
 import { rebuildAllTableWidgetsEffect, rebuildTableWidgetsEffect } from '../tableState/tableWidgetEffects';
@@ -65,6 +65,25 @@ function decideFullDocumentReplaceDecoration(tr: Transaction): DecorationDecisio
     return { type: 'noneDecorations' };
 }
 
+/**
+ * Switching activation to a different table ends the previous table's `mapDecorations`
+ * window without a clear effect, leaving its widget frozen with cell ranges that predate
+ * any in-cell edits — while `resolvedActiveCellField` moves on to the new table, so
+ * `coordsAt()` can no longer live-resolve the old one. Rebuilding restores the invariant
+ * that a frozen widget is always covered by the resolved active cell.
+ */
+function decideActiveTableSwitchDecoration(tr: Transaction): DecorationDecision | null {
+    const previousTableFrom = getActiveCell(tr.startState)?.tableFrom;
+    if (previousTableFrom === undefined) {
+        return null;
+    }
+
+    const switchesTable = tr.effects.some(
+        (effect) => effect.is(setActiveCellEffect) && effect.value.tableFrom !== previousTableFrom
+    );
+    return switchesTable ? { type: 'rebuildAllDecorations' } : null;
+}
+
 function decideDocumentEditDecoration(tr: Transaction): DecorationDecision {
     if (hasEffect(tr, clearActiveCellEffect) || hasEffect(tr, rebuildTableWidgetsEffect)) {
         return { type: 'rebuildAllDecorations' };
@@ -95,6 +114,7 @@ export function decideTableDecorationUpdate(tr: Transaction): DecorationDecision
         decideSyncDecoration(tr) ??
         decideRebuildRequestDecoration(tr) ??
         decideFullDocumentReplaceDecoration(tr) ??
+        decideActiveTableSwitchDecoration(tr) ??
         decideDocumentEditDecoration(tr)
     );
 }


### PR DESCRIPTION
## Summary

`TableWidget.coordsAt()` runs inside CodeMirror's synchronous measure phase, and CodeMirror reaches it several times per measure (drawSelection cursor/range rects, scrollIntoView, vertical motion). It previously resolved live cell ranges there via `resolveContainingTableAtPos()` + `buildTableContext()`, which meant per call:

- `ensureSyntaxTree()`, which mutates the shared parse context viewport before its `isDone()` short-circuit, cutting fragments and resetting the parse when skipped regions overlap;
- a full `doc.sliceString()` of the table plus split/join trimming, up to twice;
- a `buildTableContext()` LRU lookup keyed by the table's exact source text — always a miss on this path, since it only runs while the text is changing, churning the 50-entry cache every keystroke.

The live ranges are already in state: `resolvedActiveCellField` re-derives the full `TableContext` on every `docChanged`, and both `mapDecorations` branches require an active cell. `coordsAt()` now reads that field directly and containment-checks the position against the resolved table's span, falling back to the widget's cached snapshot otherwise. No syntax tree access, doc slicing, or parsing in the measure phase.

## Regression found in review, and its fix

Review of the first commit surfaced a real regression (confirmed with a deterministic repro): switching activation straight from an edited table A to another table B left A's widget frozen with pre-edit ranges while the field moved on to B — the bare `setActiveCellEffect` switch produced `keepDecorations`, and normalization is skipped when B is already canonical. The old reparse path handled that case; the new field read did not.

Fixed in the follow-up commit by treating a `setActiveCellEffect` whose `tableFrom` differs from the current active table like a clear: `rebuildAllDecorations`. The rebuild is work that was owed anyway (A's text changed; `eq()` reuses DOM for tables whose text didn't), and within-table cell hops still keep decorations. Real-world exposure was narrow — coords queries into A while B's editor is open, past the edited cell's old boundary — which is why it never reproduced in manual testing, but the unit-level repro was deterministic.

## Test plan

- Existing `coordsAt` live-widget tests now set an active cell alongside sync transactions (the state production actually creates), so they exercise the path they describe.
- New policy tests: cross-table switch → `rebuildAllDecorations`; within-table move → `keepDecorations`.
- New end-to-end regression test (two tables: grow a cell in A via sync edit, bare-switch to B, query coords in A) — verified to fail without the policy fix.
- Full suite: 655 tests passing; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)