### PR TITLE
feat: keyboard navigation in and out of tables, and improve behavior backspacing into table

### DIFF
--- a/docs/Architecture/Interaction-and-Navigation.md
+++ b/docs/Architecture/Interaction-and-Navigation.md
@@ -22,6 +22,10 @@ to detect entry into a rendered table. Entry from above opens the top-left heade
 opens the first cell of the final row at the start of its last line. Other vertical movement remains owned by the main
 editor.
 
+Inside a nested editor, plain ArrowUp from the header's visual top boundary exits to the blank line above the table.
+Plain ArrowDown from the final row's visual bottom boundary exits to the blank line below it. The active cell is cleared,
+the nested editor closes through the normal lifecycle, and focus returns to the main editor.
+
 ### Scrolling
 
 Primary cell navigation opens the target nested editor, then focuses its `contentDOM`. The browser scrolls that focused

--- a/docs/Architecture/Interaction-and-Navigation.md
+++ b/docs/Architecture/Interaction-and-Navigation.md
@@ -12,10 +12,10 @@ Cells are separate editor instances (or `<td>` when inactive). Key events are in
 | **ArrowLeft/Right** | Navigate Cell | At boundary, jumps to prev/next cell.                     |
 | **ArrowUp/Down**    | Navigate Line | At visual top/bottom boundary, jumps to cell above/below. |
 
-From the main editor, Backspace or Delete stops before it can remove the final line break adjoining a rendered table or
-any of the table's hidden Markdown. The first deletion selects the complete cell grid; subsequent deletion uses the
-normal multi-cell removal behavior. Extra blank lines between the caret and table remain ordinary editable text. A
-transaction filter applies the same protection to mobile soft-keyboard deletions that do not produce a usable keydown.
+From the main editor, hardware Backspace or Delete stops before it can remove the final line break adjoining a rendered
+table or any of the table's hidden Markdown. The first deletion selects the complete cell grid; subsequent deletion uses
+the normal multi-cell removal behavior. Extra blank lines between the caret and table remain ordinary editable text.
+Soft-keyboard and IME deletions are left to CodeMirror's platform behavior and are not intercepted by this extension.
 
 Plain ArrowDown/ArrowUp from the main editor uses CodeMirror's visual movement target and the document range it crossed
 to detect entry into a rendered table. Entry from above opens the top-left header cell at its start; entry from below

--- a/docs/Architecture/Interaction-and-Navigation.md
+++ b/docs/Architecture/Interaction-and-Navigation.md
@@ -17,9 +17,10 @@ any of the table's hidden Markdown. The first deletion selects the complete cell
 normal multi-cell removal behavior. Extra blank lines between the caret and table remain ordinary editable text. A
 transaction filter applies the same protection to mobile soft-keyboard deletions that do not produce a usable keydown.
 
-Plain ArrowDown/ArrowUp from the main editor uses CodeMirror's visual movement target to detect entry into a rendered
-table. Entry from above opens the top-left header cell at its start; entry from below opens the first cell of the final
-row at the start of its last line. Other vertical movement remains owned by the main editor.
+Plain ArrowDown/ArrowUp from the main editor uses CodeMirror's visual movement target and the document range it crossed
+to detect entry into a rendered table. Entry from above opens the top-left header cell at its start; entry from below
+opens the first cell of the final row at the start of its last line. Other vertical movement remains owned by the main
+editor.
 
 ### Scrolling
 

--- a/docs/Architecture/Interaction-and-Navigation.md
+++ b/docs/Architecture/Interaction-and-Navigation.md
@@ -12,6 +12,11 @@ Cells are separate editor instances (or `<td>` when inactive). Key events are in
 | **ArrowLeft/Right** | Navigate Cell | At boundary, jumps to prev/next cell.                     |
 | **ArrowUp/Down**    | Navigate Line | At visual top/bottom boundary, jumps to cell above/below. |
 
+From the main editor, Backspace or Delete stops before it can remove the final line break adjoining a rendered table or
+any of the table's hidden Markdown. The first deletion selects the complete cell grid; subsequent deletion uses the
+normal multi-cell removal behavior. Extra blank lines between the caret and table remain ordinary editable text. A
+transaction filter applies the same protection to mobile soft-keyboard deletions that do not produce a usable keydown.
+
 ### Scrolling
 
 Primary cell navigation opens the target nested editor, then focuses its `contentDOM`. The browser scrolls that focused

--- a/docs/Architecture/Interaction-and-Navigation.md
+++ b/docs/Architecture/Interaction-and-Navigation.md
@@ -17,6 +17,11 @@ table or any of the table's hidden Markdown. The first deletion selects the comp
 the normal multi-cell removal behavior. Extra blank lines between the caret and table remain ordinary editable text.
 Soft-keyboard and IME deletions are left to CodeMirror's platform behavior and are not intercepted by this extension.
 
+While a cell selection is live the caret is parked at the focus cell's document position so clipboard and shortcut
+handling keep working, and the main editor's caret is hidden so the highlight alone conveys the state. An unmodified
+arrow key collapses the selection and moves the caret out of the table, the way an arrow key collapses a text selection;
+Shift+Arrow extends it instead. Any other command that moves the caret outside the selected table drops the selection.
+
 Plain ArrowDown/ArrowUp from the main editor detects entry into a rendered table from the visual movement target, or,
 when that target overshoots, from the block the movement stepped over. CodeMirror's vertical motion deliberately scans
 past block widgets, so a movement toward a table usually lands on the far side of it; the block adjacent to the caret's

--- a/docs/Architecture/Interaction-and-Navigation.md
+++ b/docs/Architecture/Interaction-and-Navigation.md
@@ -17,6 +17,10 @@ any of the table's hidden Markdown. The first deletion selects the complete cell
 normal multi-cell removal behavior. Extra blank lines between the caret and table remain ordinary editable text. A
 transaction filter applies the same protection to mobile soft-keyboard deletions that do not produce a usable keydown.
 
+Plain ArrowDown/ArrowUp from the main editor uses CodeMirror's visual movement target to detect entry into a rendered
+table. Entry from above opens the top-left header cell at its start; entry from below opens the first cell of the final
+row at the start of its last line. Other vertical movement remains owned by the main editor.
+
 ### Scrolling
 
 Primary cell navigation opens the target nested editor, then focuses its `contentDOM`. The browser scrolls that focused

--- a/docs/Architecture/Interaction-and-Navigation.md
+++ b/docs/Architecture/Interaction-and-Navigation.md
@@ -17,10 +17,12 @@ table or any of the table's hidden Markdown. The first deletion selects the comp
 the normal multi-cell removal behavior. Extra blank lines between the caret and table remain ordinary editable text.
 Soft-keyboard and IME deletions are left to CodeMirror's platform behavior and are not intercepted by this extension.
 
-Plain ArrowDown/ArrowUp from the main editor uses CodeMirror's visual movement target and the document range it crossed
-to detect entry into a rendered table. Entry from above opens the top-left header cell at its start; entry from below
-opens the first cell of the final row at the start of its last line. Other vertical movement remains owned by the main
-editor.
+Plain ArrowDown/ArrowUp from the main editor detects entry into a rendered table from the visual movement target, or,
+when that target overshoots, from the block the movement stepped over. CodeMirror's vertical motion deliberately scans
+past block widgets, so a movement toward a table usually lands on the far side of it; the block adjacent to the caret's
+own line block is then the one that was skipped, and a replaced block there identifies the table. Entry from above opens
+the top-left header cell at its start; entry from below opens the first cell of the final row at the start of its last
+line. Other vertical movement remains owned by the main editor.
 
 Inside a nested editor, plain ArrowUp from the header's visual top boundary exits to the blank line above the table.
 Plain ArrowDown from the final row's visual bottom boundary exits to the blank line below it. The active cell is cleared,

--- a/docs/Architecture/Interaction-and-Navigation.md
+++ b/docs/Architecture/Interaction-and-Navigation.md
@@ -14,7 +14,8 @@ Cells are separate editor instances (or `<td>` when inactive). Key events are in
 
 From the main editor, hardware Backspace or Delete stops before it can remove the final line break adjoining a rendered
 table or any of the table's hidden Markdown. The first deletion selects the complete cell grid; subsequent deletion uses
-the normal multi-cell removal behavior. Extra blank lines between the caret and table remain ordinary editable text.
+the normal multi-cell removal behavior. Platform-standard word/line deletion shortcuts and Shift+Backspace receive the
+same protection. Extra blank lines between the caret and table remain ordinary editable text.
 Soft-keyboard and IME deletions are left to CodeMirror's platform behavior and are not intercepted by this extension.
 
 While a cell selection is live the caret is parked at the focus cell's document position so clipboard and shortcut

--- a/src/contentScript/__tests__/cellSelectionKeymap.test.ts
+++ b/src/contentScript/__tests__/cellSelectionKeymap.test.ts
@@ -299,9 +299,51 @@ describe('cellSelectionKeymap', () => {
         expect(getCellSelection(view.state)).toEqual({ tableFrom: 0, anchor, focus: expected });
     });
 
-    it.each(['ArrowRight', 'ArrowLeft', 'ArrowDown', 'ArrowUp'])('ignores %s without Shift', (key) => {
-        const view = mountSelectionView(GRID_DOC);
+    it.each([
+        { key: 'ArrowDown', edge: 'after' },
+        { key: 'ArrowRight', edge: 'after' },
+        { key: 'ArrowUp', edge: 'before' },
+        { key: 'ArrowLeft', edge: 'before' },
+    ])('collapses the selection $edge the table on $key without Shift', ({ key, edge }) => {
+        const prefix = 'above';
+        const view = mountSelectionView(`${prefix}\n${GRID_DOC}\nbelow`);
+        const tableFrom = prefix.length + 1;
+        view.dispatch({
+            effects: setCellSelectionEffect.of({
+                tableFrom,
+                anchor: { section: 'header', row: 0, col: 0 },
+                focus: { section: 'body', row: 1, col: 2 },
+            }),
+        });
 
+        pressKey({ key });
+
+        expect(getCellSelection(view.state)).toBeNull();
+        expect(view.state.selection.main.head).toBe(
+            edge === 'before' ? tableFrom - 1 : tableFrom + GRID_DOC.length + 1
+        );
+    });
+
+    it.each(['ArrowRight', 'ArrowLeft', 'ArrowDown', 'ArrowUp'])(
+        'drops the selection on %s when the table has no adjacent line',
+        (key) => {
+            const view = mountSelectionView(GRID_DOC);
+            view.dispatch({
+                effects: setCellSelectionEffect.of({
+                    tableFrom: 0,
+                    anchor: { section: 'body', row: 0, col: 1 },
+                    focus: { section: 'body', row: 0, col: 1 },
+                }),
+            });
+
+            pressKey({ key });
+
+            expect(getCellSelection(view.state)).toBeNull();
+        }
+    );
+
+    it.each(['ArrowRight', 'ArrowDown'])('leaves %s with a modifier to the main editor', (key) => {
+        const view = mountSelectionView(GRID_DOC);
         const selection = {
             tableFrom: 0,
             anchor: { section: 'body', row: 0, col: 1 },
@@ -309,7 +351,7 @@ describe('cellSelectionKeymap', () => {
         } as const;
         view.dispatch({ effects: setCellSelectionEffect.of(selection) });
 
-        pressKey({ key });
+        pressKey({ key, ctrlKey: true });
 
         expect(getCellSelection(view.state)).toEqual(selection);
     });

--- a/src/contentScript/__tests__/cellSelectionKeymap.test.ts
+++ b/src/contentScript/__tests__/cellSelectionKeymap.test.ts
@@ -45,6 +45,7 @@ function pressKey(init: KeyboardEventInit & { key: string }): void {
 }
 
 afterEach(() => {
+    vi.restoreAllMocks();
     // Destroy here rather than per-test so a failing assertion cannot leak the
     // plugin's document-level keydown listener into the next test.
     while (mountedViews.length > 0) {
@@ -157,7 +158,52 @@ describe('cellSelectionKeymap', () => {
         });
     });
 
-    it.each(['shiftKey', 'altKey', 'ctrlKey', 'metaKey'] as const)('ignores Delete combined with %s', (modifier) => {
+    it.each([
+        { label: 'Ctrl+Backspace', init: { key: 'Backspace', ctrlKey: true } },
+        { label: 'Ctrl+Delete', init: { key: 'Delete', ctrlKey: true } },
+        { label: 'Shift+Backspace', init: { key: 'Backspace', shiftKey: true } },
+    ])('routes $label through selection removal', ({ init }) => {
+        const view = mountSelectionView(['| H1 | H2 |', '| --- | --- |', '| a1 | a2 |'].join('\n'));
+
+        view.dispatch({
+            effects: setCellSelectionEffect.of({
+                tableFrom: 0,
+                anchor: { section: 'body', row: 0, col: 0 },
+                focus: { section: 'body', row: 0, col: 1 },
+            }),
+        });
+
+        pressKey(init);
+
+        expect(view.state.doc.toString()).toBe(['| H1 | H2 |', '| --- | --- |', '|  |  |'].join('\n'));
+    });
+
+    it.each([
+        { label: 'Option+Backspace', init: { key: 'Backspace', altKey: true } },
+        { label: 'Option+Delete', init: { key: 'Delete', altKey: true } },
+        { label: 'Command+Backspace', init: { key: 'Backspace', metaKey: true } },
+        { label: 'Command+Delete', init: { key: 'Delete', metaKey: true } },
+    ])('routes $label through selection removal on macOS', ({ init }) => {
+        vi.spyOn(window.navigator, 'platform', 'get').mockReturnValue('MacIntel');
+        const view = mountSelectionView(['| H1 | H2 |', '| --- | --- |', '| a1 | a2 |'].join('\n'));
+
+        view.dispatch({
+            effects: setCellSelectionEffect.of({
+                tableFrom: 0,
+                anchor: { section: 'body', row: 0, col: 0 },
+                focus: { section: 'body', row: 0, col: 1 },
+            }),
+        });
+
+        pressKey(init);
+
+        expect(view.state.doc.toString()).toBe(['| H1 | H2 |', '| --- | --- |', '|  |  |'].join('\n'));
+    });
+
+    it.each([
+        { label: 'Shift+Delete', modifiers: { shiftKey: true } },
+        { label: 'Ctrl+Alt+Delete', modifiers: { ctrlKey: true, altKey: true } },
+    ])('ignores $label because it is not a CodeMirror deletion command', ({ modifiers }) => {
         const initialDoc = ['| H1 | H2 |', '| --- | --- |', '| a1 | a2 |'].join('\n');
         const view = mountSelectionView(initialDoc);
 
@@ -169,7 +215,7 @@ describe('cellSelectionKeymap', () => {
             }),
         });
 
-        pressKey({ key: 'Delete', [modifier]: true });
+        pressKey({ key: 'Delete', ...modifiers });
 
         expect(view.state.doc.toString()).toBe(initialDoc);
     });

--- a/src/contentScript/__tests__/cellSelectionScopeGuard.test.ts
+++ b/src/contentScript/__tests__/cellSelectionScopeGuard.test.ts
@@ -1,0 +1,111 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { markdown } from '@codemirror/lang-markdown';
+import { EditorView } from '@codemirror/view';
+import { GFM } from '@lezer/markdown';
+import { afterEach, describe, expect, it } from 'vitest';
+import { activeCellField } from '../tableState/activeCellState';
+import { cellSelectionField, getCellSelection, setCellSelectionEffect } from '../tableState/cellSelectionState';
+import { selectWholeTable } from '../tableRuntime/selection/cellSelectionController';
+import { cellSelectionScopeGuard } from '../tableRuntime/selection/cellSelectionScopeGuard';
+import { resolveTableContextAtPos } from '../tableRuntime/tableResolution';
+
+const TABLE = ['| H1 | H2 |', '| --- | --- |', '| a1 | a2 |'].join('\n');
+const PREFIX = 'above';
+const DOC = `${PREFIX}\n${TABLE}\nbelow`;
+const TABLE_FROM = PREFIX.length + 1;
+const TABLE_TO = TABLE_FROM + TABLE.length;
+
+const mountedViews: EditorView[] = [];
+
+function mountView(): EditorView {
+    const parent = document.createElement('div');
+    document.body.appendChild(parent);
+
+    const view = new EditorView({
+        parent,
+        doc: DOC,
+        extensions: [markdown({ extensions: [GFM] }), activeCellField, cellSelectionField, cellSelectionScopeGuard],
+    });
+    mountedViews.push(view);
+
+    return view;
+}
+
+/** The guard defers its clear to an animation frame; jsdom runs those on a timer. */
+function flushFrames(): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, 32));
+}
+
+function selectTable(view: EditorView): void {
+    const ctx = resolveTableContextAtPos(view.state, TABLE_FROM);
+    expect(ctx).not.toBeNull();
+    expect(selectWholeTable(view, ctx!, 'end')).toBe(true);
+}
+
+afterEach(() => {
+    while (mountedViews.length > 0) {
+        mountedViews.pop()?.destroy();
+    }
+    document.body.replaceChildren();
+});
+
+describe('cellSelectionScopeGuard', () => {
+    it('drops the selection when a main-editor command moves the caret out of the table', async () => {
+        const view = mountView();
+        selectTable(view);
+        expect(getCellSelection(view.state)).not.toBeNull();
+
+        // Stands in for any unhandled movement command, e.g. Ctrl+Home.
+        view.dispatch({ selection: { anchor: 0 } });
+        await flushFrames();
+
+        expect(getCellSelection(view.state)).toBeNull();
+    });
+
+    it('keeps the selection while the caret stays inside the table', async () => {
+        const view = mountView();
+        selectTable(view);
+
+        view.dispatch({ selection: { anchor: TABLE_TO - 1 } });
+        await flushFrames();
+
+        expect(getCellSelection(view.state)).not.toBeNull();
+    });
+
+    it('keeps the selection through the transitions that establish it', async () => {
+        const view = mountView();
+        selectTable(view);
+        await flushFrames();
+
+        expect(getCellSelection(view.state)).not.toBeNull();
+    });
+
+    it('drops the selection when only one end of a range leaves the table', async () => {
+        const view = mountView();
+        selectTable(view);
+
+        view.dispatch({ selection: { anchor: TABLE_TO - 1, head: DOC.length } });
+        await flushFrames();
+
+        expect(getCellSelection(view.state)).toBeNull();
+    });
+
+    it('leaves a selection whose table no longer resolves to the existing cleanup paths', async () => {
+        const view = mountView();
+        view.dispatch({
+            effects: setCellSelectionEffect.of({
+                tableFrom: DOC.length,
+                anchor: { section: 'header', row: 0, col: 0 },
+                focus: { section: 'header', row: 0, col: 0 },
+            }),
+        });
+
+        view.dispatch({ selection: { anchor: 0 } });
+        await flushFrames();
+
+        expect(getCellSelection(view.state)).not.toBeNull();
+    });
+});

--- a/src/contentScript/__tests__/cellSelectionVisuals.test.ts
+++ b/src/contentScript/__tests__/cellSelectionVisuals.test.ts
@@ -1,0 +1,60 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { markdown } from '@codemirror/lang-markdown';
+import { EditorView } from '@codemirror/view';
+import { GFM } from '@lezer/markdown';
+import { afterEach, describe, expect, it } from 'vitest';
+import { activeCellField } from '../tableState/activeCellState';
+import { cellSelectionField, clearCellSelectionEffect } from '../tableState/cellSelectionState';
+import { selectWholeTable } from '../tableRuntime/selection/cellSelectionController';
+import { resolveTableContextAtPos } from '../tableRuntime/tableResolution';
+import { cellSelectionCaretSuppression } from '../tableWidget/cellSelectionVisuals';
+
+const TABLE = ['| H1 | H2 |', '| --- | --- |', '| a1 | a2 |'].join('\n');
+const DOC = `above\n${TABLE}\nbelow`;
+const TABLE_FROM = 'above'.length + 1;
+
+const mountedViews: EditorView[] = [];
+
+function mountView(): EditorView {
+    const parent = document.createElement('div');
+    document.body.appendChild(parent);
+
+    const view = new EditorView({
+        parent,
+        doc: DOC,
+        extensions: [
+            markdown({ extensions: [GFM] }),
+            activeCellField,
+            cellSelectionField,
+            cellSelectionCaretSuppression,
+        ],
+    });
+    mountedViews.push(view);
+
+    return view;
+}
+
+afterEach(() => {
+    while (mountedViews.length > 0) {
+        mountedViews.pop()?.destroy();
+    }
+    document.body.replaceChildren();
+});
+
+describe('cellSelectionCaretSuppression', () => {
+    it('marks the editor while a cell selection is active and unmarks it afterwards', () => {
+        const view = mountView();
+        expect(view.dom.hasAttribute('data-rt-cell-selection')).toBe(false);
+
+        const ctx = resolveTableContextAtPos(view.state, TABLE_FROM);
+        expect(ctx).not.toBeNull();
+        expect(selectWholeTable(view, ctx!, 'end')).toBe(true);
+        expect(view.dom.hasAttribute('data-rt-cell-selection')).toBe(true);
+
+        view.dispatch({ effects: clearCellSelectionEffect.of(undefined) });
+        expect(view.dom.hasAttribute('data-rt-cell-selection')).toBe(false);
+    });
+});

--- a/src/contentScript/__tests__/mainEditorTableEntry.test.ts
+++ b/src/contentScript/__tests__/mainEditorTableEntry.test.ts
@@ -163,13 +163,38 @@ describe('mainEditorTableEntry deletion protection', () => {
         expect(getCellSelection(view.state)).toBeNull();
     });
 
-    it('does not intercept modified deletion keys', () => {
-        const doc = `${TABLE}\nafter`;
-        const view = mountView(doc, TABLE.length + 1);
+    it.each([
+        {
+            label: 'Ctrl+Backspace',
+            key: 'Backspace',
+            modifiers: { ctrlKey: true },
+            doc: `${TABLE}\nafter`,
+            caret: TABLE.length + 1,
+            focusEdge: 'end' as const,
+        },
+        {
+            label: 'Ctrl+Delete',
+            key: 'Delete',
+            modifiers: { ctrlKey: true },
+            doc: `before\n${TABLE}`,
+            caret: 'before'.length,
+            focusEdge: 'start' as const,
+        },
+        {
+            label: 'Shift+Backspace',
+            key: 'Backspace',
+            modifiers: { shiftKey: true },
+            doc: `${TABLE}\nafter`,
+            caret: TABLE.length + 1,
+            focusEdge: 'end' as const,
+        },
+    ])('protects the table from $label', ({ key, modifiers, doc, caret, focusEdge }) => {
+        const view = mountView(doc, caret);
 
-        pressKey(view, 'Backspace', { altKey: true });
+        pressKey(view, key, modifiers);
 
-        expect(getCellSelection(view.state)).toBeNull();
+        expect(view.state.doc.toString()).toBe(doc);
+        expectWholeTableSelection(view, focusEdge);
     });
 
     it('does not enter selection mode while an active cell exists', () => {

--- a/src/contentScript/__tests__/mainEditorTableEntry.test.ts
+++ b/src/contentScript/__tests__/mainEditorTableEntry.test.ts
@@ -245,12 +245,12 @@ describe('mainEditorTableEntry deletion protection', () => {
 });
 
 describe('mainEditorTableEntry vertical movement', () => {
-    it('opens the top-left header cell when ArrowDown enters from above', () => {
+    it('opens the top-left header cell when ArrowDown skips across the table widget', () => {
         const prefix = 'above';
-        const doc = `${prefix}\n${TABLE}`;
+        const doc = `${prefix}\n${TABLE}\nbelow`;
         const tableFrom = prefix.length + 1;
         const view = mountView(doc, prefix.length);
-        mockVerticalTarget(view, tableFrom);
+        mockVerticalTarget(view, tableFrom + TABLE.length + 1);
 
         pressKey(view, 'ArrowDown');
 
@@ -265,15 +265,17 @@ describe('mainEditorTableEntry vertical movement', () => {
         });
     });
 
-    it('opens the bottom-left body cell when ArrowUp enters from below', () => {
-        const doc = `${TABLE}\nbelow`;
-        const view = mountView(doc, TABLE.length + 1);
-        mockVerticalTarget(view, TABLE.length);
+    it('opens the bottom-left body cell when ArrowUp skips across the table widget', () => {
+        const prefix = 'above';
+        const doc = `${prefix}\n${TABLE}\nbelow`;
+        const tableFrom = prefix.length + 1;
+        const view = mountView(doc, tableFrom + TABLE.length + 1);
+        mockVerticalTarget(view, prefix.length);
 
         pressKey(view, 'ArrowUp');
 
         expect(getActiveCell(view.state)).toEqual({
-            tableFrom: 0,
+            tableFrom,
             section: 'body',
             row: 1,
             col: 0,

--- a/src/contentScript/__tests__/mainEditorTableEntry.test.ts
+++ b/src/contentScript/__tests__/mainEditorTableEntry.test.ts
@@ -5,7 +5,7 @@
 import { defaultKeymap } from '@codemirror/commands';
 import { EditorSelection, EditorState } from '@codemirror/state';
 import { EditorView, keymap } from '@codemirror/view';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { activeCellField, getActiveCell, setActiveCellEffect } from '../tableState/activeCellState';
 import { cellSelectionField, getCellSelection } from '../tableState/cellSelectionState';
 import { searchForceSourceModeField, setSearchForceSourceModeEffect } from '../tableState/searchForceSourceMode';
@@ -13,11 +13,19 @@ import { sourceModeField, toggleSourceModeEffect } from '../tableState/sourceMod
 import { mainEditorTableEntryExtension } from '../tableRuntime/navigation/mainEditorTableEntry';
 import { getPendingOpenCellRequest, openCellRequestField } from '../tableRuntime/openCellRequest';
 import { cellSelectionKeyCapturePlugin } from '../tableRuntime/selection/cellSelectionKeymap';
+import { tableDecorationField } from '../tableWidget/tableDecorationField';
 import { createMarkdownState } from './testMarkdownState';
 
 const TABLE = ['| H1 | H2 |', '| --- | --- |', '| a1 | a2 |', '| b1 | b2 |'].join('\n');
 const EMPTY_TABLE = ['|  |  |', '| --- | --- |', '|  |  |', '|  |  |'].join('\n');
 const mountedViews: EditorView[] = [];
+
+/** TableWidget observes its own DOM for height changes; jsdom has no ResizeObserver. */
+class ResizeObserverMock {
+    observe(): void {}
+    unobserve(): void {}
+    disconnect(): void {}
+}
 
 function mountView(doc: string, selection: number | { anchor: number; head: number }): EditorView {
     const parent = document.createElement('div');
@@ -31,6 +39,9 @@ function mountView(doc: string, selection: number | { anchor: number; head: numb
             searchForceSourceModeField,
             sourceModeField,
             openCellRequestField,
+            // Tables must render as block replace decorations: vertical entry reads the
+            // block structure to find the table a movement stepped over.
+            tableDecorationField,
             EditorState.allowMultipleSelections.of(true),
             mainEditorTableEntryExtension,
             cellSelectionKeyCapturePlugin,
@@ -65,8 +76,13 @@ function expectWholeTableSelection(view: EditorView, focusEdge: 'start' | 'end')
     );
 }
 
+beforeEach(() => {
+    vi.stubGlobal('ResizeObserver', ResizeObserverMock as unknown as typeof ResizeObserver);
+});
+
 afterEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
     while (mountedViews.length > 0) {
         mountedViews.pop()?.destroy();
     }
@@ -291,6 +307,30 @@ describe('mainEditorTableEntry vertical movement', () => {
         pressKey(view, 'ArrowDown');
 
         expect(getActiveCell(view.state)).toBeNull();
+    });
+
+    it('does not enter the table below when the movement stays inside a wrapped line', () => {
+        const wrappedLine = 'a fairly long paragraph that wraps across several visual lines';
+        const doc = `${wrappedLine}\n${TABLE}`;
+        const view = mountView(doc, 2);
+        // A wrapped-line step lands further along the same line block, still short of the table.
+        mockVerticalTarget(view, 20);
+
+        pressKey(view, 'ArrowDown');
+
+        expect(getActiveCell(view.state)).toBeNull();
+        expect(getPendingOpenCellRequest(view.state)).toBeNull();
+    });
+
+    it('does not enter a table when the movement lands on an ordinary neighbouring line', () => {
+        const doc = `above\nmiddle\n${TABLE}`;
+        const view = mountView(doc, 5);
+        mockVerticalTarget(view, 8);
+
+        pressKey(view, 'ArrowDown');
+
+        expect(getActiveCell(view.state)).toBeNull();
+        expect(getPendingOpenCellRequest(view.state)).toBeNull();
     });
 
     it('does not intercept a non-collapsed vertical selection', () => {

--- a/src/contentScript/__tests__/mainEditorTableEntry.test.ts
+++ b/src/contentScript/__tests__/mainEditorTableEntry.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { defaultKeymap } from '@codemirror/commands';
-import { EditorSelection, EditorState, Transaction } from '@codemirror/state';
+import { EditorSelection, EditorState } from '@codemirror/state';
 import { EditorView, keymap } from '@codemirror/view';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { activeCellField, getActiveCell, setActiveCellEffect } from '../tableState/activeCellState';
@@ -124,41 +124,6 @@ describe('mainEditorTableEntry deletion protection', () => {
     });
 
     it.each([
-        { label: 'backward', direction: 'backward' as const, doc: `${TABLE}\nafter`, caret: TABLE.length + 1 },
-        {
-            label: 'forward',
-            direction: 'forward' as const,
-            doc: `before\n${TABLE}`,
-            caret: 'before'.length,
-        },
-    ])('rewrites a soft-keyboard $label deletion into the same table selection', ({ direction, doc, caret }) => {
-        const view = mountView(doc, caret);
-        const changes =
-            direction === 'backward' ? { from: TABLE.length, to: TABLE.length + 1 } : { from: caret, to: caret + 1 };
-
-        view.dispatch({
-            changes,
-            annotations: Transaction.userEvent.of('input.type'),
-        });
-
-        expect(view.state.doc.toString()).toBe(doc);
-        expectWholeTableSelection(view, direction === 'backward' ? 'end' : 'start');
-    });
-
-    it('rewrites an explicit delete.backward transaction', () => {
-        const doc = `${TABLE}\nafter`;
-        const view = mountView(doc, TABLE.length + 1);
-
-        view.dispatch({
-            changes: { from: TABLE.length, to: TABLE.length + 1 },
-            annotations: Transaction.userEvent.of('delete.backward'),
-        });
-
-        expect(view.state.doc.toString()).toBe(doc);
-        expectWholeTableSelection(view, 'end');
-    });
-
-    it.each([
         { label: 'source mode', effect: toggleSourceModeEffect.of(true) },
         { label: 'search-forced raw mode', effect: setSearchForceSourceModeEffect.of(true) },
     ])('leaves table Markdown editable in $label', ({ effect }) => {
@@ -205,19 +170,6 @@ describe('mainEditorTableEntry deletion protection', () => {
 
         pressKey(view, 'Backspace');
 
-        expect(getCellSelection(view.state)).toBeNull();
-    });
-
-    it('does not rewrite input.type changes that insert replacement text', () => {
-        const doc = `${TABLE}\nafter`;
-        const view = mountView(doc, TABLE.length + 1);
-
-        view.dispatch({
-            changes: { from: TABLE.length, to: TABLE.length + 1, insert: 'x' },
-            annotations: Transaction.userEvent.of('input.type'),
-        });
-
-        expect(view.state.doc.toString()).toBe(`${TABLE}xafter`);
         expect(getCellSelection(view.state)).toBeNull();
     });
 

--- a/src/contentScript/__tests__/mainEditorTableEntry.test.ts
+++ b/src/contentScript/__tests__/mainEditorTableEntry.test.ts
@@ -1,0 +1,240 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { defaultKeymap } from '@codemirror/commands';
+import { EditorSelection, EditorState, Transaction } from '@codemirror/state';
+import { EditorView, keymap } from '@codemirror/view';
+import { afterEach, describe, expect, it } from 'vitest';
+import { activeCellField, setActiveCellEffect } from '../tableState/activeCellState';
+import { cellSelectionField, getCellSelection } from '../tableState/cellSelectionState';
+import { searchForceSourceModeField, setSearchForceSourceModeEffect } from '../tableState/searchForceSourceMode';
+import { sourceModeField, toggleSourceModeEffect } from '../tableState/sourceMode';
+import { mainEditorTableEntryExtension } from '../tableRuntime/navigation/mainEditorTableEntry';
+import { openCellRequestField } from '../tableRuntime/openCellRequest';
+import { cellSelectionKeyCapturePlugin } from '../tableRuntime/selection/cellSelectionKeymap';
+import { createMarkdownState } from './testMarkdownState';
+
+const TABLE = ['| H1 | H2 |', '| --- | --- |', '| a1 | a2 |', '| b1 | b2 |'].join('\n');
+const EMPTY_TABLE = ['|  |  |', '| --- | --- |', '|  |  |', '|  |  |'].join('\n');
+const mountedViews: EditorView[] = [];
+
+function mountView(doc: string, selection: number | { anchor: number; head: number }): EditorView {
+    const parent = document.createElement('div');
+    document.body.appendChild(parent);
+
+    const view = new EditorView({
+        parent,
+        state: createMarkdownState(doc, [
+            activeCellField,
+            cellSelectionField,
+            searchForceSourceModeField,
+            sourceModeField,
+            openCellRequestField,
+            EditorState.allowMultipleSelections.of(true),
+            mainEditorTableEntryExtension,
+            cellSelectionKeyCapturePlugin,
+            keymap.of(defaultKeymap),
+        ]),
+    });
+    view.dispatch({ selection: typeof selection === 'number' ? { anchor: selection } : selection });
+    view.contentDOM.focus();
+    mountedViews.push(view);
+    return view;
+}
+
+function pressKey(view: EditorView, key: string, modifiers: KeyboardEventInit = {}): void {
+    view.contentDOM.dispatchEvent(
+        new KeyboardEvent('keydown', {
+            key,
+            bubbles: true,
+            cancelable: true,
+            ...modifiers,
+        })
+    );
+}
+
+function expectWholeTableSelection(view: EditorView, focusEdge: 'start' | 'end'): void {
+    const start = { section: 'header', row: 0, col: 0 } as const;
+    const end = { section: 'body', row: 1, col: 1 } as const;
+
+    expect(getCellSelection(view.state)).toEqual(
+        focusEdge === 'start'
+            ? { tableFrom: view.state.doc.toString().indexOf(TABLE), anchor: end, focus: start }
+            : { tableFrom: view.state.doc.toString().indexOf(TABLE), anchor: start, focus: end }
+    );
+}
+
+afterEach(() => {
+    while (mountedViews.length > 0) {
+        mountedViews.pop()?.destroy();
+    }
+    document.body.replaceChildren();
+});
+
+describe('mainEditorTableEntry deletion protection', () => {
+    it('selects the entire table when Backspace reaches it from below', () => {
+        const doc = `${TABLE}\nafter`;
+        const view = mountView(doc, TABLE.length + 1);
+
+        pressKey(view, 'Backspace');
+
+        expect(view.state.doc.toString()).toBe(doc);
+        expectWholeTableSelection(view, 'end');
+    });
+
+    it('selects the entire table when Delete reaches it from above', () => {
+        const prefix = 'before';
+        const doc = `${prefix}\n${TABLE}`;
+        const view = mountView(doc, prefix.length);
+
+        pressKey(view, 'Delete');
+
+        expect(view.state.doc.toString()).toBe(doc);
+        expectWholeTableSelection(view, 'start');
+    });
+
+    it('deletes extra blank lines normally before protecting the final table boundary', () => {
+        const doc = `${TABLE}\n\nafter`;
+        const view = mountView(doc, TABLE.length + 2);
+
+        pressKey(view, 'Backspace');
+        expect(view.state.doc.toString()).toBe(`${TABLE}\nafter`);
+        expect(getCellSelection(view.state)).toBeNull();
+
+        pressKey(view, 'Backspace');
+        expect(view.state.doc.toString()).toBe(`${TABLE}\nafter`);
+        expectWholeTableSelection(view, 'end');
+    });
+
+    it('routes the next Backspace through the existing multi-cell removal behavior', () => {
+        const doc = `${TABLE}\nafter`;
+        const view = mountView(doc, TABLE.length + 1);
+
+        pressKey(view, 'Backspace');
+        pressKey(view, 'Backspace');
+
+        expect(view.state.doc.toString()).toBe(`${EMPTY_TABLE}\nafter`);
+        expect(getCellSelection(view.state)).not.toBeNull();
+    });
+
+    it.each([
+        { label: 'backward', direction: 'backward' as const, doc: `${TABLE}\nafter`, caret: TABLE.length + 1 },
+        {
+            label: 'forward',
+            direction: 'forward' as const,
+            doc: `before\n${TABLE}`,
+            caret: 'before'.length,
+        },
+    ])('rewrites a soft-keyboard $label deletion into the same table selection', ({ direction, doc, caret }) => {
+        const view = mountView(doc, caret);
+        const changes =
+            direction === 'backward' ? { from: TABLE.length, to: TABLE.length + 1 } : { from: caret, to: caret + 1 };
+
+        view.dispatch({
+            changes,
+            annotations: Transaction.userEvent.of('input.type'),
+        });
+
+        expect(view.state.doc.toString()).toBe(doc);
+        expectWholeTableSelection(view, direction === 'backward' ? 'end' : 'start');
+    });
+
+    it('rewrites an explicit delete.backward transaction', () => {
+        const doc = `${TABLE}\nafter`;
+        const view = mountView(doc, TABLE.length + 1);
+
+        view.dispatch({
+            changes: { from: TABLE.length, to: TABLE.length + 1 },
+            annotations: Transaction.userEvent.of('delete.backward'),
+        });
+
+        expect(view.state.doc.toString()).toBe(doc);
+        expectWholeTableSelection(view, 'end');
+    });
+
+    it.each([
+        { label: 'source mode', effect: toggleSourceModeEffect.of(true) },
+        { label: 'search-forced raw mode', effect: setSearchForceSourceModeEffect.of(true) },
+    ])('leaves table Markdown editable in $label', ({ effect }) => {
+        const doc = `${TABLE}\nafter`;
+        const view = mountView(doc, TABLE.length + 1);
+        view.dispatch({ effects: effect });
+
+        pressKey(view, 'Backspace');
+
+        expect(view.state.doc.toString()).not.toBe(doc);
+        expect(getCellSelection(view.state)).toBeNull();
+    });
+
+    it('does not intercept deletion for a non-collapsed selection', () => {
+        const doc = `${TABLE}\nafter`;
+        const view = mountView(doc, { anchor: TABLE.length + 1, head: TABLE.length + 'after'.length + 1 });
+
+        pressKey(view, 'Backspace');
+
+        expect(view.state.doc.toString()).toBe(`${TABLE}\n`);
+        expect(getCellSelection(view.state)).toBeNull();
+    });
+
+    it('does not intercept modified deletion keys', () => {
+        const doc = `${TABLE}\nafter`;
+        const view = mountView(doc, TABLE.length + 1);
+
+        pressKey(view, 'Backspace', { altKey: true });
+
+        expect(getCellSelection(view.state)).toBeNull();
+    });
+
+    it('does not enter selection mode while an active cell exists', () => {
+        const doc = `${TABLE}\nafter`;
+        const view = mountView(doc, TABLE.length + 1);
+        view.dispatch({
+            effects: setActiveCellEffect.of({
+                tableFrom: 0,
+                section: 'body',
+                row: 1,
+                col: 0,
+            }),
+        });
+
+        pressKey(view, 'Backspace');
+
+        expect(getCellSelection(view.state)).toBeNull();
+    });
+
+    it('does not rewrite input.type changes that insert replacement text', () => {
+        const doc = `${TABLE}\nafter`;
+        const view = mountView(doc, TABLE.length + 1);
+
+        view.dispatch({
+            changes: { from: TABLE.length, to: TABLE.length + 1, insert: 'x' },
+            annotations: Transaction.userEvent.of('input.type'),
+        });
+
+        expect(view.state.doc.toString()).toBe(`${TABLE}xafter`);
+        expect(getCellSelection(view.state)).toBeNull();
+    });
+
+    it('does not intercept movement that stays outside a table', () => {
+        const doc = `text\n\n${TABLE}`;
+        const view = mountView(doc, 6);
+
+        pressKey(view, 'Backspace');
+
+        expect(view.state.doc.toString()).toBe(`text\n${TABLE}`);
+        expect(getCellSelection(view.state)).toBeNull();
+    });
+
+    it('requires a single selection range', () => {
+        const doc = `${TABLE}\nafter`;
+        const view = mountView(doc, TABLE.length + 1);
+        view.dispatch({
+            selection: EditorSelection.create([EditorSelection.cursor(TABLE.length + 1), EditorSelection.cursor(0)]),
+        });
+
+        pressKey(view, 'Backspace');
+
+        expect(getCellSelection(view.state)).toBeNull();
+    });
+});

--- a/src/contentScript/__tests__/mainEditorTableEntry.test.ts
+++ b/src/contentScript/__tests__/mainEditorTableEntry.test.ts
@@ -5,13 +5,13 @@
 import { defaultKeymap } from '@codemirror/commands';
 import { EditorSelection, EditorState, Transaction } from '@codemirror/state';
 import { EditorView, keymap } from '@codemirror/view';
-import { afterEach, describe, expect, it } from 'vitest';
-import { activeCellField, setActiveCellEffect } from '../tableState/activeCellState';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { activeCellField, getActiveCell, setActiveCellEffect } from '../tableState/activeCellState';
 import { cellSelectionField, getCellSelection } from '../tableState/cellSelectionState';
 import { searchForceSourceModeField, setSearchForceSourceModeEffect } from '../tableState/searchForceSourceMode';
 import { sourceModeField, toggleSourceModeEffect } from '../tableState/sourceMode';
 import { mainEditorTableEntryExtension } from '../tableRuntime/navigation/mainEditorTableEntry';
-import { openCellRequestField } from '../tableRuntime/openCellRequest';
+import { getPendingOpenCellRequest, openCellRequestField } from '../tableRuntime/openCellRequest';
 import { cellSelectionKeyCapturePlugin } from '../tableRuntime/selection/cellSelectionKeymap';
 import { createMarkdownState } from './testMarkdownState';
 
@@ -66,11 +66,16 @@ function expectWholeTableSelection(view: EditorView, focusEdge: 'start' | 'end')
 }
 
 afterEach(() => {
+    vi.restoreAllMocks();
     while (mountedViews.length > 0) {
         mountedViews.pop()?.destroy();
     }
     document.body.replaceChildren();
 });
+
+function mockVerticalTarget(view: EditorView, targetPos: number): void {
+    vi.spyOn(view, 'moveVertically').mockReturnValue(EditorSelection.cursor(targetPos));
+}
 
 describe('mainEditorTableEntry deletion protection', () => {
     it('selects the entire table when Backspace reaches it from below', () => {
@@ -236,5 +241,124 @@ describe('mainEditorTableEntry deletion protection', () => {
         pressKey(view, 'Backspace');
 
         expect(getCellSelection(view.state)).toBeNull();
+    });
+});
+
+describe('mainEditorTableEntry vertical movement', () => {
+    it('opens the top-left header cell when ArrowDown enters from above', () => {
+        const prefix = 'above';
+        const doc = `${prefix}\n${TABLE}`;
+        const tableFrom = prefix.length + 1;
+        const view = mountView(doc, prefix.length);
+        mockVerticalTarget(view, tableFrom);
+
+        pressKey(view, 'ArrowDown');
+
+        expect(getActiveCell(view.state)).toEqual({
+            tableFrom,
+            section: 'header',
+            row: 0,
+            col: 0,
+        });
+        expect(getPendingOpenCellRequest(view.state)).toMatchObject({
+            initialCursorPos: 'start',
+        });
+    });
+
+    it('opens the bottom-left body cell when ArrowUp enters from below', () => {
+        const doc = `${TABLE}\nbelow`;
+        const view = mountView(doc, TABLE.length + 1);
+        mockVerticalTarget(view, TABLE.length);
+
+        pressKey(view, 'ArrowUp');
+
+        expect(getActiveCell(view.state)).toEqual({
+            tableFrom: 0,
+            section: 'body',
+            row: 1,
+            col: 0,
+        });
+        expect(getPendingOpenCellRequest(view.state)).toMatchObject({
+            initialCursorPos: 'lastLineStart',
+        });
+    });
+
+    it('opens the header when ArrowUp enters a table with no body rows', () => {
+        const headerOnlyTable = ['| H1 | H2 |', '| --- | --- |'].join('\n');
+        const doc = `${headerOnlyTable}\nbelow`;
+        const view = mountView(doc, headerOnlyTable.length + 1);
+        mockVerticalTarget(view, headerOnlyTable.length);
+
+        pressKey(view, 'ArrowUp');
+
+        expect(getActiveCell(view.state)).toEqual({
+            tableFrom: 0,
+            section: 'header',
+            row: 0,
+            col: 0,
+        });
+        expect(getPendingOpenCellRequest(view.state)).toMatchObject({
+            initialCursorPos: 'lastLineStart',
+        });
+    });
+
+    it.each([
+        { label: 'source mode', effect: toggleSourceModeEffect.of(true) },
+        { label: 'search-forced raw mode', effect: setSearchForceSourceModeEffect.of(true) },
+    ])('leaves vertical movement in the main editor during $label', ({ effect }) => {
+        const prefix = 'above';
+        const doc = `${prefix}\n${TABLE}`;
+        const view = mountView(doc, prefix.length);
+        view.dispatch({ effects: effect });
+        mockVerticalTarget(view, prefix.length + 1);
+
+        pressKey(view, 'ArrowDown');
+
+        expect(getActiveCell(view.state)).toBeNull();
+        expect(getPendingOpenCellRequest(view.state)).toBeNull();
+    });
+
+    it('does not activate a table when vertical movement stays outside it', () => {
+        const prefix = 'above';
+        const doc = `${prefix}\n${TABLE}`;
+        const view = mountView(doc, prefix.length);
+        mockVerticalTarget(view, prefix.length - 1);
+
+        pressKey(view, 'ArrowDown');
+
+        expect(getActiveCell(view.state)).toBeNull();
+    });
+
+    it('requires entry from the side implied by the arrow direction', () => {
+        const doc = `${TABLE}\nbelow`;
+        const view = mountView(doc, TABLE.length + 1);
+        mockVerticalTarget(view, TABLE.length);
+
+        pressKey(view, 'ArrowDown');
+
+        expect(getActiveCell(view.state)).toBeNull();
+    });
+
+    it('does not intercept a non-collapsed vertical selection', () => {
+        const prefix = 'above';
+        const doc = `${prefix}\n${TABLE}`;
+        const view = mountView(doc, { anchor: 0, head: prefix.length });
+        mockVerticalTarget(view, prefix.length + 1);
+
+        pressKey(view, 'ArrowDown');
+
+        expect(getActiveCell(view.state)).toBeNull();
+    });
+
+    it('leaves Shift+ArrowDown to the main editor', () => {
+        const prefix = 'above';
+        const doc = `${prefix}\n${TABLE}`;
+        const view = mountView(doc, prefix.length);
+        mockVerticalTarget(view, prefix.length + 1);
+
+        pressKey(view, 'ArrowDown', { shiftKey: true });
+
+        expect(getActiveCell(view.state)).toBeNull();
+        expect(getPendingOpenCellRequest(view.state)).toBeNull();
     });
 });

--- a/src/contentScript/__tests__/tableNavigation.test.ts
+++ b/src/contentScript/__tests__/tableNavigation.test.ts
@@ -5,7 +5,7 @@ import { navigateCell } from '../tableRuntime/navigation/tableNavigation';
 import { getResolvedActiveCell, resolveCellWithinResolvedTable } from '../tableRuntime/activeCell/resolvedActiveCell';
 import { SECTION_BODY, SECTION_HEADER } from '../tableWidget/domHelpers';
 
-import { setActiveCellEffect } from '../tableState/activeCellState';
+import { clearActiveCellEffect, setActiveCellEffect } from '../tableState/activeCellState';
 import { triggerOpenCellRequestEffect } from '../tableRuntime/openCellRequest';
 import { insertRowAtBottom } from '../tableRuntime/operations/structuralOperations';
 import { beginOpenCellRequestEffect } from '../tableRuntime/openCellRequest';
@@ -297,5 +297,70 @@ describe('navigateCell', () => {
             row: 0,
             col: 0,
         });
+    });
+
+    it('should exit above the table when moving up from the header boundary', () => {
+        const ctx = setupTable(2, 2);
+        ctx.from = 10;
+        ctx.to = 89;
+        setupActiveCell(SECTION_HEADER, 0, 1);
+
+        const result = navigateCell(mockView, 'up', { exitTableAtBoundary: true });
+
+        expect(result).toBe(true);
+        expect(mockDispatch).toHaveBeenCalledWith({
+            selection: { anchor: 9 },
+            effects: expect.objectContaining({
+                is: expect.any(Function),
+            }),
+            scrollIntoView: true,
+        });
+        expect(getEffects().some((effect) => effect.is(clearActiveCellEffect))).toBe(true);
+        expect(mockView.contentDOM.focus).toHaveBeenCalledWith({ preventScroll: true });
+    });
+
+    it('should exit below the table when moving down from the final body row', () => {
+        const ctx = setupTable(2, 2);
+        ctx.from = 10;
+        ctx.to = 89;
+        setupActiveCell(SECTION_BODY, 1, 0);
+
+        const result = navigateCell(mockView, 'down', { exitTableAtBoundary: true });
+
+        expect(result).toBe(true);
+        expect(mockDispatch).toHaveBeenCalledWith({
+            selection: { anchor: 90 },
+            effects: expect.objectContaining({
+                is: expect.any(Function),
+            }),
+            scrollIntoView: true,
+        });
+        expect(getEffects().some((effect) => effect.is(clearActiveCellEffect))).toBe(true);
+        expect(mockView.contentDOM.focus).toHaveBeenCalledWith({ preventScroll: true });
+    });
+
+    it('should keep boundary navigation blocked when table exit is not requested', () => {
+        const ctx = setupTable(1, 2);
+        ctx.from = 10;
+        ctx.to = 89;
+        setupActiveCell(SECTION_HEADER, 0, 0);
+
+        const result = navigateCell(mockView, 'up');
+
+        expect(result).toBe(true);
+        expect(mockDispatch).not.toHaveBeenCalled();
+        expect(mockView.contentDOM.focus).not.toHaveBeenCalled();
+    });
+
+    it('should remain blocked when no adjacent line exists at the document edge', () => {
+        const ctx = setupTable(1, 2);
+        ctx.from = 0;
+        setupActiveCell(SECTION_HEADER, 0, 0);
+
+        const result = navigateCell(mockView, 'up', { exitTableAtBoundary: true });
+
+        expect(result).toBe(true);
+        expect(mockDispatch).not.toHaveBeenCalled();
+        expect(mockView.contentDOM.focus).not.toHaveBeenCalled();
     });
 });

--- a/src/contentScript/__tests__/tableNavigation.test.ts
+++ b/src/contentScript/__tests__/tableNavigation.test.ts
@@ -46,6 +46,7 @@ describe('navigateCell', () => {
         mockView = {
             state: mockState,
             dispatch: mockDispatch,
+            focus: vi.fn(),
             contentDOM: {
                 focus: vi.fn(),
                 querySelectorAll: vi.fn().mockReturnValue([]),
@@ -257,7 +258,7 @@ describe('navigateCell', () => {
         const result = navigateCell(mockView, 'down', { allowRowCreation: true });
 
         expect(result).toBe(true);
-        expect(mockView.contentDOM.focus).not.toHaveBeenCalled();
+        expect(mockView.focus).not.toHaveBeenCalled();
     });
 
     it('should navigate previous from body start to header end', () => {
@@ -316,7 +317,7 @@ describe('navigateCell', () => {
             scrollIntoView: true,
         });
         expect(getEffects().some((effect) => effect.is(clearActiveCellEffect))).toBe(true);
-        expect(mockView.contentDOM.focus).toHaveBeenCalledWith({ preventScroll: true });
+        expect(mockView.focus).toHaveBeenCalled();
     });
 
     it('should exit below the table when moving down from the final body row', () => {
@@ -336,7 +337,7 @@ describe('navigateCell', () => {
             scrollIntoView: true,
         });
         expect(getEffects().some((effect) => effect.is(clearActiveCellEffect))).toBe(true);
-        expect(mockView.contentDOM.focus).toHaveBeenCalledWith({ preventScroll: true });
+        expect(mockView.focus).toHaveBeenCalled();
     });
 
     it('should keep boundary navigation blocked when table exit is not requested', () => {
@@ -349,7 +350,7 @@ describe('navigateCell', () => {
 
         expect(result).toBe(true);
         expect(mockDispatch).not.toHaveBeenCalled();
-        expect(mockView.contentDOM.focus).not.toHaveBeenCalled();
+        expect(mockView.focus).not.toHaveBeenCalled();
     });
 
     it('should remain blocked when no adjacent line exists at the document edge', () => {
@@ -361,6 +362,6 @@ describe('navigateCell', () => {
 
         expect(result).toBe(true);
         expect(mockDispatch).not.toHaveBeenCalled();
-        expect(mockView.contentDOM.focus).not.toHaveBeenCalled();
+        expect(mockView.focus).not.toHaveBeenCalled();
     });
 });

--- a/src/contentScript/__tests__/tableNavigation.test.ts
+++ b/src/contentScript/__tests__/tableNavigation.test.ts
@@ -309,13 +309,9 @@ describe('navigateCell', () => {
         const result = navigateCell(mockView, 'up', { exitTableAtBoundary: true });
 
         expect(result).toBe(true);
-        expect(mockDispatch).toHaveBeenCalledWith({
-            selection: { anchor: 9 },
-            effects: expect.objectContaining({
-                is: expect.any(Function),
-            }),
-            scrollIntoView: true,
-        });
+        expect(mockDispatch).toHaveBeenCalledWith(
+            expect.objectContaining({ selection: { anchor: 9 }, scrollIntoView: true })
+        );
         expect(getEffects().some((effect) => effect.is(clearActiveCellEffect))).toBe(true);
         expect(mockView.focus).toHaveBeenCalled();
     });
@@ -329,13 +325,9 @@ describe('navigateCell', () => {
         const result = navigateCell(mockView, 'down', { exitTableAtBoundary: true });
 
         expect(result).toBe(true);
-        expect(mockDispatch).toHaveBeenCalledWith({
-            selection: { anchor: 90 },
-            effects: expect.objectContaining({
-                is: expect.any(Function),
-            }),
-            scrollIntoView: true,
-        });
+        expect(mockDispatch).toHaveBeenCalledWith(
+            expect.objectContaining({ selection: { anchor: 90 }, scrollIntoView: true })
+        );
         expect(getEffects().some((effect) => effect.is(clearActiveCellEffect))).toBe(true);
         expect(mockView.focus).toHaveBeenCalled();
     });

--- a/src/contentScript/nestedEditor/domHandlers.ts
+++ b/src/contentScript/nestedEditor/domHandlers.ts
@@ -89,12 +89,18 @@ export function createNestedEditorKeymap(
 
                 if (headRect && fromRect && Math.abs(headRect.top - fromRect.top) < 2) {
                     options.syncPendingChangesToRoot();
-                    return navigateCell(mainView, 'up', { initialCursorPos: 'lastLineStart' });
+                    return navigateCell(mainView, 'up', {
+                        initialCursorPos: 'lastLineStart',
+                        exitTableAtBoundary: true,
+                    });
                 }
 
                 if (head === from) {
                     options.syncPendingChangesToRoot();
-                    return navigateCell(mainView, 'up', { initialCursorPos: 'lastLineStart' });
+                    return navigateCell(mainView, 'up', {
+                        initialCursorPos: 'lastLineStart',
+                        exitTableAtBoundary: true,
+                    });
                 }
 
                 return false;
@@ -110,12 +116,18 @@ export function createNestedEditorKeymap(
 
                 if (headRect && toRect && Math.abs(headRect.top - toRect.top) < 2) {
                     options.syncPendingChangesToRoot();
-                    return navigateCell(mainView, 'down', { initialCursorPos: 'start' });
+                    return navigateCell(mainView, 'down', {
+                        initialCursorPos: 'start',
+                        exitTableAtBoundary: true,
+                    });
                 }
 
                 if (head === to) {
                     options.syncPendingChangesToRoot();
-                    return navigateCell(mainView, 'down', { initialCursorPos: 'start' });
+                    return navigateCell(mainView, 'down', {
+                        initialCursorPos: 'start',
+                        exitTableAtBoundary: true,
+                    });
                 }
 
                 return false;

--- a/src/contentScript/tableRuntime/activeCell/cellActivation.ts
+++ b/src/contentScript/tableRuntime/activeCell/cellActivation.ts
@@ -11,6 +11,7 @@ import { buildTableContext } from '../../tableModel/tableContext';
 import { createActiveCellFromRanges } from './activeCellFactory';
 import { createResolvedActiveCell } from './resolvedActiveCell';
 import { requestOpenCell } from '../openCellRequest';
+import type { InitialCursorPos } from '../../shared/cursorPlacement';
 
 export interface ActivateCellOptions {
     /** If true and position is outside any table, clears active cell and focuses main editor (default: false) */
@@ -21,6 +22,10 @@ export interface ActivateCellOptions {
     preserveMainSelection?: boolean;
     /** Optional fallback identity used when the cursor lands on table structure during lifecycle-driven reactivation */
     preferredActiveCell?: ActiveCell | null;
+}
+
+export interface ActivateTableCellOptions {
+    initialCursorPos?: InitialCursorPos;
 }
 
 export function resolveActivationTargetCell(params: {
@@ -126,32 +131,37 @@ export function activateCellAtPosition(view: EditorView, pos: number, options?: 
  * Activates a specific cell by table position and coordinates.
  * Callers that depend on newly mounted widgets should schedule this after the
  * relevant DOM update has had a chance to render.
+ * @returns true when an open-cell request was dispatched.
  */
 export function activateTableCell(
     view: EditorView,
     tableFrom: number,
-    coords: { section: 'header' | 'body'; row: number; col: number }
-): void {
-    if (!view.dom.isConnected) return;
+    coords: { section: 'header' | 'body'; row: number; col: number },
+    options: ActivateTableCellOptions = {}
+): boolean {
+    if (!view.dom.isConnected) return false;
 
     // Don't activate cells in source mode (no widgets exist)
-    if (isSourceModeEnabled(view.state)) return;
+    if (isSourceModeEnabled(view.state)) return false;
 
     const table = resolveContainingTableAtPos(view.state, tableFrom);
-    if (!table) return;
+    if (!table) return false;
 
     const ctx = buildTableContext(table);
-    if (!ctx) return;
+    if (!ctx) return false;
 
     const resolvedCell = createResolvedActiveCell({
         ctx,
         coords,
     });
 
-    if (!resolvedCell) return;
+    if (!resolvedCell) return false;
 
     requestOpenCell(view, {
         target: { resolvedCell },
         normalizeIfNeeded: true,
+        initialCursorPos: options.initialCursorPos,
     });
+
+    return true;
 }

--- a/src/contentScript/tableRuntime/navigation/mainEditorTableEntry.ts
+++ b/src/contentScript/tableRuntime/navigation/mainEditorTableEntry.ts
@@ -1,0 +1,137 @@
+import { EditorState, Prec, Transaction, type Extension, type TransactionSpec } from '@codemirror/state';
+import { keymap, type EditorView } from '@codemirror/view';
+import { getActiveCell } from '../../tableState/activeCellState';
+import { getCellSelection } from '../../tableState/cellSelectionState';
+import { isEffectiveRawMode } from '../../tableState/sourceMode';
+import { getPendingOpenCellRequest } from '../openCellRequest';
+import { resolveTableContextAtPos } from '../tableResolution';
+import {
+    buildWholeTableSelectionTransaction,
+    selectWholeTable,
+    type WholeTableSelectionFocus,
+} from '../selection/cellSelectionController';
+
+type DeletionDirection = 'backward' | 'forward';
+
+// A rendered widget implies that table parsing has already completed. Keyboard
+// entry must never block waiting for syntax work on the input event path.
+const TABLE_ENTRY_SYNTAX_TREE_TIMEOUT_MS = 0;
+
+interface PureDeletion {
+    from: number;
+    to: number;
+}
+
+function canEnterRenderedTable(state: EditorState): boolean {
+    return (
+        !isEffectiveRawMode(state) &&
+        state.selection.ranges.length === 1 &&
+        state.selection.main.empty &&
+        !getCellSelection(state) &&
+        !getActiveCell(state) &&
+        !getPendingOpenCellRequest(state)
+    );
+}
+
+function focusEdgeForDirection(direction: DeletionDirection): WholeTableSelectionFocus {
+    return direction === 'backward' ? 'end' : 'start';
+}
+
+function selectTableAtCharacterTarget(view: EditorView, direction: DeletionDirection): boolean {
+    if (!canEnterRenderedTable(view.state)) {
+        return false;
+    }
+
+    const current = view.state.selection.main;
+    const target = view.moveByChar(current, direction === 'forward');
+    if (target.head === current.head) {
+        return false;
+    }
+
+    const ctx = resolveTableContextAtPos(view.state, target.head, TABLE_ENTRY_SYNTAX_TREE_TIMEOUT_MS);
+    if (!ctx) {
+        return false;
+    }
+
+    return selectWholeTable(view, ctx, focusEdgeForDirection(direction));
+}
+
+function findSinglePureDeletion(transaction: Transaction): PureDeletion | null {
+    let deletion: PureDeletion | null = null;
+    let valid = true;
+
+    transaction.changes.iterChanges((from, to, _fromB, _toB, inserted) => {
+        if (deletion || from === to || inserted.length > 0) {
+            valid = false;
+            return;
+        }
+
+        deletion = { from, to };
+    });
+
+    return valid ? deletion : null;
+}
+
+function inferDeletionDirection(transaction: Transaction, deletion: PureDeletion): DeletionDirection | null {
+    const userEvent = transaction.annotation(Transaction.userEvent);
+    if (userEvent === 'delete.backward') {
+        return 'backward';
+    }
+    if (userEvent === 'delete.forward') {
+        return 'forward';
+    }
+    if (userEvent !== 'input.type') {
+        return null;
+    }
+
+    const caret = transaction.startState.selection.main.head;
+    if (deletion.to === caret && deletion.from < caret) {
+        return 'backward';
+    }
+    if (deletion.from === caret && deletion.to > caret) {
+        return 'forward';
+    }
+
+    return null;
+}
+
+function rewriteTableBoundaryDeletion(transaction: Transaction): TransactionSpec | Transaction {
+    if (!transaction.docChanged || !canEnterRenderedTable(transaction.startState)) {
+        return transaction;
+    }
+
+    const deletion = findSinglePureDeletion(transaction);
+    if (!deletion) {
+        return transaction;
+    }
+
+    const direction = inferDeletionDirection(transaction, deletion);
+    if (!direction) {
+        return transaction;
+    }
+
+    const targetPos = direction === 'backward' ? deletion.from : deletion.to;
+    const ctx = resolveTableContextAtPos(transaction.startState, targetPos, TABLE_ENTRY_SYNTAX_TREE_TIMEOUT_MS);
+    if (!ctx) {
+        return transaction;
+    }
+
+    return buildWholeTableSelectionTransaction(ctx, focusEdgeForDirection(direction)) ?? transaction;
+}
+
+const tableBoundaryDeletionFilter = EditorState.transactionFilter.of(rewriteTableBoundaryDeletion);
+
+const tableBoundaryDeletionKeymap = Prec.highest(
+    keymap.of([
+        {
+            key: 'Backspace',
+            run: (view) => selectTableAtCharacterTarget(view, 'backward'),
+        },
+        {
+            key: 'Delete',
+            run: (view) => selectTableAtCharacterTarget(view, 'forward'),
+        },
+    ])
+);
+
+export const mainEditorTableEntryExtension: Extension = [tableBoundaryDeletionFilter, tableBoundaryDeletionKeymap];

--- a/src/contentScript/tableRuntime/navigation/mainEditorTableEntry.ts
+++ b/src/contentScript/tableRuntime/navigation/mainEditorTableEntry.ts
@@ -1,12 +1,12 @@
 import { EditorState, Prec, type Extension } from '@codemirror/state';
-import { keymap, type EditorView } from '@codemirror/view';
+import { BlockType, keymap, type BlockInfo, type EditorView } from '@codemirror/view';
 import { getActiveCell } from '../../tableState/activeCellState';
 import { fromUnifiedRow, getCellSelection } from '../../tableState/cellSelectionState';
 import { isEffectiveRawMode } from '../../tableState/sourceMode';
-import { buildTableContext, getTableGridBounds, type TableContext } from '../../tableModel/tableContext';
+import { getTableGridBounds, type TableContext } from '../../tableModel/tableContext';
 import { activateTableCell } from '../activeCell/cellActivation';
 import { getPendingOpenCellRequest } from '../openCellRequest';
-import { findTableRanges, resolveTableContextAtPos } from '../tableResolution';
+import { resolveTableContextAtPos } from '../tableResolution';
 import { selectWholeTable, type WholeTableSelectionFocus } from '../selection/cellSelectionController';
 
 type DeletionDirection = 'backward' | 'forward';
@@ -66,13 +66,58 @@ function entersTableFromExpectedSide(
     return direction === 'down' ? currentPos < ctx.from : currentPos > ctx.to;
 }
 
+/** True when the movement left the caret's own line block rather than moving within a wrapped line. */
+function leavesBlock(block: BlockInfo, targetPos: number, direction: VerticalEntryDirection): boolean {
+    return direction === 'down' ? targetPos > block.to : targetPos < block.from;
+}
+
 /**
- * CodeMirror may place a vertical movement target on either side of a block
- * replacement instead of inside its document range. Resolve the direct target
- * first, then fall back to the nearest table fully crossed by the movement.
+ * Resolves the table that a vertical movement stepped over without landing in.
+ *
+ * `moveVertically` works in screen coordinates, and CodeMirror deliberately scans past
+ * block widgets while doing so: on hitting a non-text block it moves the probe to just
+ * beyond that block and keeps looking for a real line. Rendered tables are block replace
+ * decorations, so the returned target sits on the far side of the table rather than inside
+ * it, and resolving the target position alone finds nothing.
+ *
+ * So ask the layout which block was skipped instead of searching the document for one that
+ * fits. The block adjacent to the caret's own block, on the side being moved toward, is
+ * exactly the block CodeMirror scanned past. Both lookups are height-map queries and the
+ * table resolution is a point lookup, so this stays correct far down a long note where
+ * enumerating every table would require a full-document parse.
+ */
+function resolveSkippedTableBlock(
+    view: EditorView,
+    currentPos: number,
+    targetPos: number,
+    direction: VerticalEntryDirection
+): TableContext | null {
+    const currentBlock = view.lineBlockAt(currentPos);
+    if (!leavesBlock(currentBlock, targetPos, direction)) {
+        return null;
+    }
+
+    const probePos = direction === 'down' ? currentBlock.to + 1 : currentBlock.from - 1;
+    if (probePos < 0 || probePos > view.state.doc.length) {
+        return null;
+    }
+
+    // A composite `type` means the line is split by block widgets, which a whole-line
+    // table replacement never produces; treating it as "not a table" is the safe read.
+    const skippedBlock = view.lineBlockAt(probePos);
+    if (skippedBlock.type !== BlockType.WidgetRange) {
+        return null;
+    }
+
+    return resolveTableContextAtPos(view.state, skippedBlock.from, TABLE_ENTRY_SYNTAX_TREE_TIMEOUT_MS);
+}
+
+/**
+ * Resolve the table a vertical movement should enter: the one under the movement target,
+ * or else the one the movement skipped over.
  */
 function resolveVerticalEntryContext(
-    state: EditorState,
+    view: EditorView,
     currentPos: number,
     targetPos: number,
     direction: VerticalEntryDirection
@@ -81,29 +126,12 @@ function resolveVerticalEntryContext(
         return null;
     }
 
-    const directCtx = resolveTableContextAtPos(state, targetPos, TABLE_ENTRY_SYNTAX_TREE_TIMEOUT_MS);
+    const directCtx = resolveTableContextAtPos(view.state, targetPos, TABLE_ENTRY_SYNTAX_TREE_TIMEOUT_MS);
     if (directCtx && entersTableFromExpectedSide(currentPos, directCtx, direction)) {
         return directCtx;
     }
 
-    const tables = findTableRanges(state, TABLE_ENTRY_SYNTAX_TREE_TIMEOUT_MS);
-    if (!tables) {
-        return null;
-    }
-
-    if (direction === 'down') {
-        const crossed = tables.find((table) => currentPos < table.from && targetPos > table.to);
-        return crossed ? buildTableContext(crossed) : null;
-    }
-
-    for (let index = tables.length - 1; index >= 0; index--) {
-        const table = tables[index];
-        if (currentPos > table.to && targetPos < table.from) {
-            return buildTableContext(table);
-        }
-    }
-
-    return null;
+    return resolveSkippedTableBlock(view, currentPos, targetPos, direction);
 }
 
 function activateTableAtVerticalTarget(view: EditorView, direction: VerticalEntryDirection): boolean {
@@ -117,7 +145,7 @@ function activateTableAtVerticalTarget(view: EditorView, direction: VerticalEntr
         return false;
     }
 
-    const ctx = resolveVerticalEntryContext(view.state, current.head, target.head, direction);
+    const ctx = resolveVerticalEntryContext(view, current.head, target.head, direction);
     if (!ctx) {
         return false;
     }

--- a/src/contentScript/tableRuntime/navigation/mainEditorTableEntry.ts
+++ b/src/contentScript/tableRuntime/navigation/mainEditorTableEntry.ts
@@ -12,6 +12,9 @@ import { selectWholeTable, type WholeTableSelectionFocus } from '../selection/ce
 type DeletionDirection = 'backward' | 'forward';
 type VerticalEntryDirection = 'up' | 'down';
 
+const selectTableBackward = (view: EditorView): boolean => selectTableAtCharacterTarget(view, 'backward');
+const selectTableForward = (view: EditorView): boolean => selectTableAtCharacterTarget(view, 'forward');
+
 // A rendered widget implies that table parsing has already completed. Keyboard
 // entry must never block waiting for syntax work on the keyboard event path.
 const TABLE_ENTRY_SYNTAX_TREE_TIMEOUT_MS = 0;
@@ -165,11 +168,30 @@ const tableEntryKeymap = Prec.highest(
     keymap.of([
         {
             key: 'Backspace',
-            run: (view) => selectTableAtCharacterTarget(view, 'backward'),
+            run: selectTableBackward,
+            shift: selectTableBackward,
         },
         {
             key: 'Delete',
-            run: (view) => selectTableAtCharacterTarget(view, 'forward'),
+            run: selectTableForward,
+        },
+        {
+            key: 'Mod-Backspace',
+            mac: 'Alt-Backspace',
+            run: selectTableBackward,
+        },
+        {
+            key: 'Mod-Delete',
+            mac: 'Alt-Delete',
+            run: selectTableForward,
+        },
+        {
+            mac: 'Mod-Backspace',
+            run: selectTableBackward,
+        },
+        {
+            mac: 'Mod-Delete',
+            run: selectTableForward,
         },
         {
             key: 'ArrowUp',

--- a/src/contentScript/tableRuntime/navigation/mainEditorTableEntry.ts
+++ b/src/contentScript/tableRuntime/navigation/mainEditorTableEntry.ts
@@ -1,8 +1,10 @@
 import { EditorState, Prec, Transaction, type Extension, type TransactionSpec } from '@codemirror/state';
 import { keymap, type EditorView } from '@codemirror/view';
 import { getActiveCell } from '../../tableState/activeCellState';
-import { getCellSelection } from '../../tableState/cellSelectionState';
+import { fromUnifiedRow, getCellSelection } from '../../tableState/cellSelectionState';
 import { isEffectiveRawMode } from '../../tableState/sourceMode';
+import { getTableGridBounds } from '../../tableModel/tableContext';
+import { activateTableCell } from '../activeCell/cellActivation';
 import { getPendingOpenCellRequest } from '../openCellRequest';
 import { resolveTableContextAtPos } from '../tableResolution';
 import {
@@ -12,6 +14,7 @@ import {
 } from '../selection/cellSelectionController';
 
 type DeletionDirection = 'backward' | 'forward';
+type VerticalEntryDirection = 'up' | 'down';
 
 // A rendered widget implies that table parsing has already completed. Keyboard
 // entry must never block waiting for syntax work on the input event path.
@@ -54,6 +57,38 @@ function selectTableAtCharacterTarget(view: EditorView, direction: DeletionDirec
     }
 
     return selectWholeTable(view, ctx, focusEdgeForDirection(direction));
+}
+
+function activateTableAtVerticalTarget(view: EditorView, direction: VerticalEntryDirection): boolean {
+    if (!canEnterRenderedTable(view.state)) {
+        return false;
+    }
+
+    const current = view.state.selection.main;
+    const target = view.moveVertically(current, direction === 'down');
+    if (target.head === current.head) {
+        return false;
+    }
+
+    const ctx = resolveTableContextAtPos(view.state, target.head, TABLE_ENTRY_SYNTAX_TREE_TIMEOUT_MS);
+    if (!ctx) {
+        return false;
+    }
+
+    const entersFromExpectedSide = direction === 'down' ? current.head < ctx.from : current.head > ctx.to;
+    if (!entersFromExpectedSide) {
+        return false;
+    }
+
+    const bounds = getTableGridBounds(ctx);
+    if (bounds.totalRows <= 0 || bounds.totalCols <= 0) {
+        return false;
+    }
+
+    const targetCoords = fromUnifiedRow(direction === 'down' ? 0 : bounds.totalRows - 1, 0);
+    return activateTableCell(view, ctx.from, targetCoords, {
+        initialCursorPos: direction === 'down' ? 'start' : 'lastLineStart',
+    });
 }
 
 function findSinglePureDeletion(transaction: Transaction): PureDeletion | null {
@@ -121,7 +156,7 @@ function rewriteTableBoundaryDeletion(transaction: Transaction): TransactionSpec
 
 const tableBoundaryDeletionFilter = EditorState.transactionFilter.of(rewriteTableBoundaryDeletion);
 
-const tableBoundaryDeletionKeymap = Prec.highest(
+const tableEntryKeymap = Prec.highest(
     keymap.of([
         {
             key: 'Backspace',
@@ -131,7 +166,15 @@ const tableBoundaryDeletionKeymap = Prec.highest(
             key: 'Delete',
             run: (view) => selectTableAtCharacterTarget(view, 'forward'),
         },
+        {
+            key: 'ArrowUp',
+            run: (view) => activateTableAtVerticalTarget(view, 'up'),
+        },
+        {
+            key: 'ArrowDown',
+            run: (view) => activateTableAtVerticalTarget(view, 'down'),
+        },
     ])
 );
 
-export const mainEditorTableEntryExtension: Extension = [tableBoundaryDeletionFilter, tableBoundaryDeletionKeymap];
+export const mainEditorTableEntryExtension: Extension = [tableBoundaryDeletionFilter, tableEntryKeymap];

--- a/src/contentScript/tableRuntime/navigation/mainEditorTableEntry.ts
+++ b/src/contentScript/tableRuntime/navigation/mainEditorTableEntry.ts
@@ -1,4 +1,4 @@
-import { EditorState, Prec, Transaction, type Extension, type TransactionSpec } from '@codemirror/state';
+import { EditorState, Prec, type Extension } from '@codemirror/state';
 import { keymap, type EditorView } from '@codemirror/view';
 import { getActiveCell } from '../../tableState/activeCellState';
 import { fromUnifiedRow, getCellSelection } from '../../tableState/cellSelectionState';
@@ -7,23 +7,14 @@ import { buildTableContext, getTableGridBounds, type TableContext } from '../../
 import { activateTableCell } from '../activeCell/cellActivation';
 import { getPendingOpenCellRequest } from '../openCellRequest';
 import { findTableRanges, resolveTableContextAtPos } from '../tableResolution';
-import {
-    buildWholeTableSelectionTransaction,
-    selectWholeTable,
-    type WholeTableSelectionFocus,
-} from '../selection/cellSelectionController';
+import { selectWholeTable, type WholeTableSelectionFocus } from '../selection/cellSelectionController';
 
 type DeletionDirection = 'backward' | 'forward';
 type VerticalEntryDirection = 'up' | 'down';
 
 // A rendered widget implies that table parsing has already completed. Keyboard
-// entry must never block waiting for syntax work on the input event path.
+// entry must never block waiting for syntax work on the keyboard event path.
 const TABLE_ENTRY_SYNTAX_TREE_TIMEOUT_MS = 0;
-
-interface PureDeletion {
-    from: number;
-    to: number;
-}
 
 function canEnterRenderedTable(state: EditorState): boolean {
     return (
@@ -142,71 +133,6 @@ function activateTableAtVerticalTarget(view: EditorView, direction: VerticalEntr
     });
 }
 
-function findSinglePureDeletion(transaction: Transaction): PureDeletion | null {
-    let deletion: PureDeletion | null = null;
-    let valid = true;
-
-    transaction.changes.iterChanges((from, to, _fromB, _toB, inserted) => {
-        if (deletion || from === to || inserted.length > 0) {
-            valid = false;
-            return;
-        }
-
-        deletion = { from, to };
-    });
-
-    return valid ? deletion : null;
-}
-
-function inferDeletionDirection(transaction: Transaction, deletion: PureDeletion): DeletionDirection | null {
-    const userEvent = transaction.annotation(Transaction.userEvent);
-    if (userEvent === 'delete.backward') {
-        return 'backward';
-    }
-    if (userEvent === 'delete.forward') {
-        return 'forward';
-    }
-    if (userEvent !== 'input.type') {
-        return null;
-    }
-
-    const caret = transaction.startState.selection.main.head;
-    if (deletion.to === caret && deletion.from < caret) {
-        return 'backward';
-    }
-    if (deletion.from === caret && deletion.to > caret) {
-        return 'forward';
-    }
-
-    return null;
-}
-
-function rewriteTableBoundaryDeletion(transaction: Transaction): TransactionSpec | Transaction {
-    if (!transaction.docChanged || !canEnterRenderedTable(transaction.startState)) {
-        return transaction;
-    }
-
-    const deletion = findSinglePureDeletion(transaction);
-    if (!deletion) {
-        return transaction;
-    }
-
-    const direction = inferDeletionDirection(transaction, deletion);
-    if (!direction) {
-        return transaction;
-    }
-
-    const targetPos = direction === 'backward' ? deletion.from : deletion.to;
-    const ctx = resolveTableContextAtPos(transaction.startState, targetPos, TABLE_ENTRY_SYNTAX_TREE_TIMEOUT_MS);
-    if (!ctx) {
-        return transaction;
-    }
-
-    return buildWholeTableSelectionTransaction(ctx, focusEdgeForDirection(direction)) ?? transaction;
-}
-
-const tableBoundaryDeletionFilter = EditorState.transactionFilter.of(rewriteTableBoundaryDeletion);
-
 const tableEntryKeymap = Prec.highest(
     keymap.of([
         {
@@ -228,4 +154,4 @@ const tableEntryKeymap = Prec.highest(
     ])
 );
 
-export const mainEditorTableEntryExtension: Extension = [tableBoundaryDeletionFilter, tableEntryKeymap];
+export const mainEditorTableEntryExtension: Extension = tableEntryKeymap;

--- a/src/contentScript/tableRuntime/navigation/mainEditorTableEntry.ts
+++ b/src/contentScript/tableRuntime/navigation/mainEditorTableEntry.ts
@@ -3,10 +3,10 @@ import { keymap, type EditorView } from '@codemirror/view';
 import { getActiveCell } from '../../tableState/activeCellState';
 import { fromUnifiedRow, getCellSelection } from '../../tableState/cellSelectionState';
 import { isEffectiveRawMode } from '../../tableState/sourceMode';
-import { getTableGridBounds } from '../../tableModel/tableContext';
+import { buildTableContext, getTableGridBounds, type TableContext } from '../../tableModel/tableContext';
 import { activateTableCell } from '../activeCell/cellActivation';
 import { getPendingOpenCellRequest } from '../openCellRequest';
-import { resolveTableContextAtPos } from '../tableResolution';
+import { findTableRanges, resolveTableContextAtPos } from '../tableResolution';
 import {
     buildWholeTableSelectionTransaction,
     selectWholeTable,
@@ -59,6 +59,62 @@ function selectTableAtCharacterTarget(view: EditorView, direction: DeletionDirec
     return selectWholeTable(view, ctx, focusEdgeForDirection(direction));
 }
 
+function isPositionMovingInDirection(
+    currentPos: number,
+    targetPos: number,
+    direction: VerticalEntryDirection
+): boolean {
+    return direction === 'down' ? targetPos > currentPos : targetPos < currentPos;
+}
+
+function entersTableFromExpectedSide(
+    currentPos: number,
+    ctx: TableContext,
+    direction: VerticalEntryDirection
+): boolean {
+    return direction === 'down' ? currentPos < ctx.from : currentPos > ctx.to;
+}
+
+/**
+ * CodeMirror may place a vertical movement target on either side of a block
+ * replacement instead of inside its document range. Resolve the direct target
+ * first, then fall back to the nearest table fully crossed by the movement.
+ */
+function resolveVerticalEntryContext(
+    state: EditorState,
+    currentPos: number,
+    targetPos: number,
+    direction: VerticalEntryDirection
+): TableContext | null {
+    if (!isPositionMovingInDirection(currentPos, targetPos, direction)) {
+        return null;
+    }
+
+    const directCtx = resolveTableContextAtPos(state, targetPos, TABLE_ENTRY_SYNTAX_TREE_TIMEOUT_MS);
+    if (directCtx && entersTableFromExpectedSide(currentPos, directCtx, direction)) {
+        return directCtx;
+    }
+
+    const tables = findTableRanges(state, TABLE_ENTRY_SYNTAX_TREE_TIMEOUT_MS);
+    if (!tables) {
+        return null;
+    }
+
+    if (direction === 'down') {
+        const crossed = tables.find((table) => currentPos < table.from && targetPos > table.to);
+        return crossed ? buildTableContext(crossed) : null;
+    }
+
+    for (let index = tables.length - 1; index >= 0; index--) {
+        const table = tables[index];
+        if (currentPos > table.to && targetPos < table.from) {
+            return buildTableContext(table);
+        }
+    }
+
+    return null;
+}
+
 function activateTableAtVerticalTarget(view: EditorView, direction: VerticalEntryDirection): boolean {
     if (!canEnterRenderedTable(view.state)) {
         return false;
@@ -70,13 +126,8 @@ function activateTableAtVerticalTarget(view: EditorView, direction: VerticalEntr
         return false;
     }
 
-    const ctx = resolveTableContextAtPos(view.state, target.head, TABLE_ENTRY_SYNTAX_TREE_TIMEOUT_MS);
+    const ctx = resolveVerticalEntryContext(view.state, current.head, target.head, direction);
     if (!ctx) {
-        return false;
-    }
-
-    const entersFromExpectedSide = direction === 'down' ? current.head < ctx.from : current.head > ctx.to;
-    if (!entersFromExpectedSide) {
         return false;
     }
 

--- a/src/contentScript/tableRuntime/navigation/tableExit.ts
+++ b/src/contentScript/tableRuntime/navigation/tableExit.ts
@@ -1,0 +1,41 @@
+import type { StateEffect } from '@codemirror/state';
+import type { EditorView } from '@codemirror/view';
+import type { ResolvedTable } from '../../tableModel/types';
+
+/** Which side of a table the caret leaves through. */
+export type TableExitSide = 'before' | 'after';
+
+/**
+ * Moves the caret to the line adjacent to a table, applies `effects`, and hands focus
+ * back to the main editor. Returns false when the table sits against a document edge
+ * and there is no adjacent line, leaving the caller to decide what to do instead.
+ *
+ * Focus must be restored with `view.focus()`, not a bare `contentDOM.focus()`. Callers
+ * reach this while the caret is parked inside the table's replaced range — often with a
+ * nested editor still holding focus — so CodeMirror has not written the new selection to
+ * the DOM (it only controls the DOM selection while focused). `view.focus()` suppresses
+ * the DOM observer across the focus call and syncs the DOM selection from state; focusing
+ * the content element directly lets the observer read the stale DOM selection back and
+ * jump the caret to an unrelated part of the document. `view.focus()` prevents scrolling
+ * internally, so the viewport still stays put.
+ */
+export function exitTableToAdjacentLine(
+    view: EditorView,
+    table: Pick<ResolvedTable, 'from' | 'to'>,
+    side: TableExitSide,
+    effects: StateEffect<unknown>[]
+): boolean {
+    const exitPos = side === 'before' ? table.from - 1 : table.to + 1;
+    if (exitPos < 0 || exitPos > view.state.doc.length) {
+        return false;
+    }
+
+    view.dispatch({
+        selection: { anchor: exitPos },
+        effects,
+        scrollIntoView: true,
+    });
+    view.focus();
+
+    return true;
+}

--- a/src/contentScript/tableRuntime/navigation/tableNavigation.ts
+++ b/src/contentScript/tableRuntime/navigation/tableNavigation.ts
@@ -10,7 +10,6 @@ import { getTableGridBounds } from '../../tableModel/tableContext';
 import { requestOpenCell, shouldSuppressNavigationKeys } from '../openCellRequest';
 import { resolveNavigationTarget, type NavigationDirection } from './navigationTarget';
 import { clearActiveCellEffect } from '../../tableState/activeCellState';
-import { focusMainEditorWithoutScroll } from '../../shared/mainEditorFocus';
 
 export interface NavigateCellOptions {
     initialCursorPos?: InitialCursorPos;
@@ -18,6 +17,19 @@ export interface NavigateCellOptions {
     exitTableAtBoundary?: boolean;
 }
 
+/**
+ * Hands the caret back to the main editor at the line adjacent to the table.
+ *
+ * Focus must be restored with `view.focus()`, not a bare `contentDOM.focus()`. The
+ * dispatch above runs while the nested editor still owns focus, so CodeMirror skips
+ * writing the new selection to the DOM (it only controls the DOM selection while
+ * focused). Clearing the active cell then destroys the focused nested editor, leaving
+ * the browser with a stale or collapsed DOM selection. `view.focus()` suppresses the
+ * DOM observer across the focus call and syncs the DOM selection from state; focusing
+ * the content element directly lets the observer read that stale selection back and
+ * jump the caret to an unrelated part of the document. `view.focus()` prevents
+ * scrolling internally, so the viewport still stays put.
+ */
 function exitTable(view: EditorView, resolvedActiveCell: ResolvedActiveCell, direction: 'up' | 'down'): void {
     const { from, to } = resolvedActiveCell.ctx;
     const exitPos = direction === 'up' ? from - 1 : to + 1;
@@ -30,7 +42,7 @@ function exitTable(view: EditorView, resolvedActiveCell: ResolvedActiveCell, dir
         effects: clearActiveCellEffect.of(undefined),
         scrollIntoView: true,
     });
-    focusMainEditorWithoutScroll(view);
+    view.focus();
 }
 
 export function navigateCell(

--- a/src/contentScript/tableRuntime/navigation/tableNavigation.ts
+++ b/src/contentScript/tableRuntime/navigation/tableNavigation.ts
@@ -10,6 +10,7 @@ import { getTableGridBounds } from '../../tableModel/tableContext';
 import { requestOpenCell, shouldSuppressNavigationKeys } from '../openCellRequest';
 import { resolveNavigationTarget, type NavigationDirection } from './navigationTarget';
 import { clearActiveCellEffect } from '../../tableState/activeCellState';
+import { exitTableToAdjacentLine } from './tableExit';
 
 export interface NavigateCellOptions {
     initialCursorPos?: InitialCursorPos;
@@ -17,32 +18,10 @@ export interface NavigateCellOptions {
     exitTableAtBoundary?: boolean;
 }
 
-/**
- * Hands the caret back to the main editor at the line adjacent to the table.
- *
- * Focus must be restored with `view.focus()`, not a bare `contentDOM.focus()`. The
- * dispatch above runs while the nested editor still owns focus, so CodeMirror skips
- * writing the new selection to the DOM (it only controls the DOM selection while
- * focused). Clearing the active cell then destroys the focused nested editor, leaving
- * the browser with a stale or collapsed DOM selection. `view.focus()` suppresses the
- * DOM observer across the focus call and syncs the DOM selection from state; focusing
- * the content element directly lets the observer read that stale selection back and
- * jump the caret to an unrelated part of the document. `view.focus()` prevents
- * scrolling internally, so the viewport still stays put.
- */
 function exitTable(view: EditorView, resolvedActiveCell: ResolvedActiveCell, direction: 'up' | 'down'): void {
-    const { from, to } = resolvedActiveCell.ctx;
-    const exitPos = direction === 'up' ? from - 1 : to + 1;
-    if (exitPos < 0 || exitPos > view.state.doc.length) {
-        return;
-    }
-
-    view.dispatch({
-        selection: { anchor: exitPos },
-        effects: clearActiveCellEffect.of(undefined),
-        scrollIntoView: true,
-    });
-    view.focus();
+    exitTableToAdjacentLine(view, resolvedActiveCell.ctx, direction === 'up' ? 'before' : 'after', [
+        clearActiveCellEffect.of(undefined),
+    ]);
 }
 
 export function navigateCell(

--- a/src/contentScript/tableRuntime/navigation/tableNavigation.ts
+++ b/src/contentScript/tableRuntime/navigation/tableNavigation.ts
@@ -1,15 +1,42 @@
 import { EditorView } from '@codemirror/view';
-import { getResolvedActiveCell, resolveCellWithinResolvedTable } from '../activeCell/resolvedActiveCell';
+import {
+    getResolvedActiveCell,
+    resolveCellWithinResolvedTable,
+    type ResolvedActiveCell,
+} from '../activeCell/resolvedActiveCell';
 import { insertRowAtBottom } from '../operations/structuralOperations';
 import type { InitialCursorPos } from '../../shared/cursorPlacement';
 import { getTableGridBounds } from '../../tableModel/tableContext';
 import { requestOpenCell, shouldSuppressNavigationKeys } from '../openCellRequest';
 import { resolveNavigationTarget, type NavigationDirection } from './navigationTarget';
+import { clearActiveCellEffect } from '../../tableState/activeCellState';
+import { focusMainEditorWithoutScroll } from '../../shared/mainEditorFocus';
+
+export interface NavigateCellOptions {
+    initialCursorPos?: InitialCursorPos;
+    allowRowCreation?: boolean;
+    exitTableAtBoundary?: boolean;
+}
+
+function exitTable(view: EditorView, resolvedActiveCell: ResolvedActiveCell, direction: 'up' | 'down'): void {
+    const { from, to } = resolvedActiveCell.ctx;
+    const exitPos = direction === 'up' ? from - 1 : to + 1;
+    if (exitPos < 0 || exitPos > view.state.doc.length) {
+        return;
+    }
+
+    view.dispatch({
+        selection: { anchor: exitPos },
+        effects: clearActiveCellEffect.of(undefined),
+        scrollIntoView: true,
+    });
+    focusMainEditorWithoutScroll(view);
+}
 
 export function navigateCell(
     view: EditorView,
     direction: NavigationDirection,
-    options: { initialCursorPos?: InitialCursorPos; allowRowCreation?: boolean } = {}
+    options: NavigateCellOptions = {}
 ): boolean {
     // Prevent race conditions from rapid key-holding
     if (shouldSuppressNavigationKeys(view.state)) {
@@ -29,6 +56,9 @@ export function navigateCell(
     });
 
     if (target.kind === 'blocked') {
+        if (options.exitTableAtBoundary && (direction === 'up' || direction === 'down')) {
+            exitTable(view, resolvedActiveCell, direction);
+        }
         return true;
     }
 

--- a/src/contentScript/tableRuntime/selection/cellSelectionController.ts
+++ b/src/contentScript/tableRuntime/selection/cellSelectionController.ts
@@ -1,4 +1,4 @@
-import { EditorSelection } from '@codemirror/state';
+import { EditorSelection, type TransactionSpec } from '@codemirror/state';
 import type { EditorView } from '@codemirror/view';
 import { clearActiveCellEffect } from '../../tableState/activeCellState';
 import {
@@ -118,6 +118,62 @@ export function startCellSelectionFromActiveCell(view: EditorView, direction: Ce
         },
         { clearActiveCell: true }
     );
+}
+
+export type WholeTableSelectionFocus = 'start' | 'end';
+
+function createWholeTableSelection(ctx: TableContext, focusEdge: WholeTableSelectionFocus): CellSelection | null {
+    const bounds = getTableGridBounds(ctx);
+    if (bounds.totalRows <= 0 || bounds.totalCols <= 0) {
+        return null;
+    }
+
+    const start = fromUnifiedRow(0, 0);
+    const end = fromUnifiedRow(bounds.totalRows - 1, bounds.totalCols - 1);
+
+    return focusEdge === 'start'
+        ? { tableFrom: ctx.from, anchor: end, focus: start }
+        : { tableFrom: ctx.from, anchor: start, focus: end };
+}
+
+/**
+ * Builds the state transition used when deletion reaches a rendered table.
+ * The focus edge follows the direction the caret approached from, keeping the
+ * hidden root selection and any subsequent scrolling close to that boundary.
+ */
+export function buildWholeTableSelectionTransaction(
+    ctx: TableContext,
+    focusEdge: WholeTableSelectionFocus
+): TransactionSpec | null {
+    const selection = createWholeTableSelection(ctx, focusEdge);
+    if (!selection) {
+        return null;
+    }
+
+    const focusRange = resolveCellDocRange({
+        tableFrom: ctx.from,
+        ranges: ctx.cellRanges,
+        coords: selection.focus,
+    });
+    if (!focusRange) {
+        return null;
+    }
+
+    return {
+        selection: EditorSelection.single(focusRange.editableFrom),
+        effects: [setCellSelectionEffect.of(selection), clearActiveCellEffect.of(undefined)],
+        annotations: cellSelectionTransitionAnnotation.of(true),
+        scrollIntoView: false,
+    };
+}
+
+export function selectWholeTable(view: EditorView, ctx: TableContext, focusEdge: WholeTableSelectionFocus): boolean {
+    const selection = createWholeTableSelection(ctx, focusEdge);
+    if (!selection) {
+        return false;
+    }
+
+    return dispatchSelectionWithContext(view, ctx, selection, { clearActiveCell: true });
 }
 
 export function extendExistingCellSelection(view: EditorView, direction: CellSelectionDirection): boolean {

--- a/src/contentScript/tableRuntime/selection/cellSelectionController.ts
+++ b/src/contentScript/tableRuntime/selection/cellSelectionController.ts
@@ -1,4 +1,4 @@
-import { EditorSelection, type TransactionSpec } from '@codemirror/state';
+import { EditorSelection } from '@codemirror/state';
 import type { EditorView } from '@codemirror/view';
 import { clearActiveCellEffect } from '../../tableState/activeCellState';
 import {
@@ -134,37 +134,6 @@ function createWholeTableSelection(ctx: TableContext, focusEdge: WholeTableSelec
     return focusEdge === 'start'
         ? { tableFrom: ctx.from, anchor: end, focus: start }
         : { tableFrom: ctx.from, anchor: start, focus: end };
-}
-
-/**
- * Builds the state transition used when deletion reaches a rendered table.
- * The focus edge follows the direction the caret approached from, keeping the
- * hidden root selection and any subsequent scrolling close to that boundary.
- */
-export function buildWholeTableSelectionTransaction(
-    ctx: TableContext,
-    focusEdge: WholeTableSelectionFocus
-): TransactionSpec | null {
-    const selection = createWholeTableSelection(ctx, focusEdge);
-    if (!selection) {
-        return null;
-    }
-
-    const focusRange = resolveCellDocRange({
-        tableFrom: ctx.from,
-        ranges: ctx.cellRanges,
-        coords: selection.focus,
-    });
-    if (!focusRange) {
-        return null;
-    }
-
-    return {
-        selection: EditorSelection.single(focusRange.editableFrom),
-        effects: [setCellSelectionEffect.of(selection), clearActiveCellEffect.of(undefined)],
-        annotations: cellSelectionTransitionAnnotation.of(true),
-        scrollIntoView: false,
-    };
 }
 
 export function selectWholeTable(view: EditorView, ctx: TableContext, focusEdge: WholeTableSelectionFocus): boolean {

--- a/src/contentScript/tableRuntime/selection/cellSelectionController.ts
+++ b/src/contentScript/tableRuntime/selection/cellSelectionController.ts
@@ -3,6 +3,7 @@ import type { EditorView } from '@codemirror/view';
 import { clearActiveCellEffect } from '../../tableState/activeCellState';
 import {
     cellSelectionTransitionAnnotation,
+    clearCellSelectionEffect,
     fromUnifiedRow,
     getCellSelection,
     moveCellCoords,
@@ -18,6 +19,7 @@ import { resolveCellDocRange, resolveTableContextAtPos } from '../tableResolutio
 import { makeTableId, type CellCoords } from '../../tableModel/types';
 import { findCellElement } from '../../tableWidget/domHelpers';
 import { getResolvedActiveCell } from '../activeCell/resolvedActiveCell';
+import { exitTableToAdjacentLine, type TableExitSide } from '../navigation/tableExit';
 
 function clampSelectionFocusWithinContext(ctx: TableContext, focus: CellCoords): CellCoords | null {
     const bounds = getTableGridBounds(ctx);
@@ -165,6 +167,39 @@ export function extendExistingCellSelection(view: EditorView, direction: CellSel
         },
         { clearActiveCell: false }
     );
+}
+
+function exitSideForDirection(direction: CellSelectionDirection): TableExitSide {
+    return direction === 'up' || direction === 'left' ? 'before' : 'after';
+}
+
+/**
+ * Collapses a cell selection the way an unmodified arrow key collapses a text selection:
+ * the highlight is dropped and the caret lands outside the table, on the side the arrow
+ * points toward.
+ *
+ * Reports whether the key was consumed rather than whether the caret moved. A table
+ * pressed against a document edge has no adjacent line to move to, but the selection
+ * still has to go — letting the key fall through to the main editor there would move the
+ * caret around inside the table's hidden Markdown with the highlight left behind.
+ */
+export function collapseCellSelectionOutOfTable(view: EditorView, direction: CellSelectionDirection): boolean {
+    const selection = getCellSelection(view.state);
+    if (!selection) {
+        return false;
+    }
+
+    const ctx = resolveTableContextAtPos(view.state, selection.tableFrom);
+    if (!ctx) {
+        return false;
+    }
+
+    const effects = [clearCellSelectionEffect.of(undefined)];
+    if (!exitTableToAdjacentLine(view, ctx, exitSideForDirection(direction), effects)) {
+        view.dispatch({ effects });
+    }
+
+    return true;
 }
 
 export function setOrExtendCellSelectionToCoords(view: EditorView, focus: CellCoords, tableFrom: number): boolean {

--- a/src/contentScript/tableRuntime/selection/cellSelectionKeymap.ts
+++ b/src/contentScript/tableRuntime/selection/cellSelectionKeymap.ts
@@ -7,7 +7,11 @@ import {
 } from '../../tableState/cellSelectionState';
 import { getActiveCell } from '../../tableState/activeCellState';
 import { createActiveCellFromRanges } from '../activeCell/activeCellFactory';
-import { extendExistingCellSelection, startCellSelectionFromActiveCell } from './cellSelectionController';
+import {
+    collapseCellSelectionOutOfTable,
+    extendExistingCellSelection,
+    startCellSelectionFromActiveCell,
+} from './cellSelectionController';
 import { resolveTableContextAtPos } from '../tableResolution';
 import { canHandleTableSelectionKeydown } from './cellSelectionShortcutScope';
 import { handleSelectionDelete } from './cellSelectionClipboard';
@@ -105,9 +109,23 @@ function handleActivateKey(view: EditorView, event: KeyboardEvent): boolean {
     return !event.shiftKey && activateSelectionFocus(view);
 }
 
-/** Arrow keys extend the selection only while Shift is held. */
+function hasNoModifiers(event: KeyboardEvent): boolean {
+    return !event.shiftKey && !event.altKey && !event.ctrlKey && !event.metaKey;
+}
+
+/**
+ * Shift+Arrow extends the selection; a bare arrow collapses it and leaves the table.
+ * Modified arrows (word/line movement) are left to the main editor, which moves the
+ * caret out of the table's range and lets the selection guard drop the highlight.
+ */
 function arrowKeyHandler(direction: CellSelectionDirection): SelectionKeyHandler {
-    return (view, event) => event.shiftKey && extendOrStartSelection(view, direction);
+    return (view, event) => {
+        if (event.shiftKey) {
+            return extendOrStartSelection(view, direction);
+        }
+
+        return hasNoModifiers(event) && collapseCellSelectionOutOfTable(view, direction);
+    };
 }
 
 const selectionKeyHandlers: ReadonlyMap<string, SelectionKeyHandler> = new Map([

--- a/src/contentScript/tableRuntime/selection/cellSelectionKeymap.ts
+++ b/src/contentScript/tableRuntime/selection/cellSelectionKeymap.ts
@@ -16,6 +16,7 @@ import { resolveTableContextAtPos } from '../tableResolution';
 import { canHandleTableSelectionKeydown } from './cellSelectionShortcutScope';
 import { handleSelectionDelete } from './cellSelectionClipboard';
 import { requestOpenCell } from '../openCellRequest';
+import { getViewWindow } from '../../shared/domContext';
 
 type SelectionKeyHandler = (view: EditorView, event: KeyboardEvent) => boolean;
 
@@ -100,8 +101,24 @@ function runHistoryCommand(view: EditorView, command: Command): boolean {
     return handled;
 }
 
+const APPLE_PLATFORM_PATTERN = /Mac|iPhone|iPad|iPod/;
+
+/** Mirrors the modified Backspace/Delete gestures in CodeMirror's standard keymap. */
+function isSelectionDeletionKey(view: EditorView, event: KeyboardEvent): boolean {
+    const isApplePlatform = APPLE_PLATFORM_PATTERN.test(getViewWindow(view).navigator.platform);
+    if (isApplePlatform) {
+        return !event.ctrlKey && !event.shiftKey && event.altKey !== event.metaKey;
+    }
+
+    return !event.altKey && !event.metaKey && !event.shiftKey && event.ctrlKey;
+}
+
 function handleDeleteKey(view: EditorView, event: KeyboardEvent): boolean {
-    return !event.shiftKey && !event.altKey && !event.ctrlKey && !event.metaKey && handleSelectionDelete(view);
+    const isPlainDelete = !event.shiftKey && !event.altKey && !event.ctrlKey && !event.metaKey;
+    const isShiftBackspace =
+        event.key === 'Backspace' && event.shiftKey && !event.altKey && !event.ctrlKey && !event.metaKey;
+
+    return (isPlainDelete || isShiftBackspace || isSelectionDeletionKey(view, event)) && handleSelectionDelete(view);
 }
 
 /** Enter and Tab both open the focus cell; Shift+Enter/Tab are left to the editor. */

--- a/src/contentScript/tableRuntime/selection/cellSelectionScopeGuard.ts
+++ b/src/contentScript/tableRuntime/selection/cellSelectionScopeGuard.ts
@@ -1,0 +1,75 @@
+import { ViewPlugin, type EditorView, type ViewUpdate } from '@codemirror/view';
+import { clearCellSelectionEffect, getCellSelection } from '../../tableState/cellSelectionState';
+import { requestViewAnimationFrame } from '../../shared/domContext';
+import { hasCellSelectionTransitionAnnotation } from '../lifecycle/transactionFactPredicates';
+import { resolveContainingTableAtPos } from '../tableResolution';
+
+// The selected table is rendered as a widget, so the syntax tree already covers its start.
+// Resolution runs on the keyboard event path and must never block waiting for parse work.
+const SELECTION_SCOPE_SYNTAX_TREE_TIMEOUT_MS = 0;
+
+/**
+ * True when the caret no longer sits inside the table the cell selection belongs to.
+ *
+ * An unresolvable table reads as "cannot tell" rather than "left": the selection is stale
+ * either way, and clearing it here would pre-empt the paths that already handle a table
+ * disappearing out from under a selection.
+ */
+function selectionLeftSelectedTable(view: EditorView): boolean {
+    const cellSelection = getCellSelection(view.state);
+    if (!cellSelection) {
+        return false;
+    }
+
+    const table = resolveContainingTableAtPos(
+        view.state,
+        cellSelection.tableFrom,
+        SELECTION_SCOPE_SYNTAX_TREE_TIMEOUT_MS
+    );
+    if (!table) {
+        return false;
+    }
+
+    const { anchor, head } = view.state.selection.main;
+    const isInsideTable = (pos: number): boolean => pos >= table.from && pos <= table.to;
+
+    return !isInsideTable(anchor) || !isInsideTable(head);
+}
+
+/**
+ * Drops a cell selection once the caret leaves its table.
+ *
+ * A cell selection is a highlight drawn over a widget while the real caret is parked inside
+ * the table's replaced range. Nothing in CodeMirror ties the two together, so any main-editor
+ * command that moves the caret out — Ctrl+Home, PageUp/PageDown, a modified arrow — would
+ * otherwise strand the highlight on a table the caret has left.
+ *
+ * The dedicated selection paths (arrow keys, Escape, delete, activating a cell) clear the
+ * selection themselves and mark their transactions with `cellSelectionTransitionAnnotation`,
+ * which also covers their own moves of the caret inside the table. This guard is the backstop
+ * for everything else.
+ */
+export const cellSelectionScopeGuard = ViewPlugin.fromClass(
+    class {
+        constructor(private readonly view: EditorView) {}
+
+        update(update: ViewUpdate): void {
+            if (!update.selectionSet || hasCellSelectionTransitionAnnotation(update.transactions)) {
+                return;
+            }
+
+            if (!selectionLeftSelectedTable(this.view)) {
+                return;
+            }
+
+            // Dispatching during an update is not allowed, so the clear lands on the next frame.
+            requestViewAnimationFrame(this.view, () => {
+                if (!this.view.dom.isConnected || !selectionLeftSelectedTable(this.view)) {
+                    return;
+                }
+
+                this.view.dispatch({ effects: clearCellSelectionEffect.of(undefined) });
+            });
+        }
+    }
+);

--- a/src/contentScript/tableRuntime/selection/cellSelectionShortcutScope.ts
+++ b/src/contentScript/tableRuntime/selection/cellSelectionShortcutScope.ts
@@ -108,6 +108,10 @@ function canHandleShortcutForFocusedElement(
         return true;
     }
 
+    if (selection && isStructuralFocusHost(view, activeElement)) {
+        return true;
+    }
+
     if (isInteractiveElement(activeElement)) {
         return false;
     }
@@ -116,11 +120,7 @@ function canHandleShortcutForFocusedElement(
         return false;
     }
 
-    return (
-        isStructuralFocusHost(view, activeElement) ||
-        isInsideSelectedTableWidget(view, selection, activeElement) ||
-        view.dom.contains(activeElement)
-    );
+    return isInsideSelectedTableWidget(view, selection, activeElement) || view.dom.contains(activeElement);
 }
 
 /**

--- a/src/contentScript/tableWidget/cellSelectionVisuals.ts
+++ b/src/contentScript/tableWidget/cellSelectionVisuals.ts
@@ -1,5 +1,6 @@
+import type { Extension } from '@codemirror/state';
 import { EditorView, ViewPlugin, type ViewUpdate } from '@codemirror/view';
-import { getCellSelection, isCellInRect, toSelectionRect } from '../tableState/cellSelectionState';
+import { cellSelectionField, getCellSelection, isCellInRect, toSelectionRect } from '../tableState/cellSelectionState';
 import { CLASS_CELL_SELECTED, findTableWidgetElement, readCellCoords } from './domHelpers';
 import { makeTableId } from '../tableModel/types';
 
@@ -80,3 +81,29 @@ class CellSelectionVisualsController {
 }
 
 export const cellSelectionVisualsPlugin = ViewPlugin.fromClass(CellSelectionVisualsController);
+
+/**
+ * Hides the main editor's caret while a cell selection is active.
+ *
+ * The selection highlight is drawn on the widget's cells, but the real caret stays parked
+ * at the focus cell's document position so clipboard and shortcut handling keep working.
+ * `TableWidget.coordsAt` maps that position onto the cell's rectangle, so the caret paints
+ * inside the rendered table — a blinking insertion point between cells, in a table where
+ * typing is not what the selection is for. Suppress it and let the highlight carry the state.
+ *
+ * `caret-color` covers the browser's native caret; `.cm-cursorLayer` covers the one
+ * `drawSelection` paints when the host editor enables it.
+ */
+export const cellSelectionCaretSuppression: Extension = [
+    EditorView.editorAttributes.compute([cellSelectionField], (state): Record<string, string> =>
+        getCellSelection(state) ? { 'data-rt-cell-selection': '' } : {}
+    ),
+    EditorView.baseTheme({
+        '&[data-rt-cell-selection] .cm-content': {
+            caretColor: 'transparent',
+        },
+        '&[data-rt-cell-selection] .cm-cursorLayer': {
+            display: 'none',
+        },
+    }),
+];

--- a/src/contentScript/tableWidget/tableWidgetExtension.ts
+++ b/src/contentScript/tableWidget/tableWidgetExtension.ts
@@ -18,7 +18,8 @@ import { sourceModeField } from '../tableState/sourceMode';
 import { insertedTableActivationField } from '../tableState/insertedTableActivation';
 import { cellSelectionClipboardPlugin } from '../tableRuntime/selection/cellSelectionClipboard';
 import { cellSelectionKeyCapturePlugin } from '../tableRuntime/selection/cellSelectionKeymap';
-import { cellSelectionVisualsPlugin } from './cellSelectionVisuals';
+import { cellSelectionScopeGuard } from '../tableRuntime/selection/cellSelectionScopeGuard';
+import { cellSelectionCaretSuppression, cellSelectionVisualsPlugin } from './cellSelectionVisuals';
 import { isNestedEditorOpen, nestedEditorPlugin } from '../nestedEditor/nestedEditorController';
 import { nestedEditorFocusGuard } from '../nestedEditor/nestedEditorFocusGuard';
 import { createMainEditorActiveCellGuard } from '../editorBridge/mainEditorGuard';
@@ -127,8 +128,10 @@ async function registerTableWidgetExtension(
         closeOnOutsideMouseDown,
         outsideInteractionCapturePlugin,
         cellSelectionKeyCapturePlugin,
+        cellSelectionScopeGuard,
         cellSelectionClipboardPlugin,
         cellSelectionVisualsPlugin,
+        cellSelectionCaretSuppression,
         nestedEditorFocusGuard,
         nestedEditorLifecyclePlugin,
         tableDecorationField,

--- a/src/contentScript/tableWidget/tableWidgetExtension.ts
+++ b/src/contentScript/tableWidget/tableWidgetExtension.ts
@@ -36,6 +36,7 @@ import {
 } from '../tableRuntime/openCellRequest';
 import { createNoteIdWatcher } from '../tableRuntime/noteIdWatcher';
 import { createUndoScrollPreservation } from '../tableRuntime/undoScrollPreservation';
+import { mainEditorTableEntryExtension } from '../tableRuntime/navigation/mainEditorTableEntry';
 import {
     closeOnOutsideMouseDown,
     outsideInteractionCapturePlugin,
@@ -117,6 +118,7 @@ async function registerTableWidgetExtension(
         openCellRequestField,
         insertedTableActivationField,
         cellSelectionField,
+        mainEditorTableEntryExtension,
         createMainEditorActiveCellGuard(() => isNestedEditorOpen(cm6View)),
         openCellRequestKeymap,
         openCellRequestTimeoutPlugin,


### PR DESCRIPTION
Improve keyboard navigation within tables by allowing vertical arrow keys to enter/exit tables seamlessly.

Also improve behavior when backspacing/deleting into tables: instead of allowing characters inside the rendered table widget to be deleted, invoke the existing multi-cell selection functionality and select all table cells instead, so the next backspace clears all cells and one more deletes the table.

**Note:** Backspacing behavior was changed in #187 