### PR TITLE
fix: selection appearance issues when editor selection spans tables

### DIFF
--- a/docs/Architecture/Table-Display.md
+++ b/docs/Architecture/Table-Display.md
@@ -12,6 +12,18 @@ Lezer syntax tree scanner detects Markdown tables → replaced with `Decoration.
 - Wide tables scroll horizontally within container.
 - Each cell renders into a dedicated content wrapper (`CLASS_CELL_CONTENT`) so styling can be applied consistently between initial render and nested-editor activation.
 
+### Document Selection Over a Widget
+
+A selection spanning a table is drawn by CodeMirror's `.cm-selectionLayer`, which paints at
+`z-index: -1` (behind content). Two rules in `tableStyles.ts` keep that the only highlight:
+
+- `::selection` is suppressed inside `CLASS_CELL_CONTENT`. `drawSelection()` only suppresses the
+  native highlight under `.cm-line`, and a block widget sits outside every line, so without this
+  the browser stacks a second, opaque highlight over the layer. The widget-scoped selector is
+  load-bearing: it beats Joplin's own `&.cm-focused ::selection !important` rule on specificity.
+- `<th>` drops its background while `spannedTableVisuals.ts` marks the widget spanned, so the
+  layer shows through the header row too.
+
 ### Media and Embed Constraints
 
 Rendered cell HTML can include images, videos, and Joplin-rendered YouTube embeds.

--- a/docs/Architecture/Table-Display.md
+++ b/docs/Architecture/Table-Display.md
@@ -21,8 +21,10 @@ A selection spanning a table is drawn by CodeMirror's `.cm-selectionLayer`, whic
   native highlight under `.cm-line`, and a block widget sits outside every line, so without this
   the browser stacks a second, opaque highlight over the layer. The widget-scoped selector is
   load-bearing: it beats Joplin's own `&.cm-focused ::selection !important` rule on specificity.
-- `<th>` drops its background while `spannedTableVisuals.ts` marks the widget spanned, so the
-  layer shows through the header row too.
+- `<th>` drops its background while `spannedTableVisuals.ts` marks the widget strictly enclosed
+  by the selection, so the layer shows through the header row too. Exact and one-sided boundary
+  matches are excluded because CodeMirror does not paint its layer across the replacement widget
+  in those cases.
 
 ### Media and Embed Constraints
 

--- a/src/contentScript/__tests__/elementClassSync.test.ts
+++ b/src/contentScript/__tests__/elementClassSync.test.ts
@@ -1,0 +1,122 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { StateEffect, StateField } from '@codemirror/state';
+import { EditorView } from '@codemirror/view';
+import { afterEach, describe, expect, it } from 'vitest';
+import { createElementClassSyncPlugin } from '../tableWidget/elementClassSync';
+
+const MARKED = 'test-marked';
+
+// The collector reads from state so a dispatch drives it, the way the real collectors
+// derive their elements from the selection.
+const setTargetsEffect = StateEffect.define<string[]>();
+const targetsField = StateField.define<string[]>({
+    create: () => [],
+    update(value, transaction) {
+        for (const effect of transaction.effects) {
+            if (effect.is(setTargetsEffect)) {
+                return effect.value;
+            }
+        }
+        return value;
+    },
+});
+
+const mountedViews: EditorView[] = [];
+
+function mountView(): { view: EditorView; targets: Record<string, HTMLElement> } {
+    const parent = document.createElement('div');
+    document.body.appendChild(parent);
+
+    // Elements the plugin can mark, kept outside the editor content so CodeMirror's own
+    // DOM updates never replace them mid-test.
+    const targets: Record<string, HTMLElement> = {};
+    for (const id of ['a', 'b']) {
+        const element = document.createElement('div');
+        element.id = id;
+        parent.appendChild(element);
+        targets[id] = element;
+    }
+
+    const view = new EditorView({
+        parent,
+        doc: 'doc',
+        extensions: [
+            targetsField,
+            createElementClassSyncPlugin(MARKED, (v) => v.state.field(targetsField).map((id) => targets[id])),
+        ],
+    });
+    mountedViews.push(view);
+
+    return { view, targets };
+}
+
+/** Runs the measure cycle the class sync defers its DOM work to. */
+function flushMeasure(): Promise<void> {
+    return new Promise((resolve) => requestAnimationFrame(() => resolve()));
+}
+
+async function setTargets(view: EditorView, ids: string[]): Promise<void> {
+    view.dispatch({ effects: setTargetsEffect.of(ids) });
+    await flushMeasure();
+}
+
+afterEach(() => {
+    while (mountedViews.length > 0) {
+        mountedViews.pop()?.destroy();
+    }
+    document.body.replaceChildren();
+});
+
+describe('createElementClassSyncPlugin', () => {
+    it('marks the collected elements', async () => {
+        const { view, targets } = mountView();
+
+        await setTargets(view, ['a', 'b']);
+
+        expect(targets.a.classList.contains(MARKED)).toBe(true);
+        expect(targets.b.classList.contains(MARKED)).toBe(true);
+    });
+
+    it('unmarks elements the collector stops returning', async () => {
+        const { view, targets } = mountView();
+        await setTargets(view, ['a', 'b']);
+
+        await setTargets(view, ['b']);
+
+        expect(targets.a.classList.contains(MARKED)).toBe(false);
+        expect(targets.b.classList.contains(MARKED)).toBe(true);
+    });
+
+    it('clears every mark when the collector returns nothing', async () => {
+        const { view, targets } = mountView();
+        await setTargets(view, ['a', 'b']);
+
+        await setTargets(view, []);
+
+        expect(targets.a.classList.contains(MARKED)).toBe(false);
+        expect(targets.b.classList.contains(MARKED)).toBe(false);
+    });
+
+    it('leaves a class it did not add alone', async () => {
+        const { view, targets } = mountView();
+        targets.a.classList.add(MARKED);
+
+        // 'a' is never collected, so the sync must not take ownership of its class.
+        await setTargets(view, ['b']);
+
+        expect(targets.a.classList.contains(MARKED)).toBe(true);
+    });
+
+    it('clears its marks when the view is destroyed', async () => {
+        const { view, targets } = mountView();
+        await setTargets(view, ['a', 'b']);
+
+        view.destroy();
+
+        expect(targets.a.classList.contains(MARKED)).toBe(false);
+        expect(targets.b.classList.contains(MARKED)).toBe(false);
+    });
+});

--- a/src/contentScript/__tests__/spannedTableVisuals.test.ts
+++ b/src/contentScript/__tests__/spannedTableVisuals.test.ts
@@ -30,18 +30,26 @@ function spannedIdsFor(state: EditorState, anchor: number, head: number): Set<st
 }
 
 describe('collectSpannedTableIds', () => {
-    it('reports a table whose whole range is covered by the selection', () => {
+    it('reports a table whose range is strictly enclosed by the selection', () => {
         const state = createState();
         const table = tableRange(state);
 
         expect(spannedIdsFor(state, 0, state.doc.length)).toEqual(new Set([makeTableId(table.from)]));
     });
 
-    it('reports a selection that matches the table range exactly', () => {
+    it('ignores a selection that matches the table range exactly', () => {
         const state = createState();
         const table = tableRange(state);
 
-        expect(spannedIdsFor(state, table.from, table.to)).toEqual(new Set([makeTableId(table.from)]));
+        expect(spannedIdsFor(state, table.from, table.to)).toEqual(new Set());
+    });
+
+    it('ignores a fully covered table when either selection endpoint matches its boundary', () => {
+        const state = createState();
+        const table = tableRange(state);
+
+        expect(spannedIdsFor(state, table.from, state.doc.length)).toEqual(new Set());
+        expect(spannedIdsFor(state, 0, table.to)).toEqual(new Set());
     });
 
     it('ignores a selection that only reaches part-way into the table', () => {

--- a/src/contentScript/__tests__/spannedTableVisuals.test.ts
+++ b/src/contentScript/__tests__/spannedTableVisuals.test.ts
@@ -1,0 +1,65 @@
+import type { EditorState } from '@codemirror/state';
+import { describe, expect, it } from 'vitest';
+import { makeTableId } from '../tableModel/types';
+import { collectSpannedTableIds } from '../tableWidget/spannedTableVisuals';
+import { tableDecorationField } from '../tableWidget/tableDecorationField';
+import { createMarkdownState } from './testMarkdownState';
+
+const TABLE = ['| H1 | H2 |', '| --- | --- |', '| a1 | a2 |'].join('\n');
+const DOC = `above\n${TABLE}\nbelow`;
+
+function createState(): EditorState {
+    return createMarkdownState(DOC, [tableDecorationField]);
+}
+
+function tableRange(state: EditorState): { from: number; to: number } {
+    let range: { from: number; to: number } | null = null;
+    state.field(tableDecorationField).decorations.between(0, state.doc.length, (from, to) => {
+        range = { from, to };
+    });
+
+    if (!range) {
+        throw new Error('Expected the document to contain a table decoration');
+    }
+
+    return range;
+}
+
+function spannedIdsFor(state: EditorState, anchor: number, head: number): Set<string> {
+    return collectSpannedTableIds(state.update({ selection: { anchor, head } }).state);
+}
+
+describe('collectSpannedTableIds', () => {
+    it('reports a table whose whole range is covered by the selection', () => {
+        const state = createState();
+        const table = tableRange(state);
+
+        expect(spannedIdsFor(state, 0, state.doc.length)).toEqual(new Set([makeTableId(table.from)]));
+    });
+
+    it('reports a selection that matches the table range exactly', () => {
+        const state = createState();
+        const table = tableRange(state);
+
+        expect(spannedIdsFor(state, table.from, table.to)).toEqual(new Set([makeTableId(table.from)]));
+    });
+
+    it('ignores a selection that only reaches part-way into the table', () => {
+        const state = createState();
+        const table = tableRange(state);
+
+        expect(spannedIdsFor(state, 0, table.to - 1)).toEqual(new Set());
+        expect(spannedIdsFor(state, table.from + 1, state.doc.length)).toEqual(new Set());
+    });
+
+    it('ignores a cursor parked inside the table', () => {
+        const state = createState();
+        const table = tableRange(state);
+
+        expect(spannedIdsFor(state, table.from, table.from)).toEqual(new Set());
+    });
+
+    it('returns nothing when the decoration field is absent', () => {
+        expect(collectSpannedTableIds(createMarkdownState(DOC))).toEqual(new Set());
+    });
+});

--- a/src/contentScript/nestedEditor/rootEditorSelectionTheme.ts
+++ b/src/contentScript/nestedEditor/rootEditorSelectionTheme.ts
@@ -16,10 +16,8 @@ export const rootEditorActiveCellAttribute = EditorView.editorAttributes.compute
 export const rootEditorSelectionSuppression = EditorView.baseTheme({
     [`&[data-rt-nested-active] .${CLASS_CELL_EDITOR} .cm-content::selection`]: {
         'background-color': 'transparent !important',
-        color: 'inherit !important',
     },
     [`&[data-rt-nested-active] .${CLASS_CELL_EDITOR} .cm-content *::selection`]: {
         'background-color': 'transparent !important',
-        color: 'inherit !important',
     },
 });

--- a/src/contentScript/tableWidget/cellSelectionVisuals.ts
+++ b/src/contentScript/tableWidget/cellSelectionVisuals.ts
@@ -1,8 +1,9 @@
 import type { Extension } from '@codemirror/state';
-import { EditorView, ViewPlugin, type ViewUpdate } from '@codemirror/view';
+import { EditorView } from '@codemirror/view';
 import { cellSelectionField, getCellSelection, isCellInRect, toSelectionRect } from '../tableState/cellSelectionState';
 import { CLASS_CELL_SELECTED, findTableWidgetElement, readCellCoords } from './domHelpers';
 import { makeTableId } from '../tableModel/types';
+import { createElementClassSyncPlugin } from './elementClassSync';
 
 function collectSelectedCells(view: EditorView): HTMLElement[] {
     const selection = getCellSelection(view.state);
@@ -33,54 +34,10 @@ function collectSelectedCells(view: EditorView): HTMLElement[] {
     return selectedCells;
 }
 
-class CellSelectionVisualsController {
-    private selectedCells = new Set<HTMLElement>();
-    private destroyed = false;
-
-    constructor(private readonly view: EditorView) {
-        this.scheduleSync();
-    }
-
-    update(_update: ViewUpdate): void {
-        this.scheduleSync();
-    }
-
-    destroy(): void {
-        this.destroyed = true;
-        this.clear();
-    }
-
-    private clear(): void {
-        for (const cell of this.selectedCells) {
-            cell.classList.remove(CLASS_CELL_SELECTED);
-        }
-        this.selectedCells.clear();
-    }
-
-    private scheduleSync(): void {
-        this.view.requestMeasure({
-            key: this,
-            // Selection rewrites can rebuild the table widget, and ViewPlugin.update()
-            // may run before the replacement DOM is mounted. Defer the DOM query/write
-            // to the measure phase so the highlight is applied against the current widget.
-            read: () => collectSelectedCells(this.view),
-            write: (selectedCells: HTMLElement[]) => {
-                if (this.destroyed) {
-                    return;
-                }
-
-                this.clear();
-
-                for (const element of selectedCells) {
-                    element.classList.add(CLASS_CELL_SELECTED);
-                    this.selectedCells.add(element);
-                }
-            },
-        });
-    }
-}
-
-export const cellSelectionVisualsPlugin = ViewPlugin.fromClass(CellSelectionVisualsController);
+export const cellSelectionVisualsPlugin: Extension = createElementClassSyncPlugin(
+    CLASS_CELL_SELECTED,
+    collectSelectedCells
+);
 
 /**
  * Hides the main editor's caret while a cell selection is active.

--- a/src/contentScript/tableWidget/domHelpers.ts
+++ b/src/contentScript/tableWidget/domHelpers.ts
@@ -5,6 +5,8 @@ import type { EditorView } from '@codemirror/view';
 export const CLASS_TABLE_WIDGET = 'cm-table-widget';
 export const CLASS_TABLE_WIDGET_TABLE = 'cm-table-widget-table';
 export const CLASS_CELL_SELECTED = 'cm-table-cell-selected';
+// Set on a widget root while a document selection covers the whole table.
+export const CLASS_TABLE_WIDGET_SPANNED = 'cm-table-widget-spanned';
 
 // Floating toolbar container (positioned relative to the active table widget)
 export const CLASS_FLOATING_TOOLBAR = 'cm-table-floating-toolbar';

--- a/src/contentScript/tableWidget/domHelpers.ts
+++ b/src/contentScript/tableWidget/domHelpers.ts
@@ -26,7 +26,7 @@ export const SECTION_BODY = 'body';
  * Returns the CSS selector matching every table widget root.
  *
  * Deliberately position-agnostic: identity comes from `posAtDOM()` via
- * `findTableWidgetElement()`, never from `data-table-from`.
+ * `iterateTableWidgets()`, never from `data-table-from`.
  *
  * @returns The CSS selector string.
  *
@@ -86,27 +86,59 @@ export function readCellCoords(cell: HTMLElement): CellCoords | null {
 }
 
 /**
- * Locate a table widget root element by matching its current document position.
+ * Yields every rendered table widget root paired with the table it currently belongs to.
  *
- * We deliberately avoid relying on `data-table-from` for identity because it may
- * become stale when decorations are mapped (but not rebuilt) through edits.
+ * The single place identity is resolved: always from `posAtDOM()`, never from
+ * `data-table-from`, which may become stale when decorations are mapped (but not
+ * rebuilt) through edits. Widgets whose position cannot be resolved are skipped.
  */
-export function findTableWidgetElement(view: EditorView, tableId: TableId): HTMLElement | null {
+function* iterateTableWidgets(view: EditorView): Generator<{ element: HTMLElement; tableId: TableId }> {
     // Prefer contentDOM so we only scan editor content (not gutters/toolbars).
-    const allWidgets = view.contentDOM.querySelectorAll(getWidgetSelector());
-
-    for (const widget of allWidgets) {
+    for (const element of view.contentDOM.querySelectorAll<HTMLElement>(getWidgetSelector())) {
+        let tableId: TableId;
         try {
-            const widgetPos = view.posAtDOM(widget);
-            if (makeTableId(widgetPos) === tableId) {
-                return widget as HTMLElement;
-            }
+            tableId = makeTableId(view.posAtDOM(element));
         } catch {
             // posAtDOM can fail for edge cases, continue
+            continue;
+        }
+
+        yield { element, tableId };
+    }
+}
+
+/**
+ * Locate a table widget root element by matching its current document position.
+ */
+export function findTableWidgetElement(view: EditorView, tableId: TableId): HTMLElement | null {
+    for (const widget of iterateTableWidgets(view)) {
+        if (widget.tableId === tableId) {
+            return widget.element;
         }
     }
 
     return null;
+}
+
+/**
+ * Collects the widget roots of the given tables, in document order.
+ *
+ * Ids with no rendered widget (outside the viewport, or already gone) are simply absent
+ * from the result.
+ */
+export function collectTableWidgetElements(view: EditorView, tableIds: ReadonlySet<TableId>): HTMLElement[] {
+    if (tableIds.size === 0) {
+        return [];
+    }
+
+    const elements: HTMLElement[] = [];
+    for (const { element, tableId } of iterateTableWidgets(view)) {
+        if (tableIds.has(tableId)) {
+            elements.push(element);
+        }
+    }
+
+    return elements;
 }
 
 /**

--- a/src/contentScript/tableWidget/domHelpers.ts
+++ b/src/contentScript/tableWidget/domHelpers.ts
@@ -5,7 +5,7 @@ import type { EditorView } from '@codemirror/view';
 export const CLASS_TABLE_WIDGET = 'cm-table-widget';
 export const CLASS_TABLE_WIDGET_TABLE = 'cm-table-widget-table';
 export const CLASS_CELL_SELECTED = 'cm-table-cell-selected';
-// Set on a widget root while a document selection covers the whole table.
+// Set on a widget root while CodeMirror's document selection layer spans the whole table.
 export const CLASS_TABLE_WIDGET_SPANNED = 'cm-table-widget-spanned';
 
 // Floating toolbar container (positioned relative to the active table widget)

--- a/src/contentScript/tableWidget/elementClassSync.ts
+++ b/src/contentScript/tableWidget/elementClassSync.ts
@@ -1,0 +1,70 @@
+import type { Extension } from '@codemirror/state';
+import { EditorView, ViewPlugin, type PluginValue } from '@codemirror/view';
+
+/**
+ * Keeps a CSS class in sync with the set of elements a collector derives from editor state.
+ *
+ * Selection rewrites can rebuild a table widget, and `ViewPlugin.update()` may run before the
+ * replacement DOM is mounted, so both the collect and the class write happen in the measure
+ * phase, against the DOM that is actually on screen.
+ */
+class ElementClassSync implements PluginValue {
+    private marked = new Set<HTMLElement>();
+    private destroyed = false;
+
+    constructor(
+        private readonly view: EditorView,
+        private readonly className: string,
+        private readonly collect: (view: EditorView) => HTMLElement[]
+    ) {
+        this.scheduleSync();
+    }
+
+    update(): void {
+        this.scheduleSync();
+    }
+
+    destroy(): void {
+        this.destroyed = true;
+        this.clear();
+    }
+
+    private clear(): void {
+        for (const element of this.marked) {
+            element.classList.remove(this.className);
+        }
+        this.marked.clear();
+    }
+
+    private scheduleSync(): void {
+        this.view.requestMeasure({
+            key: this,
+            read: () => this.collect(this.view),
+            write: (elements: HTMLElement[]) => {
+                if (this.destroyed) {
+                    return;
+                }
+
+                this.clear();
+
+                for (const element of elements) {
+                    element.classList.add(this.className);
+                    this.marked.add(element);
+                }
+            },
+        });
+    }
+}
+
+/**
+ * Builds a view plugin that owns `className` on whatever elements `collect` returns.
+ *
+ * Each plugin instance only ever removes the class from elements it added it to, so two
+ * syncs must not share a class name.
+ */
+export function createElementClassSyncPlugin(
+    className: string,
+    collect: (view: EditorView) => HTMLElement[]
+): Extension {
+    return ViewPlugin.define((view) => new ElementClassSync(view, className, collect));
+}

--- a/src/contentScript/tableWidget/spannedTableVisuals.ts
+++ b/src/contentScript/tableWidget/spannedTableVisuals.ts
@@ -1,0 +1,71 @@
+import type { EditorState, Extension } from '@codemirror/state';
+import type { EditorView } from '@codemirror/view';
+import { makeTableId, type TableId } from '../tableModel/types';
+import { CLASS_TABLE_WIDGET_SPANNED, getWidgetSelector } from './domHelpers';
+import { createElementClassSyncPlugin } from './elementClassSync';
+import { tableDecorationField } from './tableDecorationField';
+
+/**
+ * Returns the ids of the tables whose entire widget range sits inside one selection range.
+ *
+ * Partial overlaps are deliberately excluded: CodeMirror's own selection rectangle already
+ * stops part-way through the widget in that case, so clearing the cell backgrounds would
+ * overstate how much of the table is selected.
+ */
+export function collectSpannedTableIds(state: EditorState): Set<TableId> {
+    const spanned = new Set<TableId>();
+    const tableDecorations = state.field(tableDecorationField, false);
+    if (!tableDecorations) {
+        return spanned;
+    }
+
+    for (const range of state.selection.ranges) {
+        // A cursor parked inside a table (an active cell, or a cell selection) is not a
+        // document selection spanning it.
+        if (range.empty) {
+            continue;
+        }
+
+        tableDecorations.decorations.between(range.from, range.to, (from, to) => {
+            if (from >= range.from && to <= range.to) {
+                spanned.add(makeTableId(from));
+            }
+        });
+    }
+
+    return spanned;
+}
+
+function collectSpannedWidgets(view: EditorView): HTMLElement[] {
+    const spanned = collectSpannedTableIds(view.state);
+    if (spanned.size === 0) {
+        return [];
+    }
+
+    // Widget identity comes from `posAtDOM()`, never from `data-table-from`, which can be
+    // stale when decorations are mapped rather than rebuilt.
+    const widgets: HTMLElement[] = [];
+    for (const element of view.contentDOM.querySelectorAll<HTMLElement>(getWidgetSelector())) {
+        try {
+            if (spanned.has(makeTableId(view.posAtDOM(element)))) {
+                widgets.push(element);
+            }
+        } catch {
+            // posAtDOM can fail for edge cases, continue
+        }
+    }
+
+    return widgets;
+}
+
+/**
+ * Marks the table widgets a document selection covers, so they can drop the cell backgrounds
+ * that would otherwise hide CodeMirror's selection layer.
+ *
+ * `.cm-selectionLayer` paints at `z-index: -1`, behind the content, so the selection only
+ * shows through cells that have no background of their own.
+ */
+export const spannedTableVisualsPlugin: Extension = createElementClassSyncPlugin(
+    CLASS_TABLE_WIDGET_SPANNED,
+    collectSpannedWidgets
+);

--- a/src/contentScript/tableWidget/spannedTableVisuals.ts
+++ b/src/contentScript/tableWidget/spannedTableVisuals.ts
@@ -1,7 +1,7 @@
 import type { EditorState, Extension } from '@codemirror/state';
 import type { EditorView } from '@codemirror/view';
 import { makeTableId, type TableId } from '../tableModel/types';
-import { CLASS_TABLE_WIDGET_SPANNED, getWidgetSelector } from './domHelpers';
+import { CLASS_TABLE_WIDGET_SPANNED, collectTableWidgetElements } from './domHelpers';
 import { createElementClassSyncPlugin } from './elementClassSync';
 import { tableDecorationField } from './tableDecorationField';
 
@@ -37,25 +37,7 @@ export function collectSpannedTableIds(state: EditorState): Set<TableId> {
 }
 
 function collectSpannedWidgets(view: EditorView): HTMLElement[] {
-    const spanned = collectSpannedTableIds(view.state);
-    if (spanned.size === 0) {
-        return [];
-    }
-
-    // Widget identity comes from `posAtDOM()`, never from `data-table-from`, which can be
-    // stale when decorations are mapped rather than rebuilt.
-    const widgets: HTMLElement[] = [];
-    for (const element of view.contentDOM.querySelectorAll<HTMLElement>(getWidgetSelector())) {
-        try {
-            if (spanned.has(makeTableId(view.posAtDOM(element)))) {
-                widgets.push(element);
-            }
-        } catch {
-            // posAtDOM can fail for edge cases, continue
-        }
-    }
-
-    return widgets;
+    return collectTableWidgetElements(view, collectSpannedTableIds(view.state));
 }
 
 /**

--- a/src/contentScript/tableWidget/spannedTableVisuals.ts
+++ b/src/contentScript/tableWidget/spannedTableVisuals.ts
@@ -6,11 +6,11 @@ import { createElementClassSyncPlugin } from './elementClassSync';
 import { tableDecorationField } from './tableDecorationField';
 
 /**
- * Returns the ids of the tables whose entire widget range sits inside one selection range.
+ * Returns the ids of tables whose widget range is strictly enclosed by one selection range.
  *
- * Partial overlaps are deliberately excluded: CodeMirror's own selection rectangle already
- * stops part-way through the widget in that case, so clearing the cell backgrounds would
- * overstate how much of the table is selected.
+ * CodeMirror only paints its selection layer across a replacement widget when both selection
+ * endpoints sit outside the widget. Exact matches, boundary matches, and partial overlaps are
+ * excluded so cell backgrounds are only cleared when there is a layer underneath them.
  */
 export function collectSpannedTableIds(state: EditorState): Set<TableId> {
     const spanned = new Set<TableId>();
@@ -27,7 +27,7 @@ export function collectSpannedTableIds(state: EditorState): Set<TableId> {
         }
 
         tableDecorations.decorations.between(range.from, range.to, (from, to) => {
-            if (from >= range.from && to <= range.to) {
+            if (from > range.from && to < range.to) {
                 spanned.add(makeTableId(from));
             }
         });
@@ -59,8 +59,8 @@ function collectSpannedWidgets(view: EditorView): HTMLElement[] {
 }
 
 /**
- * Marks the table widgets a document selection covers, so they can drop the cell backgrounds
- * that would otherwise hide CodeMirror's selection layer.
+ * Marks table widgets that sit strictly inside a document selection, so they can drop the cell
+ * backgrounds that would otherwise hide CodeMirror's selection layer.
  *
  * `.cm-selectionLayer` paints at `z-index: -1`, behind the content, so the selection only
  * shows through cells that have no background of their own.

--- a/src/contentScript/tableWidget/tableStyles.ts
+++ b/src/contentScript/tableWidget/tableStyles.ts
@@ -71,6 +71,17 @@ export const tableStyles = EditorView.baseTheme({
         paddingLeft: '1px !important',
         whiteSpace: 'normal',
     },
+    // A document selection spanning a replacement widget also creates a native DOM selection
+    // through its rendered content. Suppress that second highlight so it does not stack an
+    // opaque browser selection over CodeMirror's selection background.
+    [`${getWidgetSelector()} .${CLASS_CELL_CONTENT}::selection`]: {
+        'background-color': 'transparent !important',
+        color: 'inherit !important',
+    },
+    [`${getWidgetSelector()} .${CLASS_CELL_CONTENT} *::selection`]: {
+        'background-color': 'transparent !important',
+        color: 'inherit !important',
+    },
     [`.${CLASS_CELL_EDITOR_HIDDEN}`]: {
         // Empty span - no display:none to preserve cursor positioning at boundaries
     },

--- a/src/contentScript/tableWidget/tableStyles.ts
+++ b/src/contentScript/tableWidget/tableStyles.ts
@@ -76,11 +76,9 @@ export const tableStyles = EditorView.baseTheme({
     // opaque browser selection over CodeMirror's selection background.
     [`${getWidgetSelector()} .${CLASS_CELL_CONTENT}::selection`]: {
         'background-color': 'transparent !important',
-        color: 'inherit !important',
     },
     [`${getWidgetSelector()} .${CLASS_CELL_CONTENT} *::selection`]: {
         'background-color': 'transparent !important',
-        color: 'inherit !important',
     },
     [`.${CLASS_CELL_EDITOR_HIDDEN}`]: {
         // Empty span - no display:none to preserve cursor positioning at boundaries

--- a/src/contentScript/tableWidget/tableStyles.ts
+++ b/src/contentScript/tableWidget/tableStyles.ts
@@ -5,7 +5,12 @@ import {
     CLASS_CELL_EDITOR,
     CLASS_CELL_EDITOR_HIDDEN,
 } from '../shared/tableDomClasses';
-import { CLASS_CELL_SELECTED, CLASS_TABLE_WIDGET_TABLE, getWidgetSelector } from './domHelpers';
+import {
+    CLASS_CELL_SELECTED,
+    CLASS_TABLE_WIDGET_SPANNED,
+    CLASS_TABLE_WIDGET_TABLE,
+    getWidgetSelector,
+} from './domHelpers';
 
 /**
  * Base styles for the table widget, split by responsibility:
@@ -79,6 +84,13 @@ export const tableStyles = EditorView.baseTheme({
     },
     [`${getWidgetSelector()} .${CLASS_CELL_CONTENT} *::selection`]: {
         'background-color': 'transparent !important',
+    },
+    // CodeMirror's selection layer paints at `z-index: -1`, behind the content, so it only
+    // shows through cells that have no background of their own. Drop the header tint while a
+    // document selection covers the table, so the whole table carries the same selection
+    // colour as the surrounding text instead of leaving the header row looking unselected.
+    [`.${CLASS_TABLE_WIDGET_SPANNED} .${CLASS_TABLE_WIDGET_TABLE} th`]: {
+        backgroundColor: 'transparent',
     },
     [`.${CLASS_CELL_EDITOR_HIDDEN}`]: {
         // Empty span - no display:none to preserve cursor positioning at boundaries

--- a/src/contentScript/tableWidget/tableWidgetExtension.ts
+++ b/src/contentScript/tableWidget/tableWidgetExtension.ts
@@ -44,6 +44,7 @@ import {
 } from '../tableRuntime/interaction/outsideTableInteraction';
 import { createStartupCursorCorrection } from '../tableRuntime/startupCursorCorrection';
 import { tableDecorationField } from './tableDecorationField';
+import { spannedTableVisualsPlugin } from './spannedTableVisuals';
 import {
     rootEditorActiveCellAttribute,
     rootEditorSelectionSuppression,
@@ -131,6 +132,7 @@ async function registerTableWidgetExtension(
         cellSelectionScopeGuard,
         cellSelectionClipboardPlugin,
         cellSelectionVisualsPlugin,
+        spannedTableVisualsPlugin,
         cellSelectionCaretSuppression,
         nestedEditorFocusGuard,
         nestedEditorLifecyclePlugin,


### PR DESCRIPTION
Address multiple issues related to the appearance of selections in tables. Improve the visual consistency of selections spanning table headers and prevent unwanted background highlights. Introduce new plugins for better class synchronization and remove unnecessary CSS.