### PR TITLE
refactor: enter the boundary cell on deletion into a table

### DIFF
--- a/docs/Architecture/Interaction-and-Navigation.md
+++ b/docs/Architecture/Interaction-and-Navigation.md
@@ -16,6 +16,8 @@ From the main editor, hardware Backspace or Delete stops before it can remove th
 table or any of the table's hidden Markdown. Instead, it opens the boundary cell: Backspace enters the final cell at its
 end, while Delete enters the first cell at its start. Platform-standard word/line deletion shortcuts and Shift+Backspace
 receive the same protection. Extra blank lines between the caret and table remain ordinary editable text.
+For a ragged table, the target is the edge cell that has a source range; normalization makes the table rectangular after
+that resolvable cell has been activated.
 Protection follows CodeMirror's semantic `delete.backward` and `delete.forward` transactions rather than physical key
 bindings. Soft-keyboard and IME `input.type` transactions remain under CodeMirror's platform behavior. Further deletions
 arriving before the requested cell opens are dropped, since the caret is parked inside the table until then.

--- a/docs/Architecture/Interaction-and-Navigation.md
+++ b/docs/Architecture/Interaction-and-Navigation.md
@@ -18,8 +18,8 @@ end, while Delete enters the first cell at its start. Extra blank lines between 
 For a ragged table, the target is the edge cell that has a source range; normalization makes the table rectangular after
 that resolvable cell has been activated.
 Protection follows CodeMirror's semantic `delete.backward` and `delete.forward` transactions rather than physical key
-bindings. Soft-keyboard and IME `input.type` transactions remain under CodeMirror's platform behavior. Further deletions
-arriving before the requested cell opens are dropped, since the caret is parked inside the table until then.
+bindings. Soft-keyboard and IME `input.type` transactions remain under CodeMirror's platform behavior. Further deletions into that
+table, arriving before the requested cell opens, are dropped since the caret is parked inside it until then.
 
 While a cell selection is live the caret is parked at the focus cell's document position so clipboard and shortcut
 handling keep working, and the main editor's caret is hidden so the highlight alone conveys the state. An unmodified

--- a/docs/Architecture/Interaction-and-Navigation.md
+++ b/docs/Architecture/Interaction-and-Navigation.md
@@ -18,7 +18,8 @@ end, while Delete enters the first cell at its start. Extra blank lines between 
 For a ragged table, the target is the edge cell that has a source range; normalization makes the table rectangular after
 that resolvable cell has been activated.
 Protection follows CodeMirror's semantic `delete.backward` and `delete.forward` transactions rather than physical key
-bindings. Soft-keyboard and IME `input.type` transactions remain under CodeMirror's platform behavior. Further deletions into that
+bindings, and covers every caret of a multi-cursor deletion: the first table reached in document order is entered and
+the rest of the gesture is dropped, since a cell editor holds a single caret. Soft-keyboard and IME `input.type` transactions remain under CodeMirror's platform behavior. Further deletions into that
 table, arriving before the requested cell opens, are dropped since the caret is parked inside it until then.
 
 While a cell selection is live the caret is parked at the focus cell's document position so clipboard and shortcut

--- a/docs/Architecture/Interaction-and-Navigation.md
+++ b/docs/Architecture/Interaction-and-Navigation.md
@@ -17,7 +17,8 @@ table or any of the table's hidden Markdown. Instead, it opens the boundary cell
 end, while Delete enters the first cell at its start. Platform-standard word/line deletion shortcuts and Shift+Backspace
 receive the same protection. Extra blank lines between the caret and table remain ordinary editable text.
 Protection follows CodeMirror's semantic `delete.backward` and `delete.forward` transactions rather than physical key
-bindings. Soft-keyboard and IME `input.type` transactions remain under CodeMirror's platform behavior.
+bindings. Soft-keyboard and IME `input.type` transactions remain under CodeMirror's platform behavior. Further deletions
+arriving before the requested cell opens are dropped, since the caret is parked inside the table until then.
 
 While a cell selection is live the caret is parked at the focus cell's document position so clipboard and shortcut
 handling keep working, and the main editor's caret is hidden so the highlight alone conveys the state. An unmodified

--- a/docs/Architecture/Interaction-and-Navigation.md
+++ b/docs/Architecture/Interaction-and-Navigation.md
@@ -14,8 +14,7 @@ Cells are separate editor instances (or `<td>` when inactive). Key events are in
 
 From the main editor, hardware Backspace or Delete stops before it can remove the final line break adjoining a rendered
 table or any of the table's hidden Markdown. Instead, it opens the boundary cell: Backspace enters the final cell at its
-end, while Delete enters the first cell at its start. Platform-standard word/line deletion shortcuts and Shift+Backspace
-receive the same protection. Extra blank lines between the caret and table remain ordinary editable text.
+end, while Delete enters the first cell at its start. Extra blank lines between the caret and table remain ordinary editable text.
 For a ragged table, the target is the edge cell that has a source range; normalization makes the table rectangular after
 that resolvable cell has been activated.
 Protection follows CodeMirror's semantic `delete.backward` and `delete.forward` transactions rather than physical key

--- a/docs/Architecture/Interaction-and-Navigation.md
+++ b/docs/Architecture/Interaction-and-Navigation.md
@@ -13,10 +13,11 @@ Cells are separate editor instances (or `<td>` when inactive). Key events are in
 | **ArrowUp/Down**    | Navigate Line | At visual top/bottom boundary, jumps to cell above/below. |
 
 From the main editor, hardware Backspace or Delete stops before it can remove the final line break adjoining a rendered
-table or any of the table's hidden Markdown. The first deletion selects the complete cell grid; subsequent deletion uses
-the normal multi-cell removal behavior. Platform-standard word/line deletion shortcuts and Shift+Backspace receive the
-same protection. Extra blank lines between the caret and table remain ordinary editable text.
-Soft-keyboard and IME deletions are left to CodeMirror's platform behavior and are not intercepted by this extension.
+table or any of the table's hidden Markdown. Instead, it opens the boundary cell: Backspace enters the final cell at its
+end, while Delete enters the first cell at its start. Platform-standard word/line deletion shortcuts and Shift+Backspace
+receive the same protection. Extra blank lines between the caret and table remain ordinary editable text.
+Protection follows CodeMirror's semantic `delete.backward` and `delete.forward` transactions rather than physical key
+bindings. Soft-keyboard and IME `input.type` transactions remain under CodeMirror's platform behavior.
 
 While a cell selection is live the caret is parked at the focus cell's document position so clipboard and shortcut
 handling keep working, and the main editor's caret is hidden so the highlight alone conveys the state. An unmodified

--- a/src/contentScript/__tests__/cellSelectionKeymap.test.ts
+++ b/src/contentScript/__tests__/cellSelectionKeymap.test.ts
@@ -162,6 +162,10 @@ describe('cellSelectionKeymap', () => {
         { label: 'Ctrl+Backspace', init: { key: 'Backspace', ctrlKey: true } },
         { label: 'Ctrl+Delete', init: { key: 'Delete', ctrlKey: true } },
         { label: 'Shift+Backspace', init: { key: 'Backspace', shiftKey: true } },
+        { label: 'Option+Backspace', init: { key: 'Backspace', altKey: true } },
+        { label: 'Option+Delete', init: { key: 'Delete', altKey: true } },
+        { label: 'Command+Backspace', init: { key: 'Backspace', metaKey: true } },
+        { label: 'Command+Delete', init: { key: 'Delete', metaKey: true } },
     ])('routes $label through selection removal', ({ init }) => {
         const view = mountSelectionView(['| H1 | H2 |', '| --- | --- |', '| a1 | a2 |'].join('\n'));
 
@@ -178,32 +182,7 @@ describe('cellSelectionKeymap', () => {
         expect(view.state.doc.toString()).toBe(['| H1 | H2 |', '| --- | --- |', '|  |  |'].join('\n'));
     });
 
-    it.each([
-        { label: 'Option+Backspace', init: { key: 'Backspace', altKey: true } },
-        { label: 'Option+Delete', init: { key: 'Delete', altKey: true } },
-        { label: 'Command+Backspace', init: { key: 'Backspace', metaKey: true } },
-        { label: 'Command+Delete', init: { key: 'Delete', metaKey: true } },
-    ])('routes $label through selection removal on macOS', ({ init }) => {
-        vi.spyOn(window.navigator, 'platform', 'get').mockReturnValue('MacIntel');
-        const view = mountSelectionView(['| H1 | H2 |', '| --- | --- |', '| a1 | a2 |'].join('\n'));
-
-        view.dispatch({
-            effects: setCellSelectionEffect.of({
-                tableFrom: 0,
-                anchor: { section: 'body', row: 0, col: 0 },
-                focus: { section: 'body', row: 0, col: 1 },
-            }),
-        });
-
-        pressKey(init);
-
-        expect(view.state.doc.toString()).toBe(['| H1 | H2 |', '| --- | --- |', '|  |  |'].join('\n'));
-    });
-
-    it.each([
-        { label: 'Shift+Delete', modifiers: { shiftKey: true } },
-        { label: 'Ctrl+Alt+Delete', modifiers: { ctrlKey: true, altKey: true } },
-    ])('ignores $label because it is not a CodeMirror deletion command', ({ modifiers }) => {
+    it('leaves Shift+Delete to the clipboard handler, since it is the platform cut gesture', () => {
         const initialDoc = ['| H1 | H2 |', '| --- | --- |', '| a1 | a2 |'].join('\n');
         const view = mountSelectionView(initialDoc);
 
@@ -215,7 +194,7 @@ describe('cellSelectionKeymap', () => {
             }),
         });
 
-        pressKey({ key: 'Delete', ...modifiers });
+        pressKey({ key: 'Delete', shiftKey: true });
 
         expect(view.state.doc.toString()).toBe(initialDoc);
     });

--- a/src/contentScript/__tests__/cellSelectionScopeGuard.test.ts
+++ b/src/contentScript/__tests__/cellSelectionScopeGuard.test.ts
@@ -6,11 +6,13 @@ import { markdown } from '@codemirror/lang-markdown';
 import { EditorView } from '@codemirror/view';
 import { GFM } from '@lezer/markdown';
 import { afterEach, describe, expect, it } from 'vitest';
-import { activeCellField } from '../tableState/activeCellState';
-import { cellSelectionField, getCellSelection, setCellSelectionEffect } from '../tableState/cellSelectionState';
-import { selectWholeTable } from '../tableRuntime/selection/cellSelectionController';
+import {
+    cellSelectionField,
+    cellSelectionTransitionAnnotation,
+    getCellSelection,
+    setCellSelectionEffect,
+} from '../tableState/cellSelectionState';
 import { cellSelectionScopeGuard } from '../tableRuntime/selection/cellSelectionScopeGuard';
-import { resolveTableContextAtPos } from '../tableRuntime/tableResolution';
 
 const TABLE = ['| H1 | H2 |', '| --- | --- |', '| a1 | a2 |'].join('\n');
 const PREFIX = 'above';
@@ -27,7 +29,7 @@ function mountView(): EditorView {
     const view = new EditorView({
         parent,
         doc: DOC,
-        extensions: [markdown({ extensions: [GFM] }), activeCellField, cellSelectionField, cellSelectionScopeGuard],
+        extensions: [markdown({ extensions: [GFM] }), cellSelectionField, cellSelectionScopeGuard],
     });
     mountedViews.push(view);
 
@@ -40,9 +42,15 @@ function flushFrames(): Promise<void> {
 }
 
 function selectTable(view: EditorView): void {
-    const ctx = resolveTableContextAtPos(view.state, TABLE_FROM);
-    expect(ctx).not.toBeNull();
-    expect(selectWholeTable(view, ctx!, 'end')).toBe(true);
+    view.dispatch({
+        selection: { anchor: TABLE_FROM + 1 },
+        effects: setCellSelectionEffect.of({
+            tableFrom: TABLE_FROM,
+            anchor: { section: 'header', row: 0, col: 0 },
+            focus: { section: 'body', row: 0, col: 1 },
+        }),
+        annotations: cellSelectionTransitionAnnotation.of(true),
+    });
 }
 
 afterEach(() => {

--- a/src/contentScript/__tests__/cellSelectionVisuals.test.ts
+++ b/src/contentScript/__tests__/cellSelectionVisuals.test.ts
@@ -6,10 +6,7 @@ import { markdown } from '@codemirror/lang-markdown';
 import { EditorView } from '@codemirror/view';
 import { GFM } from '@lezer/markdown';
 import { afterEach, describe, expect, it } from 'vitest';
-import { activeCellField } from '../tableState/activeCellState';
-import { cellSelectionField, clearCellSelectionEffect } from '../tableState/cellSelectionState';
-import { selectWholeTable } from '../tableRuntime/selection/cellSelectionController';
-import { resolveTableContextAtPos } from '../tableRuntime/tableResolution';
+import { cellSelectionField, clearCellSelectionEffect, setCellSelectionEffect } from '../tableState/cellSelectionState';
 import { cellSelectionCaretSuppression } from '../tableWidget/cellSelectionVisuals';
 
 const TABLE = ['| H1 | H2 |', '| --- | --- |', '| a1 | a2 |'].join('\n');
@@ -25,12 +22,7 @@ function mountView(): EditorView {
     const view = new EditorView({
         parent,
         doc: DOC,
-        extensions: [
-            markdown({ extensions: [GFM] }),
-            activeCellField,
-            cellSelectionField,
-            cellSelectionCaretSuppression,
-        ],
+        extensions: [markdown({ extensions: [GFM] }), cellSelectionField, cellSelectionCaretSuppression],
     });
     mountedViews.push(view);
 
@@ -49,9 +41,13 @@ describe('cellSelectionCaretSuppression', () => {
         const view = mountView();
         expect(view.dom.hasAttribute('data-rt-cell-selection')).toBe(false);
 
-        const ctx = resolveTableContextAtPos(view.state, TABLE_FROM);
-        expect(ctx).not.toBeNull();
-        expect(selectWholeTable(view, ctx!, 'end')).toBe(true);
+        view.dispatch({
+            effects: setCellSelectionEffect.of({
+                tableFrom: TABLE_FROM,
+                anchor: { section: 'header', row: 0, col: 0 },
+                focus: { section: 'body', row: 0, col: 1 },
+            }),
+        });
         expect(view.dom.hasAttribute('data-rt-cell-selection')).toBe(true);
 
         view.dispatch({ effects: clearCellSelectionEffect.of(undefined) });

--- a/src/contentScript/__tests__/mainEditorTableEntry.test.ts
+++ b/src/contentScript/__tests__/mainEditorTableEntry.test.ts
@@ -17,7 +17,6 @@ import { tableDecorationField } from '../tableWidget/tableDecorationField';
 import { createMarkdownState } from './testMarkdownState';
 
 const TABLE = ['| H1 | H2 |', '| --- | --- |', '| a1 | a2 |', '| b1 | b2 |'].join('\n');
-const EMPTY_TABLE = ['|  |  |', '| --- | --- |', '|  |  |', '|  |  |'].join('\n');
 const mountedViews: EditorView[] = [];
 
 /** TableWidget observes its own DOM for height changes; jsdom has no ResizeObserver. */
@@ -65,15 +64,15 @@ function pressKey(view: EditorView, key: string, modifiers: KeyboardEventInit = 
     );
 }
 
-function expectWholeTableSelection(view: EditorView, focusEdge: 'start' | 'end'): void {
-    const start = { section: 'header', row: 0, col: 0 } as const;
-    const end = { section: 'body', row: 1, col: 1 } as const;
-
-    expect(getCellSelection(view.state)).toEqual(
-        focusEdge === 'start'
-            ? { tableFrom: view.state.doc.toString().indexOf(TABLE), anchor: end, focus: start }
-            : { tableFrom: view.state.doc.toString().indexOf(TABLE), anchor: start, focus: end }
+function expectBoundaryCellOpen(view: EditorView, edge: 'start' | 'end'): void {
+    const tableFrom = view.state.doc.toString().indexOf(TABLE);
+    expect(getActiveCell(view.state)).toEqual(
+        edge === 'start'
+            ? { tableFrom, section: 'header', row: 0, col: 0 }
+            : { tableFrom, section: 'body', row: 1, col: 1 }
     );
+    expect(getPendingOpenCellRequest(view.state)).toMatchObject({ initialCursorPos: edge });
+    expect(getCellSelection(view.state)).toBeNull();
 }
 
 beforeEach(() => {
@@ -94,17 +93,17 @@ function mockVerticalTarget(view: EditorView, targetPos: number): void {
 }
 
 describe('mainEditorTableEntry deletion protection', () => {
-    it('selects the entire table when Backspace reaches it from below', () => {
+    it('opens the final cell when Backspace reaches the table from below', () => {
         const doc = `${TABLE}\nafter`;
         const view = mountView(doc, TABLE.length + 1);
 
         pressKey(view, 'Backspace');
 
         expect(view.state.doc.toString()).toBe(doc);
-        expectWholeTableSelection(view, 'end');
+        expectBoundaryCellOpen(view, 'end');
     });
 
-    it('selects the entire table when Delete reaches it from above', () => {
+    it('opens the first cell when Delete reaches the table from above', () => {
         const prefix = 'before';
         const doc = `${prefix}\n${TABLE}`;
         const view = mountView(doc, prefix.length);
@@ -112,7 +111,25 @@ describe('mainEditorTableEntry deletion protection', () => {
         pressKey(view, 'Delete');
 
         expect(view.state.doc.toString()).toBe(doc);
-        expectWholeTableSelection(view, 'start');
+        expectBoundaryCellOpen(view, 'start');
+    });
+
+    it('opens the final header cell when Backspace reaches a table with no body rows', () => {
+        const headerOnlyTable = ['| H1 | H2 |', '| --- | --- |'].join('\n');
+        const doc = `${headerOnlyTable}\nafter`;
+        const view = mountView(doc, headerOnlyTable.length + 1);
+
+        pressKey(view, 'Backspace');
+
+        expect(view.state.doc.toString()).toBe(doc);
+        expect(getActiveCell(view.state)).toEqual({
+            tableFrom: 0,
+            section: 'header',
+            row: 0,
+            col: 1,
+        });
+        expect(getPendingOpenCellRequest(view.state)).toMatchObject({ initialCursorPos: 'end' });
+        expect(getCellSelection(view.state)).toBeNull();
     });
 
     it('deletes extra blank lines normally before protecting the final table boundary', () => {
@@ -125,18 +142,48 @@ describe('mainEditorTableEntry deletion protection', () => {
 
         pressKey(view, 'Backspace');
         expect(view.state.doc.toString()).toBe(`${TABLE}\nafter`);
-        expectWholeTableSelection(view, 'end');
+        expectBoundaryCellOpen(view, 'end');
     });
 
-    it('routes the next Backspace through the existing multi-cell removal behavior', () => {
+    it('protects the table from a semantic deletion transaction without a physical key event', () => {
         const doc = `${TABLE}\nafter`;
         const view = mountView(doc, TABLE.length + 1);
 
-        pressKey(view, 'Backspace');
-        pressKey(view, 'Backspace');
+        view.dispatch({
+            changes: { from: TABLE.length, to: TABLE.length + 1 },
+            userEvent: 'delete.backward',
+        });
 
-        expect(view.state.doc.toString()).toBe(`${EMPTY_TABLE}\nafter`);
-        expect(getCellSelection(view.state)).not.toBeNull();
+        expect(view.state.doc.toString()).toBe(doc);
+        expectBoundaryCellOpen(view, 'end');
+    });
+
+    it('leaves DOM and IME-style input transactions to CodeMirror', () => {
+        const doc = `${TABLE}\nafter`;
+        const view = mountView(doc, TABLE.length + 1);
+
+        view.dispatch({
+            changes: { from: TABLE.length, to: TABLE.length + 1 },
+            userEvent: 'input.type',
+        });
+
+        expect(view.state.doc.toString()).toBe(`${TABLE}after`);
+        expect(getActiveCell(view.state)).toBeNull();
+        expect(getPendingOpenCellRequest(view.state)).toBeNull();
+    });
+
+    it('does not redirect a semantic deletion that does not touch the adjoining table', () => {
+        const doc = `${TABLE}\nafter`;
+        const view = mountView(doc, TABLE.length + 1);
+
+        view.dispatch({
+            changes: { from: 1, to: 2 },
+            userEvent: 'delete.backward',
+        });
+
+        expect(view.state.doc.toString()).not.toBe(doc);
+        expect(getActiveCell(view.state)).toBeNull();
+        expect(getPendingOpenCellRequest(view.state)).toBeNull();
     });
 
     it.each([
@@ -151,6 +198,8 @@ describe('mainEditorTableEntry deletion protection', () => {
 
         expect(view.state.doc.toString()).not.toBe(doc);
         expect(getCellSelection(view.state)).toBeNull();
+        expect(getActiveCell(view.state)).toBeNull();
+        expect(getPendingOpenCellRequest(view.state)).toBeNull();
     });
 
     it('does not intercept deletion for a non-collapsed selection', () => {
@@ -161,6 +210,7 @@ describe('mainEditorTableEntry deletion protection', () => {
 
         expect(view.state.doc.toString()).toBe(`${TABLE}\n`);
         expect(getCellSelection(view.state)).toBeNull();
+        expect(getActiveCell(view.state)).toBeNull();
     });
 
     it.each([
@@ -170,7 +220,7 @@ describe('mainEditorTableEntry deletion protection', () => {
             modifiers: { ctrlKey: true },
             doc: `${TABLE}\nafter`,
             caret: TABLE.length + 1,
-            focusEdge: 'end' as const,
+            edge: 'end' as const,
         },
         {
             label: 'Ctrl+Delete',
@@ -178,7 +228,7 @@ describe('mainEditorTableEntry deletion protection', () => {
             modifiers: { ctrlKey: true },
             doc: `before\n${TABLE}`,
             caret: 'before'.length,
-            focusEdge: 'start' as const,
+            edge: 'start' as const,
         },
         {
             label: 'Shift+Backspace',
@@ -186,15 +236,15 @@ describe('mainEditorTableEntry deletion protection', () => {
             modifiers: { shiftKey: true },
             doc: `${TABLE}\nafter`,
             caret: TABLE.length + 1,
-            focusEdge: 'end' as const,
+            edge: 'end' as const,
         },
-    ])('protects the table from $label', ({ key, modifiers, doc, caret, focusEdge }) => {
+    ])('protects the table from $label', ({ key, modifiers, doc, caret, edge }) => {
         const view = mountView(doc, caret);
 
         pressKey(view, key, modifiers);
 
         expect(view.state.doc.toString()).toBe(doc);
-        expectWholeTableSelection(view, focusEdge);
+        expectBoundaryCellOpen(view, edge);
     });
 
     it('does not enter selection mode while an active cell exists', () => {

--- a/src/contentScript/__tests__/mainEditorTableEntry.test.ts
+++ b/src/contentScript/__tests__/mainEditorTableEntry.test.ts
@@ -103,6 +103,20 @@ describe('mainEditorTableEntry deletion protection', () => {
         expectBoundaryCellOpen(view, 'end');
     });
 
+    it('leaves a deletion elsewhere in the document alone while a request is in flight', () => {
+        const suffix = 'after';
+        const doc = `${TABLE}\n${suffix}`;
+        const view = mountView(doc, TABLE.length + 1);
+
+        pressKey(view, 'Backspace');
+        view.dispatch({
+            changes: { from: doc.length - 1, to: doc.length },
+            userEvent: 'delete.backward',
+        });
+
+        expect(view.state.doc.toString()).toBe(`${TABLE}\n${suffix.slice(0, -1)}`);
+    });
+
     it('drops repeat deletions while the open-cell request is still in flight', () => {
         const doc = `${TABLE}\nafter`;
         const view = mountView(doc, TABLE.length + 1);

--- a/src/contentScript/__tests__/mainEditorTableEntry.test.ts
+++ b/src/contentScript/__tests__/mainEditorTableEntry.test.ts
@@ -277,16 +277,6 @@ describe('mainEditorTableEntry deletion protection', () => {
         expect(getCellSelection(view.state)).toBeNull();
     });
 
-    it('does not intercept movement that stays outside a table', () => {
-        const doc = `text\n\n${TABLE}`;
-        const view = mountView(doc, 6);
-
-        pressKey(view, 'Backspace');
-
-        expect(view.state.doc.toString()).toBe(`text\n${TABLE}`);
-        expect(getCellSelection(view.state)).toBeNull();
-    });
-
     it('requires a single selection range', () => {
         const doc = `${TABLE}\nafter`;
         const view = mountView(doc, TABLE.length + 1);

--- a/src/contentScript/__tests__/mainEditorTableEntry.test.ts
+++ b/src/contentScript/__tests__/mainEditorTableEntry.test.ts
@@ -319,16 +319,54 @@ describe('mainEditorTableEntry deletion protection', () => {
         expect(getCellSelection(view.state)).toBeNull();
     });
 
-    it('requires a single selection range', () => {
+    it('enters the table one of several carets reaches, collapsing the rest', () => {
         const doc = `${TABLE}\nafter`;
         const view = mountView(doc, TABLE.length + 1);
         view.dispatch({
-            selection: EditorSelection.create([EditorSelection.cursor(TABLE.length + 1), EditorSelection.cursor(0)]),
+            selection: EditorSelection.create([
+                EditorSelection.cursor(doc.length),
+                EditorSelection.cursor(TABLE.length + 1),
+            ]),
         });
 
         pressKey(view, 'Backspace');
 
-        expect(getCellSelection(view.state)).toBeNull();
+        expect(view.state.doc.toString()).toBe(doc);
+        expect(view.state.selection.ranges).toHaveLength(1);
+        expectBoundaryCellOpen(view, 'end');
+    });
+
+    it('enters the first table in document order when carets reach two of them', () => {
+        const doc = `${TABLE}\n\nbetween\n\n${TABLE}\nafter`;
+        const secondTableFrom = doc.lastIndexOf(TABLE);
+        const view = mountView(doc, TABLE.length + 1);
+        view.dispatch({
+            selection: EditorSelection.create([
+                EditorSelection.cursor(TABLE.length + 1),
+                EditorSelection.cursor(secondTableFrom + TABLE.length + 1),
+            ]),
+        });
+
+        pressKey(view, 'Backspace');
+
+        expect(view.state.doc.toString()).toBe(doc);
+        expect(getActiveCell(view.state)).toEqual({ tableFrom: 0, section: 'body', row: 1, col: 1 });
+    });
+
+    it('still deletes when no caret of a multi-range deletion reaches a table', () => {
+        const doc = `${TABLE}\n\nalpha\nbeta`;
+        const view = mountView(doc, doc.length);
+        view.dispatch({
+            selection: EditorSelection.create([
+                EditorSelection.cursor(doc.indexOf('alpha') + 'alpha'.length),
+                EditorSelection.cursor(doc.length),
+            ]),
+        });
+
+        pressKey(view, 'Backspace');
+
+        expect(view.state.doc.toString()).toBe(`${TABLE}\n\nalph\nbet`);
+        expect(getActiveCell(view.state)).toBeNull();
     });
 });
 

--- a/src/contentScript/__tests__/mainEditorTableEntry.test.ts
+++ b/src/contentScript/__tests__/mainEditorTableEntry.test.ts
@@ -145,6 +145,34 @@ describe('mainEditorTableEntry deletion protection', () => {
         expect(getCellSelection(view.state)).toBeNull();
     });
 
+    it.each([
+        {
+            label: 'shorter than the header',
+            table: ['| H1 | H2 |', '| --- | --- |', '| a1 |'].join('\n'),
+            expectedCol: 0,
+        },
+        {
+            label: 'wider than the header',
+            table: ['| H1 |', '| --- |', '| a1 | a2 |'].join('\n'),
+            expectedCol: 1,
+        },
+    ])('opens the final source-backed cell when the last row is $label', ({ table, expectedCol }) => {
+        const doc = `${table}\nafter`;
+        const view = mountView(doc, table.length + 1);
+
+        pressKey(view, 'Backspace');
+
+        expect(view.state.doc.toString()).toBe(doc);
+        expect(getActiveCell(view.state)).toEqual({
+            tableFrom: 0,
+            section: 'body',
+            row: 0,
+            col: expectedCol,
+        });
+        expect(getPendingOpenCellRequest(view.state)).toMatchObject({ initialCursorPos: 'end' });
+        expect(getCellSelection(view.state)).toBeNull();
+    });
+
     it('deletes extra blank lines normally before protecting the final table boundary', () => {
         const doc = `${TABLE}\n\nafter`;
         const view = mountView(doc, TABLE.length + 2);

--- a/src/contentScript/__tests__/mainEditorTableEntry.test.ts
+++ b/src/contentScript/__tests__/mainEditorTableEntry.test.ts
@@ -103,6 +103,19 @@ describe('mainEditorTableEntry deletion protection', () => {
         expectBoundaryCellOpen(view, 'end');
     });
 
+    it('drops repeat deletions while the open-cell request is still in flight', () => {
+        const doc = `${TABLE}\nafter`;
+        const view = mountView(doc, TABLE.length + 1);
+
+        // The nested editor mounts a frame later, so the main editor still owns these.
+        pressKey(view, 'Backspace');
+        pressKey(view, 'Backspace');
+        pressKey(view, 'Backspace');
+
+        expect(view.state.doc.toString()).toBe(doc);
+        expectBoundaryCellOpen(view, 'end');
+    });
+
     it('opens the first cell when Delete reaches the table from above', () => {
         const prefix = 'before';
         const doc = `${prefix}\n${TABLE}`;

--- a/src/contentScript/tableRuntime/activeCell/cellActivation.ts
+++ b/src/contentScript/tableRuntime/activeCell/cellActivation.ts
@@ -5,12 +5,17 @@
 import { EditorView } from '@codemirror/view';
 import { clearActiveCellEffect, getActiveCell, type ActiveCell } from '../../tableState/activeCellState';
 import { isSourceModeEnabled } from '../../tableState/sourceMode';
-import { resolveContainingTableAtPos } from '../tableResolution';
+import { resolveContainingTableAtPos, resolveTableContextAtPos } from '../tableResolution';
 import { findCellForPos } from '../../tableModel/markdownTableCellRanges';
-import { buildTableContext } from '../../tableModel/tableContext';
+import { buildTableContext, type TableContext } from '../../tableModel/tableContext';
 import { createActiveCellFromRanges } from './activeCellFactory';
 import { createResolvedActiveCell } from './resolvedActiveCell';
-import { requestOpenCell } from '../openCellRequest';
+import {
+    prepareOpenCellRequestTransaction,
+    requestOpenCell,
+    type PreparedOpenCellRequestTransaction,
+} from '../openCellRequest';
+import type { CellCoords } from '../../tableModel/types';
 import type { InitialCursorPos } from '../../shared/cursorPlacement';
 
 export interface ActivateCellOptions {
@@ -136,7 +141,7 @@ export function activateCellAtPosition(view: EditorView, pos: number, options?: 
 export function activateTableCell(
     view: EditorView,
     tableFrom: number,
-    coords: { section: 'header' | 'body'; row: number; col: number },
+    coords: CellCoords,
     options: ActivateTableCellOptions = {}
 ): boolean {
     if (!view.dom.isConnected) return false;
@@ -144,24 +149,36 @@ export function activateTableCell(
     // Don't activate cells in source mode (no widgets exist)
     if (isSourceModeEnabled(view.state)) return false;
 
-    const table = resolveContainingTableAtPos(view.state, tableFrom);
-    if (!table) return false;
-
-    const ctx = buildTableContext(table);
+    const ctx = resolveTableContextAtPos(view.state, tableFrom);
     if (!ctx) return false;
 
-    const resolvedCell = createResolvedActiveCell({
-        ctx,
-        coords,
-    });
+    const spec = prepareCellEntryTransaction({ ctx, coords, initialCursorPos: options.initialCursorPos });
+    if (!spec) return false;
 
-    if (!resolvedCell) return false;
-
-    requestOpenCell(view, {
-        target: { resolvedCell },
-        normalizeIfNeeded: true,
-        initialCursorPos: options.initialCursorPos,
-    });
+    view.dispatch(spec);
 
     return true;
+}
+
+/**
+ * Builds the transaction that opens `coords` as the active cell.
+ *
+ * Shared by the dispatching entry points and by the boundary-deletion transaction
+ * filter, which can only return a spec.
+ */
+export function prepareCellEntryTransaction(params: {
+    ctx: TableContext;
+    coords: CellCoords;
+    initialCursorPos?: InitialCursorPos;
+}): PreparedOpenCellRequestTransaction | null {
+    const resolvedCell = createResolvedActiveCell({ ctx: params.ctx, coords: params.coords });
+    if (!resolvedCell) {
+        return null;
+    }
+
+    return prepareOpenCellRequestTransaction({
+        target: { resolvedCell },
+        normalizeIfNeeded: true,
+        initialCursorPos: params.initialCursorPos,
+    });
 }

--- a/src/contentScript/tableRuntime/navigation/mainEditorTableEntry.ts
+++ b/src/contentScript/tableRuntime/navigation/mainEditorTableEntry.ts
@@ -5,7 +5,7 @@ import { fromUnifiedRow, getCellSelection } from '../../tableState/cellSelection
 import { isEffectiveRawMode } from '../../tableState/sourceMode';
 import { getTableGridBounds, type TableContext } from '../../tableModel/tableContext';
 import { activateTableCell } from '../activeCell/cellActivation';
-import { createResolvedActiveCell } from '../activeCell/resolvedActiveCell';
+import { createResolvedActiveCell, getResolvedActiveCell } from '../activeCell/resolvedActiveCell';
 import { getPendingOpenCellRequest, prepareOpenCellRequestTransaction } from '../openCellRequest';
 import { resolveTableContextAtPos } from '../tableResolution';
 
@@ -39,9 +39,40 @@ function getDeletionDirection(transaction: Transaction): DeletionDirection | nul
     return null;
 }
 
+/**
+ * True while an open-cell request is still in flight with the caret parked inside its table.
+ *
+ * A request settles a frame or more after it is dispatched - later still when the table has
+ * to be normalized first. Until the nested editor mounts and takes focus, the main editor
+ * owns the keyboard with the caret sitting in the table's replaced range, so a repeat
+ * deletion would edit the hidden Markdown that this filter exists to protect.
+ */
+function isDeletingIntoPendingOpenCell(state: EditorState): boolean {
+    if (isEffectiveRawMode(state) || !getPendingOpenCellRequest(state)) {
+        return false;
+    }
+
+    const resolved = getResolvedActiveCell(state);
+    if (!resolved) {
+        return false;
+    }
+
+    const { head } = state.selection.main;
+    return head >= resolved.tableFrom && head <= resolved.tableTo;
+}
+
 const tableBoundaryDeletionFilter = EditorState.transactionFilter.of((transaction) => {
     const direction = getDeletionDirection(transaction);
-    if (!direction || !transaction.docChanged || !canEnterRenderedTable(transaction.startState)) {
+    if (!direction || !transaction.docChanged) {
+        return transaction;
+    }
+
+    // Drop the deletion outright: the caret is already on its way into a cell.
+    if (isDeletingIntoPendingOpenCell(transaction.startState)) {
+        return [];
+    }
+
+    if (!canEnterRenderedTable(transaction.startState)) {
         return transaction;
     }
 

--- a/src/contentScript/tableRuntime/navigation/mainEditorTableEntry.ts
+++ b/src/contentScript/tableRuntime/navigation/mainEditorTableEntry.ts
@@ -107,6 +107,11 @@ const tableBoundaryDeletionFilter = EditorState.transactionFilter.of((transactio
         return transaction;
     }
 
+    // CodeMirror's deletion commands remove one contiguous range anchored at the caret, so
+    // the character next to the caret is always part of it - including word- and line-wise
+    // deletion, which stops at the line boundary and reaches the table on the following
+    // press. Probing that one position identifies the table being deleted into without
+    // walking the change set; `touchesRange` then confirms this transaction is that deletion.
     const current = transaction.startState.selection.main;
     const targetPos = current.head + (direction === 'forward' ? 1 : -1);
     if (targetPos < 0 || targetPos > transaction.startState.doc.length) {

--- a/src/contentScript/tableRuntime/navigation/mainEditorTableEntry.ts
+++ b/src/contentScript/tableRuntime/navigation/mainEditorTableEntry.ts
@@ -3,7 +3,7 @@ import { BlockType, keymap, type BlockInfo, type EditorView } from '@codemirror/
 import { getActiveCell } from '../../tableState/activeCellState';
 import { fromUnifiedRow, getCellSelection } from '../../tableState/cellSelectionState';
 import { isEffectiveRawMode } from '../../tableState/sourceMode';
-import { getTableGridBounds, type TableContext } from '../../tableModel/tableContext';
+import type { TableContext } from '../../tableModel/tableContext';
 import { prepareCellEntryTransaction } from '../activeCell/cellActivation';
 import { getResolvedActiveCell } from '../activeCell/resolvedActiveCell';
 import { getPendingOpenCellRequest, type PreparedOpenCellRequestTransaction } from '../openCellRequest';
@@ -48,16 +48,16 @@ function getDeletionDirection(transaction: Transaction): DeletionDirection | nul
     return null;
 }
 
-function resolveEdgeCellCoords(ctx: TableContext, edges: EdgeCellTarget): CellCoords | null {
-    const bounds = getTableGridBounds(ctx);
-    if (bounds.totalRows <= 0 || bounds.totalCols <= 0) {
+function resolveSourceEdgeCellCoords(ctx: TableContext, edges: EdgeCellTarget): CellCoords | null {
+    const rows = [ctx.cellRanges.headers, ...ctx.cellRanges.rows];
+    const rowIndex = edges.row === 'first' ? 0 : rows.length - 1;
+    const row = rows[rowIndex];
+    if (!row?.length) {
         return null;
     }
 
-    return fromUnifiedRow(
-        edges.row === 'first' ? 0 : bounds.totalRows - 1,
-        edges.col === 'first' ? 0 : bounds.totalCols - 1
-    );
+    const colIndex = edges.col === 'first' ? 0 : row.length - 1;
+    return fromUnifiedRow(rowIndex, colIndex);
 }
 
 /** Transaction opening a table's edge cell, or null when the table has no usable grid. */
@@ -66,7 +66,10 @@ function prepareEdgeCellEntry(
     edges: EdgeCellTarget,
     initialCursorPos: InitialCursorPos
 ): PreparedOpenCellRequestTransaction | null {
-    const coords = resolveEdgeCellCoords(ctx, edges);
+    // Open requests must start from a source-backed cell. Normalization can make a
+    // ragged table rectangular after activation, but it cannot resolve a synthetic
+    // padded cell before that transaction has run.
+    const coords = resolveSourceEdgeCellCoords(ctx, edges);
     return coords ? prepareCellEntryTransaction({ ctx, coords, initialCursorPos }) : null;
 }
 

--- a/src/contentScript/tableRuntime/navigation/mainEditorTableEntry.ts
+++ b/src/contentScript/tableRuntime/navigation/mainEditorTableEntry.ts
@@ -4,13 +4,22 @@ import { getActiveCell } from '../../tableState/activeCellState';
 import { fromUnifiedRow, getCellSelection } from '../../tableState/cellSelectionState';
 import { isEffectiveRawMode } from '../../tableState/sourceMode';
 import { getTableGridBounds, type TableContext } from '../../tableModel/tableContext';
-import { activateTableCell } from '../activeCell/cellActivation';
-import { createResolvedActiveCell, getResolvedActiveCell } from '../activeCell/resolvedActiveCell';
-import { getPendingOpenCellRequest, prepareOpenCellRequestTransaction } from '../openCellRequest';
+import { prepareCellEntryTransaction } from '../activeCell/cellActivation';
+import { getResolvedActiveCell } from '../activeCell/resolvedActiveCell';
+import { getPendingOpenCellRequest, type PreparedOpenCellRequestTransaction } from '../openCellRequest';
 import { resolveTableContextAtPos } from '../tableResolution';
+import type { CellCoords } from '../../tableModel/types';
+import type { InitialCursorPos } from '../../shared/cursorPlacement';
 
 type DeletionDirection = 'backward' | 'forward';
 type VerticalEntryDirection = 'up' | 'down';
+/** Which end of a grid axis an entry lands on. */
+type GridEdge = 'first' | 'last';
+
+interface EdgeCellTarget {
+    row: GridEdge;
+    col: GridEdge;
+}
 
 // A rendered widget implies that table parsing has already completed. Keyboard
 // entry must never block waiting for syntax work on the keyboard event path.
@@ -37,6 +46,28 @@ function getDeletionDirection(transaction: Transaction): DeletionDirection | nul
     }
 
     return null;
+}
+
+function resolveEdgeCellCoords(ctx: TableContext, edges: EdgeCellTarget): CellCoords | null {
+    const bounds = getTableGridBounds(ctx);
+    if (bounds.totalRows <= 0 || bounds.totalCols <= 0) {
+        return null;
+    }
+
+    return fromUnifiedRow(
+        edges.row === 'first' ? 0 : bounds.totalRows - 1,
+        edges.col === 'first' ? 0 : bounds.totalCols - 1
+    );
+}
+
+/** Transaction opening a table's edge cell, or null when the table has no usable grid. */
+function prepareEdgeCellEntry(
+    ctx: TableContext,
+    edges: EdgeCellTarget,
+    initialCursorPos: InitialCursorPos
+): PreparedOpenCellRequestTransaction | null {
+    const coords = resolveEdgeCellCoords(ctx, edges);
+    return coords ? prepareCellEntryTransaction({ ctx, coords, initialCursorPos }) : null;
 }
 
 /**
@@ -90,22 +121,10 @@ const tableBoundaryDeletionFilter = EditorState.transactionFilter.of((transactio
         return transaction;
     }
 
-    const bounds = getTableGridBounds(ctx);
-    if (bounds.totalRows <= 0 || bounds.totalCols <= 0) {
-        return transaction;
-    }
-
     const isBackward = direction === 'backward';
-    const targetCoords = fromUnifiedRow(isBackward ? bounds.totalRows - 1 : 0, isBackward ? bounds.totalCols - 1 : 0);
-    const resolvedCell = createResolvedActiveCell({ ctx, coords: targetCoords });
-    if (!resolvedCell) {
-        return transaction;
-    }
+    const edges: EdgeCellTarget = isBackward ? { row: 'last', col: 'last' } : { row: 'first', col: 'first' };
 
-    return prepareOpenCellRequestTransaction({
-        target: { resolvedCell },
-        initialCursorPos: isBackward ? 'end' : 'start',
-    });
+    return prepareEdgeCellEntry(ctx, edges, isBackward ? 'end' : 'start') ?? transaction;
 });
 
 function isPositionMovingInDirection(
@@ -208,15 +227,18 @@ function activateTableAtVerticalTarget(view: EditorView, direction: VerticalEntr
         return false;
     }
 
-    const bounds = getTableGridBounds(ctx);
-    if (bounds.totalRows <= 0 || bounds.totalCols <= 0) {
+    const isDown = direction === 'down';
+    const spec = prepareEdgeCellEntry(
+        ctx,
+        { row: isDown ? 'first' : 'last', col: 'first' },
+        isDown ? 'start' : 'lastLineStart'
+    );
+    if (!spec) {
         return false;
     }
 
-    const targetCoords = fromUnifiedRow(direction === 'down' ? 0 : bounds.totalRows - 1, 0);
-    return activateTableCell(view, ctx.from, targetCoords, {
-        initialCursorPos: direction === 'down' ? 'start' : 'lastLineStart',
-    });
+    view.dispatch(spec);
+    return true;
 }
 
 const tableVerticalEntryKeymap = Prec.highest(

--- a/src/contentScript/tableRuntime/navigation/mainEditorTableEntry.ts
+++ b/src/contentScript/tableRuntime/navigation/mainEditorTableEntry.ts
@@ -1,4 +1,4 @@
-import { EditorState, Prec, type Extension, type Transaction } from '@codemirror/state';
+import { EditorState, Prec, type Extension, type SelectionRange, type Transaction } from '@codemirror/state';
 import { BlockType, keymap, type BlockInfo, type EditorView } from '@codemirror/view';
 import { getActiveCell } from '../../tableState/activeCellState';
 import { fromUnifiedRow, getCellSelection } from '../../tableState/cellSelectionState';
@@ -28,12 +28,15 @@ const TABLE_ENTRY_SYNTAX_TREE_TIMEOUT_MS = 0;
 function canEnterRenderedTable(state: EditorState): boolean {
     return (
         !isEffectiveRawMode(state) &&
-        state.selection.ranges.length === 1 &&
-        state.selection.main.empty &&
         !getCellSelection(state) &&
         !getActiveCell(state) &&
         !getPendingOpenCellRequest(state)
     );
+}
+
+/** Vertical entry reads the movement target off the main range, so it needs a lone caret. */
+function canEnterFromVerticalMovement(state: EditorState): boolean {
+    return canEnterRenderedTable(state) && state.selection.ranges.length === 1 && state.selection.main.empty;
 }
 
 function getDeletionDirection(transaction: Transaction): DeletionDirection | null {
@@ -101,6 +104,33 @@ function isDeletingIntoPendingOpenCell(transaction: Transaction): boolean {
     return Boolean(transaction.changes.touchesRange(resolved.tableFrom, resolved.tableTo));
 }
 
+/** The table this range's deletion would reach, or null when it stays outside one. */
+function resolveDeletionTargetTable(
+    transaction: Transaction,
+    range: SelectionRange,
+    direction: DeletionDirection
+): TableContext | null {
+    // An explicit selection is a deliberate range deletion, a table-spanning one included.
+    if (!range.empty) {
+        return null;
+    }
+
+    // CodeMirror's deletion commands remove one contiguous range anchored at the caret, so
+    // the character next to the caret is always part of it - including word- and line-wise
+    // deletion, which stops at the line boundary and reaches the table on the following
+    // press. Probing that one position identifies the table being deleted into without
+    // walking the change set; `touchesRange` then confirms this transaction is that deletion.
+    const targetPos = range.head + (direction === 'forward' ? 1 : -1);
+    if (targetPos < 0 || targetPos > transaction.startState.doc.length) {
+        return null;
+    }
+    if (!transaction.changes.touchesRange(targetPos)) {
+        return null;
+    }
+
+    return resolveTableContextAtPos(transaction.startState, targetPos, TABLE_ENTRY_SYNTAX_TREE_TIMEOUT_MS);
+}
+
 const tableBoundaryDeletionFilter = EditorState.transactionFilter.of((transaction) => {
     const direction = getDeletionDirection(transaction);
     if (!direction || !transaction.docChanged) {
@@ -116,29 +146,26 @@ const tableBoundaryDeletionFilter = EditorState.transactionFilter.of((transactio
         return transaction;
     }
 
-    // CodeMirror's deletion commands remove one contiguous range anchored at the caret, so
-    // the character next to the caret is always part of it - including word- and line-wise
-    // deletion, which stops at the line boundary and reaches the table on the following
-    // press. Probing that one position identifies the table being deleted into without
-    // walking the change set; `touchesRange` then confirms this transaction is that deletion.
-    const current = transaction.startState.selection.main;
-    const targetPos = current.head + (direction === 'forward' ? 1 : -1);
-    if (targetPos < 0 || targetPos > transaction.startState.doc.length) {
-        return transaction;
-    }
-    if (!transaction.changes.touchesRange(targetPos)) {
-        return transaction;
-    }
-
-    const ctx = resolveTableContextAtPos(transaction.startState, targetPos, TABLE_ENTRY_SYNTAX_TREE_TIMEOUT_MS);
-    if (!ctx) {
-        return transaction;
-    }
-
     const isBackward = direction === 'backward';
     const edges: EdgeCellTarget = isBackward ? { row: 'last', col: 'last' } : { row: 'first', col: 'first' };
 
-    return prepareEdgeCellEntry(ctx, edges, isBackward ? 'end' : 'start') ?? transaction;
+    // Several carets can reach tables in one gesture. Enter the first in document order and
+    // drop the rest of the deletion: a cell editor holds one caret, so the entry transaction
+    // collapses the other ranges regardless, and letting them through would edit the very
+    // Markdown this filter protects.
+    for (const range of transaction.startState.selection.ranges) {
+        const ctx = resolveDeletionTargetTable(transaction, range, direction);
+        if (!ctx) {
+            continue;
+        }
+
+        const spec = prepareEdgeCellEntry(ctx, edges, isBackward ? 'end' : 'start');
+        if (spec) {
+            return spec;
+        }
+    }
+
+    return transaction;
 });
 
 function isPositionMovingInDirection(
@@ -226,7 +253,7 @@ function resolveVerticalEntryContext(
 }
 
 function activateTableAtVerticalTarget(view: EditorView, direction: VerticalEntryDirection): boolean {
-    if (!canEnterRenderedTable(view.state)) {
+    if (!canEnterFromVerticalMovement(view.state)) {
         return false;
     }
 

--- a/src/contentScript/tableRuntime/navigation/mainEditorTableEntry.ts
+++ b/src/contentScript/tableRuntime/navigation/mainEditorTableEntry.ts
@@ -1,19 +1,16 @@
-import { EditorState, Prec, type Extension } from '@codemirror/state';
+import { EditorState, Prec, type Extension, type Transaction } from '@codemirror/state';
 import { BlockType, keymap, type BlockInfo, type EditorView } from '@codemirror/view';
 import { getActiveCell } from '../../tableState/activeCellState';
 import { fromUnifiedRow, getCellSelection } from '../../tableState/cellSelectionState';
 import { isEffectiveRawMode } from '../../tableState/sourceMode';
 import { getTableGridBounds, type TableContext } from '../../tableModel/tableContext';
 import { activateTableCell } from '../activeCell/cellActivation';
-import { getPendingOpenCellRequest } from '../openCellRequest';
+import { createResolvedActiveCell } from '../activeCell/resolvedActiveCell';
+import { getPendingOpenCellRequest, prepareOpenCellRequestTransaction } from '../openCellRequest';
 import { resolveTableContextAtPos } from '../tableResolution';
-import { selectWholeTable, type WholeTableSelectionFocus } from '../selection/cellSelectionController';
 
 type DeletionDirection = 'backward' | 'forward';
 type VerticalEntryDirection = 'up' | 'down';
-
-const selectTableBackward = (view: EditorView): boolean => selectTableAtCharacterTarget(view, 'backward');
-const selectTableForward = (view: EditorView): boolean => selectTableAtCharacterTarget(view, 'forward');
 
 // A rendered widget implies that table parsing has already completed. Keyboard
 // entry must never block waiting for syntax work on the keyboard event path.
@@ -30,28 +27,55 @@ function canEnterRenderedTable(state: EditorState): boolean {
     );
 }
 
-function focusEdgeForDirection(direction: DeletionDirection): WholeTableSelectionFocus {
-    return direction === 'backward' ? 'end' : 'start';
+function getDeletionDirection(transaction: Transaction): DeletionDirection | null {
+    if (transaction.isUserEvent('delete.backward')) {
+        return 'backward';
+    }
+
+    if (transaction.isUserEvent('delete.forward')) {
+        return 'forward';
+    }
+
+    return null;
 }
 
-function selectTableAtCharacterTarget(view: EditorView, direction: DeletionDirection): boolean {
-    if (!canEnterRenderedTable(view.state)) {
-        return false;
+const tableBoundaryDeletionFilter = EditorState.transactionFilter.of((transaction) => {
+    const direction = getDeletionDirection(transaction);
+    if (!direction || !transaction.docChanged || !canEnterRenderedTable(transaction.startState)) {
+        return transaction;
     }
 
-    const current = view.state.selection.main;
-    const target = view.moveByChar(current, direction === 'forward');
-    if (target.head === current.head) {
-        return false;
+    const current = transaction.startState.selection.main;
+    const targetPos = current.head + (direction === 'forward' ? 1 : -1);
+    if (targetPos < 0 || targetPos > transaction.startState.doc.length) {
+        return transaction;
+    }
+    if (!transaction.changes.touchesRange(targetPos)) {
+        return transaction;
     }
 
-    const ctx = resolveTableContextAtPos(view.state, target.head, TABLE_ENTRY_SYNTAX_TREE_TIMEOUT_MS);
+    const ctx = resolveTableContextAtPos(transaction.startState, targetPos, TABLE_ENTRY_SYNTAX_TREE_TIMEOUT_MS);
     if (!ctx) {
-        return false;
+        return transaction;
     }
 
-    return selectWholeTable(view, ctx, focusEdgeForDirection(direction));
-}
+    const bounds = getTableGridBounds(ctx);
+    if (bounds.totalRows <= 0 || bounds.totalCols <= 0) {
+        return transaction;
+    }
+
+    const isBackward = direction === 'backward';
+    const targetCoords = fromUnifiedRow(isBackward ? bounds.totalRows - 1 : 0, isBackward ? bounds.totalCols - 1 : 0);
+    const resolvedCell = createResolvedActiveCell({ ctx, coords: targetCoords });
+    if (!resolvedCell) {
+        return transaction;
+    }
+
+    return prepareOpenCellRequestTransaction({
+        target: { resolvedCell },
+        initialCursorPos: isBackward ? 'end' : 'start',
+    });
+});
 
 function isPositionMovingInDirection(
     currentPos: number,
@@ -164,35 +188,8 @@ function activateTableAtVerticalTarget(view: EditorView, direction: VerticalEntr
     });
 }
 
-const tableEntryKeymap = Prec.highest(
+const tableVerticalEntryKeymap = Prec.highest(
     keymap.of([
-        {
-            key: 'Backspace',
-            run: selectTableBackward,
-            shift: selectTableBackward,
-        },
-        {
-            key: 'Delete',
-            run: selectTableForward,
-        },
-        {
-            key: 'Mod-Backspace',
-            mac: 'Alt-Backspace',
-            run: selectTableBackward,
-        },
-        {
-            key: 'Mod-Delete',
-            mac: 'Alt-Delete',
-            run: selectTableForward,
-        },
-        {
-            mac: 'Mod-Backspace',
-            run: selectTableBackward,
-        },
-        {
-            mac: 'Mod-Delete',
-            run: selectTableForward,
-        },
         {
             key: 'ArrowUp',
             run: (view) => activateTableAtVerticalTarget(view, 'up'),
@@ -204,4 +201,4 @@ const tableEntryKeymap = Prec.highest(
     ])
 );
 
-export const mainEditorTableEntryExtension: Extension = tableEntryKeymap;
+export const mainEditorTableEntryExtension: Extension = [tableBoundaryDeletionFilter, tableVerticalEntryKeymap];

--- a/src/contentScript/tableRuntime/navigation/mainEditorTableEntry.ts
+++ b/src/contentScript/tableRuntime/navigation/mainEditorTableEntry.ts
@@ -74,14 +74,16 @@ function prepareEdgeCellEntry(
 }
 
 /**
- * True while an open-cell request is still in flight with the caret parked inside its table.
+ * True when this deletion would edit the table an in-flight open-cell request is entering.
  *
  * A request settles a frame or more after it is dispatched - later still when the table has
  * to be normalized first. Until the nested editor mounts and takes focus, the main editor
  * owns the keyboard with the caret sitting in the table's replaced range, so a repeat
- * deletion would edit the hidden Markdown that this filter exists to protect.
+ * deletion would edit the hidden Markdown that this filter exists to protect. Deletions
+ * elsewhere in the document are none of this filter's business, so they must still pass.
  */
-function isDeletingIntoPendingOpenCell(state: EditorState): boolean {
+function isDeletingIntoPendingOpenCell(transaction: Transaction): boolean {
+    const state = transaction.startState;
     if (isEffectiveRawMode(state) || !getPendingOpenCellRequest(state)) {
         return false;
     }
@@ -92,7 +94,11 @@ function isDeletingIntoPendingOpenCell(state: EditorState): boolean {
     }
 
     const { head } = state.selection.main;
-    return head >= resolved.tableFrom && head <= resolved.tableTo;
+    if (head < resolved.tableFrom || head > resolved.tableTo) {
+        return false;
+    }
+
+    return Boolean(transaction.changes.touchesRange(resolved.tableFrom, resolved.tableTo));
 }
 
 const tableBoundaryDeletionFilter = EditorState.transactionFilter.of((transaction) => {
@@ -102,7 +108,7 @@ const tableBoundaryDeletionFilter = EditorState.transactionFilter.of((transactio
     }
 
     // Drop the deletion outright: the caret is already on its way into a cell.
-    if (isDeletingIntoPendingOpenCell(transaction.startState)) {
+    if (isDeletingIntoPendingOpenCell(transaction)) {
         return [];
     }
 

--- a/src/contentScript/tableRuntime/selection/cellSelectionController.ts
+++ b/src/contentScript/tableRuntime/selection/cellSelectionController.ts
@@ -122,31 +122,6 @@ export function startCellSelectionFromActiveCell(view: EditorView, direction: Ce
     );
 }
 
-export type WholeTableSelectionFocus = 'start' | 'end';
-
-function createWholeTableSelection(ctx: TableContext, focusEdge: WholeTableSelectionFocus): CellSelection | null {
-    const bounds = getTableGridBounds(ctx);
-    if (bounds.totalRows <= 0 || bounds.totalCols <= 0) {
-        return null;
-    }
-
-    const start = fromUnifiedRow(0, 0);
-    const end = fromUnifiedRow(bounds.totalRows - 1, bounds.totalCols - 1);
-
-    return focusEdge === 'start'
-        ? { tableFrom: ctx.from, anchor: end, focus: start }
-        : { tableFrom: ctx.from, anchor: start, focus: end };
-}
-
-export function selectWholeTable(view: EditorView, ctx: TableContext, focusEdge: WholeTableSelectionFocus): boolean {
-    const selection = createWholeTableSelection(ctx, focusEdge);
-    if (!selection) {
-        return false;
-    }
-
-    return dispatchSelectionWithContext(view, ctx, selection, { clearActiveCell: true });
-}
-
 export function extendExistingCellSelection(view: EditorView, direction: CellSelectionDirection): boolean {
     const selection = getCellSelection(view.state);
     if (!selection) {

--- a/src/contentScript/tableRuntime/selection/cellSelectionKeymap.ts
+++ b/src/contentScript/tableRuntime/selection/cellSelectionKeymap.ts
@@ -16,7 +16,6 @@ import { resolveTableContextAtPos } from '../tableResolution';
 import { canHandleTableSelectionKeydown } from './cellSelectionShortcutScope';
 import { handleSelectionDelete } from './cellSelectionClipboard';
 import { requestOpenCell } from '../openCellRequest';
-import { getViewWindow } from '../../shared/domContext';
 
 type SelectionKeyHandler = (view: EditorView, event: KeyboardEvent) => boolean;
 
@@ -101,24 +100,18 @@ function runHistoryCommand(view: EditorView, command: Command): boolean {
     return handled;
 }
 
-const APPLE_PLATFORM_PATTERN = /Mac|iPhone|iPad|iPod/;
-
-/** Mirrors the modified Backspace/Delete gestures in CodeMirror's standard keymap. */
-function isSelectionDeletionKey(view: EditorView, event: KeyboardEvent): boolean {
-    const isApplePlatform = APPLE_PLATFORM_PATTERN.test(getViewWindow(view).navigator.platform);
-    if (isApplePlatform) {
-        return !event.ctrlKey && !event.shiftKey && event.altKey !== event.metaKey;
+/**
+ * Every Backspace/Delete removes the selected cells: word- and line-wise deletion have no
+ * meaning over a rectangle of cells, so the modifiers carry no extra behavior to preserve.
+ * Shift+Delete is the exception - it is the platform's cut gesture, and belongs to the
+ * clipboard handler.
+ */
+function handleDeleteKey(view: EditorView, event: KeyboardEvent): boolean {
+    if (event.key === 'Delete' && event.shiftKey) {
+        return false;
     }
 
-    return !event.altKey && !event.metaKey && !event.shiftKey && event.ctrlKey;
-}
-
-function handleDeleteKey(view: EditorView, event: KeyboardEvent): boolean {
-    const isPlainDelete = !event.shiftKey && !event.altKey && !event.ctrlKey && !event.metaKey;
-    const isShiftBackspace =
-        event.key === 'Backspace' && event.shiftKey && !event.altKey && !event.ctrlKey && !event.metaKey;
-
-    return (isPlainDelete || isShiftBackspace || isSelectionDeletionKey(view, event)) && handleSelectionDelete(view);
+    return handleSelectionDelete(view);
 }
 
 /** Enter and Tab both open the focus cell; Shift+Enter/Tab are left to the editor. */


### PR DESCRIPTION
Follows up #185, which is not in a release yet, so this changes that behavior rather than layering on top of it.

## Behavior

Backspace or Delete reaching a rendered table from the main editor now **opens the boundary cell** instead of selecting the whole cell grid: Backspace enters the final cell at its end, Delete enters the first cell at its start. This matches the ArrowUp/ArrowDown entry added in #185 — moving toward a table enters it. Tables are still deletable through the Delete table command and through a selection spanning the table.

## Mechanism

Protection moved from a `Prec.highest` keymap to an `EditorState.transactionFilter` keyed on CodeMirror's `delete.backward` / `delete.forward` user events. That drops six keybindings mirroring `standardKeymap`'s platform-specific word/line deletion gestures, covers deletions dispatched by Joplin's own keymaps and user rebindings rather than only the keys we listed, and stops computing the target with `moveByChar` across a block replace decoration. Soft-keyboard and IME `input.type` transactions stay under CodeMirror's platform behavior, as before.

## Known gap, unchanged

With the caret at a table's start offset, Backspace joins the preceding line into the header row and breaks the table. Present before this branch too, and no way to place the caret there outside source mode has been found, so it is left alone.

## Verification

`npm test` (702 passing), `npm run lint`, `npm run knip`, `npm run dist`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)