### PR TITLE
feat: allow horizontal navigation to enter/exit table

### DIFF
--- a/docs/Architecture/Interaction-and-Navigation.md
+++ b/docs/Architecture/Interaction-and-Navigation.md
@@ -4,43 +4,54 @@
 
 Cells are separate editor instances (or `<td>` when inactive). Key events are intercepted to simulate natural navigation.
 
-| Key                 | Action        | Behavior                                                  |
-| :------------------ | :------------ | :-------------------------------------------------------- |
-| **Tab**             | Next Cell     | End of row/column creates new row.                        |
-| **Shift+Tab**       | Previous Cell |                                                           |
-| **Enter**           | Cell Below    | Last row creates new row.                                 |
-| **ArrowLeft/Right** | Navigate Cell | At boundary, jumps to prev/next cell.                     |
-| **ArrowUp/Down**    | Navigate Line | At visual top/bottom boundary, jumps to cell above/below. |
+| Key                 | Action        | At the cell boundary                                                        |
+| :------------------ | :------------ | :-------------------------------------------------------------------------- |
+| **Tab**             | Next cell     | Last cell creates a new row.                                                |
+| **Shift+Tab**       | Previous cell | First cell is blocked.                                                      |
+| **Enter**           | Cell below    | Last row creates a new row.                                                 |
+| **ArrowLeft/Right** | Move by char  | Cell edge moves to the previous/next cell; grid edge exits the table.       |
+| **ArrowUp/Down**    | Move by line  | Visual top/bottom moves to the cell above/below; grid edge exits the table. |
 
-From the main editor, hardware Backspace or Delete stops before it can remove the final line break adjoining a rendered
-table or any of the table's hidden Markdown. Instead, it opens the boundary cell: Backspace enters the final cell at its
-end, while Delete enters the first cell at its start. Extra blank lines between the caret and table remain ordinary editable text.
-For a ragged table, the target is the edge cell that has a source range; normalization makes the table rectangular after
-that resolvable cell has been activated.
-Protection follows CodeMirror's semantic `delete.backward` and `delete.forward` transactions rather than physical key
-bindings, and covers every caret of a multi-cursor deletion: the first table reached in document order is entered and
-the rest of the gesture is dropped, since a cell editor holds a single caret. Soft-keyboard and IME `input.type` transactions remain under CodeMirror's platform behavior. Further deletions into that
-table, arriving before the requested cell opens, are dropped since the caret is parked inside it until then.
+### Crossing the Table Boundary
 
-While a cell selection is live the caret is parked at the focus cell's document position so clipboard and shortcut
-handling keep working, and the main editor's caret is hidden so the highlight alone conveys the state. An unmodified
-arrow key collapses the selection and moves the caret out of the table, the way an arrow key collapses a text selection;
-Shift+Arrow extends it instead. Any other command that moves the caret outside the selected table drops the selection.
+A rendered table is a block replace decoration, so the main editor's caret is only ever adjacent to a table, never
+usefully inside one. Entry and exit are the two halves of that crossing, and the opposite key reverses it.
 
-Plain arrow keys from the main editor detect entry into a rendered table from CodeMirror's visual movement target.
-ArrowRight from the adjoining line above opens the first cell at its start; ArrowLeft from the adjoining line below
-opens the final cell at its end. Horizontal direction follows CodeMirror's text direction for the current line.
-ArrowDown/ArrowUp also account for a target that overshoots the widget, locating the table from the block the movement
-stepped over. CodeMirror's vertical motion deliberately scans past block widgets, so a movement toward a table usually
-lands on the far side of it; the block adjacent to the caret's own line block is then the one that was skipped, and a
-replaced block there identifies the table. Entry from above opens the top-left header cell at its start; entry from below
-opens the first cell of the final row at the start of its last line. Other vertical movement remains owned by the main
-editor.
+**Entry** (`tableRuntime/navigation/mainEditorTableEntry.ts`): deletion and plain arrow movement toward a table open a
+cell instead of moving the caret into the replaced range. Extra blank lines in between stay ordinary editable text.
 
-Inside a nested editor, plain ArrowUp from the header's visual top boundary and ArrowLeft from the first cell's start
-exit to the blank line above the table. Plain ArrowDown from the final row's visual bottom boundary and ArrowRight from
-the final cell's end exit to the blank line below it. The active cell is cleared, the nested editor closes through the
-normal lifecycle, and focus returns to the main editor.
+| Caret is        | Key                           | Opens                                                            |
+| :-------------- | :---------------------------- | :--------------------------------------------------------------- |
+| Above the table | Delete, ArrowRight, ArrowDown | First header cell, caret at its start                            |
+| Below the table | Backspace, ArrowLeft          | Final cell, caret at its end                                     |
+| Below the table | ArrowUp                       | First cell of the final row, caret at the start of its last line |
+
+**Exit** (`tableRuntime/navigation/tableExit.ts`): a nested-editor arrow key that walks off the grid clears the active
+cell, moves the caret to the adjacent line, closes the nested editor through the normal lifecycle, and returns focus to
+the main editor. ArrowUp from the header's visual top and ArrowLeft from the first cell's start exit above; ArrowDown
+from the final row's visual bottom and ArrowRight from the final cell's end exit below. A table against a document edge
+has no adjacent line, so the key is swallowed instead.
+
+Rules that hold across both halves:
+
+- Deletion protection keys off CodeMirror's semantic `delete.backward`/`delete.forward` transactions rather than
+  physical key bindings, so word- and line-wise deletes are covered while IME and soft-keyboard `input.type` stays under
+  CodeMirror's platform behavior.
+- A cell editor holds one caret, so only one may enter: a multi-cursor deletion enters the first table in document order
+  and drops the rest, as do repeat deletions arriving before the requested cell opens.
+- For a ragged table the target is the edge cell that has a source range; normalization squares the table only after
+  that cell is activated.
+- Arrow entry requires a lone empty caret in rendered mode with no live cell selection — anything else stays with the
+  main editor. Vertical entry also has to recover the table a movement _skipped_, since CodeMirror scans past block
+  widgets; see `resolveSkippedTableBlock`.
+
+### Cell Selection Caret
+
+- The caret is parked at the focus cell's document position so clipboard and shortcut handling keep working, and the
+  main editor's caret is hidden so the highlight alone conveys the state.
+- An unmodified arrow key collapses the selection and moves the caret out of the table, the way an arrow key collapses
+  a text selection; Shift+Arrow extends it instead.
+- Any other command that moves the caret outside the selected table drops the selection.
 
 ### Scrolling
 
@@ -52,18 +63,15 @@ visibility.
 
 ### Open-Cell Request State
 
-Rapid navigation can cause race conditions (new request before previous cell mounts).
+Rapid navigation races a new request against the previously requested cell mounting, so open-cell transitions are
+tracked in a `StateField` (`tableRuntime/openCellRequest.ts`) rather than a module-global lock.
 
-Open-cell transitions are tracked by a CodeMirror `StateField` in `tableRuntime/openCellRequest.ts`.
-Keyboard navigation dispatches an explicit request with target cell, cursor placement, normalization intent, and
-key-suppression state. The lifecycle trigger carries only the request id; lifecycle re-reads the pending request,
-then completes it after the nested editor opens and focus has been handed off, or fails it when the open path aborts.
-A watchdog ViewPlugin fails stuck requests after 1 second.
-
-Row creation uses the same explicit reopen path as other command-driven structural operations.
-The row-insert transaction updates table text, main-editor selection, active-cell state, and open intent together.
-Lifecycle then reopens the replacement nested editor, and Tab/Enter suppression reads the pending request state rather
-than a module-global lock.
+- The initiating action dispatches a request carrying target cell, cursor placement, normalization intent, and
+  key-suppression state; the lifecycle trigger carries only the request id.
+- Lifecycle re-reads the pending request, then completes it once the nested editor is open and focus has been handed
+  off, or fails it when the open path aborts. A watchdog `ViewPlugin` fails stuck requests after 1 second.
+- Row creation uses the same path: one transaction updates table text, main-editor selection, active-cell state, and
+  open intent together, and Tab/Enter suppression reads the pending request.
 
 ## Selection Sync
 

--- a/docs/Architecture/Interaction-and-Navigation.md
+++ b/docs/Architecture/Interaction-and-Navigation.md
@@ -27,16 +27,20 @@ handling keep working, and the main editor's caret is hidden so the highlight al
 arrow key collapses the selection and moves the caret out of the table, the way an arrow key collapses a text selection;
 Shift+Arrow extends it instead. Any other command that moves the caret outside the selected table drops the selection.
 
-Plain ArrowDown/ArrowUp from the main editor detects entry into a rendered table from the visual movement target, or,
-when that target overshoots, from the block the movement stepped over. CodeMirror's vertical motion deliberately scans
-past block widgets, so a movement toward a table usually lands on the far side of it; the block adjacent to the caret's
-own line block is then the one that was skipped, and a replaced block there identifies the table. Entry from above opens
-the top-left header cell at its start; entry from below opens the first cell of the final row at the start of its last
-line. Other vertical movement remains owned by the main editor.
+Plain arrow keys from the main editor detect entry into a rendered table from CodeMirror's visual movement target.
+ArrowRight from the adjoining line above opens the first cell at its start; ArrowLeft from the adjoining line below
+opens the final cell at its end. Horizontal direction follows CodeMirror's text direction for the current line.
+ArrowDown/ArrowUp also account for a target that overshoots the widget, locating the table from the block the movement
+stepped over. CodeMirror's vertical motion deliberately scans past block widgets, so a movement toward a table usually
+lands on the far side of it; the block adjacent to the caret's own line block is then the one that was skipped, and a
+replaced block there identifies the table. Entry from above opens the top-left header cell at its start; entry from below
+opens the first cell of the final row at the start of its last line. Other vertical movement remains owned by the main
+editor.
 
-Inside a nested editor, plain ArrowUp from the header's visual top boundary exits to the blank line above the table.
-Plain ArrowDown from the final row's visual bottom boundary exits to the blank line below it. The active cell is cleared,
-the nested editor closes through the normal lifecycle, and focus returns to the main editor.
+Inside a nested editor, plain ArrowUp from the header's visual top boundary and ArrowLeft from the first cell's start
+exit to the blank line above the table. Plain ArrowDown from the final row's visual bottom boundary and ArrowRight from
+the final cell's end exit to the blank line below it. The active cell is cleared, the nested editor closes through the
+normal lifecycle, and focus returns to the main editor.
 
 ### Scrolling
 

--- a/src/contentScript/__tests__/mainEditorTableEntry.test.ts
+++ b/src/contentScript/__tests__/mainEditorTableEntry.test.ts
@@ -4,7 +4,7 @@
 
 import { defaultKeymap } from '@codemirror/commands';
 import { EditorSelection, EditorState } from '@codemirror/state';
-import { EditorView, keymap } from '@codemirror/view';
+import { Direction, EditorView, keymap } from '@codemirror/view';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { activeCellField, getActiveCell, setActiveCellEffect } from '../tableState/activeCellState';
 import { cellSelectionField, getCellSelection } from '../tableState/cellSelectionState';
@@ -90,6 +90,15 @@ afterEach(() => {
 
 function mockVerticalTarget(view: EditorView, targetPos: number): void {
     vi.spyOn(view, 'moveVertically').mockReturnValue(EditorSelection.cursor(targetPos));
+}
+
+function expectCellOpen(
+    view: EditorView,
+    expected: { tableFrom: number; section: 'header' | 'body'; row: number; col: number },
+    initialCursorPos: 'start' | 'end'
+): void {
+    expect(getActiveCell(view.state)).toEqual(expected);
+    expect(getPendingOpenCellRequest(view.state)).toMatchObject({ initialCursorPos });
 }
 
 describe('mainEditorTableEntry deletion protection', () => {
@@ -512,5 +521,62 @@ describe('mainEditorTableEntry vertical movement', () => {
 
         expect(getActiveCell(view.state)).toBeNull();
         expect(getPendingOpenCellRequest(view.state)).toBeNull();
+    });
+});
+
+describe('mainEditorTableEntry horizontal movement', () => {
+    it('opens the first cell when ArrowRight crosses from the empty line above the table', () => {
+        const prefix = 'above\n';
+        const doc = `${prefix}\n${TABLE}`;
+        const tableFrom = prefix.length + 1;
+        const view = mountView(doc, prefix.length);
+
+        pressKey(view, 'ArrowRight');
+
+        expectCellOpen(view, { tableFrom, section: 'header', row: 0, col: 0 }, 'start');
+    });
+
+    it('opens the final cell when ArrowLeft crosses from the empty line below the table', () => {
+        const doc = `${TABLE}\n\nbelow`;
+        const view = mountView(doc, TABLE.length + 1);
+
+        pressKey(view, 'ArrowLeft');
+
+        expectCellOpen(view, { tableFrom: 0, section: 'body', row: 1, col: 1 }, 'end');
+    });
+
+    it('leaves ordinary horizontal movement to the main editor', () => {
+        const doc = `above\n\n${TABLE}`;
+        const view = mountView(doc, 1);
+
+        pressKey(view, 'ArrowRight');
+
+        expect(getActiveCell(view.state)).toBeNull();
+        expect(getPendingOpenCellRequest(view.state)).toBeNull();
+        expect(view.state.selection.main.head).toBe(2);
+    });
+
+    it('leaves Shift+ArrowRight to the main editor', () => {
+        const prefix = 'above\n';
+        const doc = `${prefix}\n${TABLE}`;
+        const view = mountView(doc, prefix.length);
+
+        pressKey(view, 'ArrowRight', { shiftKey: true });
+
+        expect(getActiveCell(view.state)).toBeNull();
+        expect(getPendingOpenCellRequest(view.state)).toBeNull();
+    });
+
+    it('uses the line text direction to interpret horizontal movement', () => {
+        const prefix = 'above\n';
+        const doc = `${prefix}\n${TABLE}`;
+        const tableFrom = prefix.length + 1;
+        const view = mountView(doc, prefix.length);
+        vi.spyOn(view, 'textDirectionAt').mockReturnValue(Direction.RTL);
+        vi.spyOn(view, 'moveByChar').mockReturnValue(EditorSelection.cursor(tableFrom));
+
+        pressKey(view, 'ArrowLeft');
+
+        expectCellOpen(view, { tableFrom, section: 'header', row: 0, col: 0 }, 'start');
     });
 });

--- a/src/contentScript/__tests__/nestedEditorKeymap.test.ts
+++ b/src/contentScript/__tests__/nestedEditorKeymap.test.ts
@@ -1,0 +1,87 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { EditorView } from '@codemirror/view';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createNestedEditorKeymap } from '../nestedEditor/domHandlers';
+import { activeCellField, getActiveCell, setActiveCellEffect, type ActiveCell } from '../tableState/activeCellState';
+import { createMarkdownState } from './testMarkdownState';
+
+const TABLE = ['| H1 | H2 |', '| --- | --- |', '| a1 | a2 |', '| b1 | b2 |'].join('\n');
+const PREFIX = 'above\n\n';
+const DOC = `${PREFIX}${TABLE}\n\nbelow`;
+const TABLE_FROM = PREFIX.length;
+const TABLE_TO = TABLE_FROM + TABLE.length;
+const mountedViews: EditorView[] = [];
+
+function mountMainView(activeCell: ActiveCell): EditorView {
+    const parent = document.createElement('div');
+    document.body.appendChild(parent);
+    const view = new EditorView({
+        parent,
+        state: createMarkdownState(DOC, [activeCellField]),
+    });
+    view.dispatch({ effects: setActiveCellEffect.of(activeCell) });
+    mountedViews.push(view);
+    return view;
+}
+
+function mountNestedView(
+    mainView: EditorView,
+    selection: number
+): { view: EditorView; sync: ReturnType<typeof vi.fn> } {
+    const parent = document.createElement('div');
+    document.body.appendChild(parent);
+    const sync = vi.fn();
+    const view = new EditorView({
+        parent,
+        doc: 'cell',
+        selection: { anchor: selection },
+        extensions: [
+            createNestedEditorKeymap(mainView, {
+                getSelectionBounds: (nestedView) => ({ from: 0, to: nestedView.state.doc.length }),
+                closeEditor: vi.fn(),
+                syncPendingChangesToRoot: sync,
+            }),
+        ],
+    });
+    view.contentDOM.focus();
+    mountedViews.push(view);
+    return { view, sync };
+}
+
+function pressKey(view: EditorView, key: string): void {
+    view.contentDOM.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true }));
+}
+
+afterEach(() => {
+    while (mountedViews.length > 0) {
+        mountedViews.pop()?.destroy();
+    }
+    document.body.replaceChildren();
+});
+
+describe('nested editor horizontal table exit', () => {
+    it('exits above the table on ArrowLeft from the first cell start', () => {
+        const mainView = mountMainView({ tableFrom: TABLE_FROM, section: 'header', row: 0, col: 0 });
+        const nested = mountNestedView(mainView, 0);
+
+        pressKey(nested.view, 'ArrowLeft');
+
+        expect(nested.sync).toHaveBeenCalledOnce();
+        expect(getActiveCell(mainView.state)).toBeNull();
+        expect(mainView.state.selection.main.head).toBe(TABLE_FROM - 1);
+    });
+
+    it('exits below the table on ArrowRight from the final cell end', () => {
+        const mainView = mountMainView({ tableFrom: TABLE_FROM, section: 'body', row: 1, col: 1 });
+        const nested = mountNestedView(mainView, 'cell'.length);
+
+        pressKey(nested.view, 'ArrowRight');
+
+        expect(nested.sync).toHaveBeenCalledOnce();
+        expect(getActiveCell(mainView.state)).toBeNull();
+        expect(mainView.state.selection.main.head).toBe(TABLE_TO + 1);
+    });
+});

--- a/src/contentScript/__tests__/tableNavigation.test.ts
+++ b/src/contentScript/__tests__/tableNavigation.test.ts
@@ -332,6 +332,38 @@ describe('navigateCell', () => {
         expect(mockView.focus).toHaveBeenCalled();
     });
 
+    it('should exit above the table when moving left from the first cell', () => {
+        const ctx = setupTable(2, 2);
+        ctx.from = 10;
+        ctx.to = 89;
+        setupActiveCell(SECTION_HEADER, 0, 0);
+
+        const result = navigateCell(mockView, 'previous', { exitTableAtBoundary: true });
+
+        expect(result).toBe(true);
+        expect(mockDispatch).toHaveBeenCalledWith(
+            expect.objectContaining({ selection: { anchor: 9 }, scrollIntoView: true })
+        );
+        expect(getEffects().some((effect) => effect.is(clearActiveCellEffect))).toBe(true);
+        expect(mockView.focus).toHaveBeenCalled();
+    });
+
+    it('should exit below the table when moving right from the final cell', () => {
+        const ctx = setupTable(2, 2);
+        ctx.from = 10;
+        ctx.to = 89;
+        setupActiveCell(SECTION_BODY, 1, 1);
+
+        const result = navigateCell(mockView, 'next', { exitTableAtBoundary: true });
+
+        expect(result).toBe(true);
+        expect(mockDispatch).toHaveBeenCalledWith(
+            expect.objectContaining({ selection: { anchor: 90 }, scrollIntoView: true })
+        );
+        expect(getEffects().some((effect) => effect.is(clearActiveCellEffect))).toBe(true);
+        expect(mockView.focus).toHaveBeenCalled();
+    });
+
     it('should keep boundary navigation blocked when table exit is not requested', () => {
         const ctx = setupTable(1, 2);
         ctx.from = 10;

--- a/src/contentScript/__tests__/tableNavigation.test.ts
+++ b/src/contentScript/__tests__/tableNavigation.test.ts
@@ -364,6 +364,36 @@ describe('navigateCell', () => {
         expect(mockView.focus).toHaveBeenCalled();
     });
 
+    // Table exit is requested for every direction, so a row wrap - the nearest thing to a
+    // grid edge that is still a legal move - must keep navigating rather than leaving.
+    it('should wrap to the previous row rather than exit when table exit is requested mid-grid', () => {
+        const ctx = setupTable(2, 2);
+        ctx.from = 10;
+        ctx.to = 89;
+        setupActiveCell(SECTION_BODY, 0, 0);
+
+        const result = navigateCell(mockView, 'previous', { exitTableAtBoundary: true });
+
+        expect(result).toBe(true);
+        expect(getSetActiveCellValue()).toMatchObject({ section: SECTION_HEADER, row: 0, col: 1 });
+        expect(getEffects().some((effect) => effect.is(clearActiveCellEffect))).toBe(false);
+        expect(mockView.focus).not.toHaveBeenCalled();
+    });
+
+    it('should wrap to the next row rather than exit when table exit is requested mid-grid', () => {
+        const ctx = setupTable(2, 2);
+        ctx.from = 10;
+        ctx.to = 89;
+        setupActiveCell(SECTION_BODY, 0, 1);
+
+        const result = navigateCell(mockView, 'next', { exitTableAtBoundary: true });
+
+        expect(result).toBe(true);
+        expect(getSetActiveCellValue()).toMatchObject({ section: SECTION_BODY, row: 1, col: 0 });
+        expect(getEffects().some((effect) => effect.is(clearActiveCellEffect))).toBe(false);
+        expect(mockView.focus).not.toHaveBeenCalled();
+    });
+
     it('should keep boundary navigation blocked when table exit is not requested', () => {
         const ctx = setupTable(1, 2);
         ctx.from = 10;

--- a/src/contentScript/nestedEditor/domHandlers.ts
+++ b/src/contentScript/nestedEditor/domHandlers.ts
@@ -63,7 +63,10 @@ export function createNestedEditorKeymap(
                 const { from } = options.getSelectionBounds(nestedView);
                 if (nestedView.state.selection.main.head === from) {
                     options.syncPendingChangesToRoot();
-                    return navigateCell(mainView, 'previous', { initialCursorPos: 'end' });
+                    return navigateCell(mainView, 'previous', {
+                        initialCursorPos: 'end',
+                        exitTableAtBoundary: true,
+                    });
                 }
                 return false;
             },
@@ -74,7 +77,10 @@ export function createNestedEditorKeymap(
                 const { to } = options.getSelectionBounds(nestedView);
                 if (nestedView.state.selection.main.head === to) {
                     options.syncPendingChangesToRoot();
-                    return navigateCell(mainView, 'next', { initialCursorPos: 'start' });
+                    return navigateCell(mainView, 'next', {
+                        initialCursorPos: 'start',
+                        exitTableAtBoundary: true,
+                    });
                 }
                 return false;
             },

--- a/src/contentScript/tableRuntime/navigation/mainEditorTableEntry.ts
+++ b/src/contentScript/tableRuntime/navigation/mainEditorTableEntry.ts
@@ -1,5 +1,5 @@
 import { EditorState, Prec, type Extension, type SelectionRange, type Transaction } from '@codemirror/state';
-import { BlockType, keymap, type BlockInfo, type EditorView } from '@codemirror/view';
+import { BlockType, Direction, keymap, type BlockInfo, type EditorView } from '@codemirror/view';
 import { getActiveCell } from '../../tableState/activeCellState';
 import { fromUnifiedRow, getCellSelection } from '../../tableState/cellSelectionState';
 import { isEffectiveRawMode } from '../../tableState/sourceMode';
@@ -13,6 +13,7 @@ import type { InitialCursorPos } from '../../shared/cursorPlacement';
 
 type DeletionDirection = 'backward' | 'forward';
 type VerticalEntryDirection = 'up' | 'down';
+type HorizontalEntryDirection = 'left' | 'right';
 /** Which end of a grid axis an entry lands on. */
 type GridEdge = 'first' | 'last';
 
@@ -34,8 +35,8 @@ function canEnterRenderedTable(state: EditorState): boolean {
     );
 }
 
-/** Vertical entry reads the movement target off the main range, so it needs a lone caret. */
-function canEnterFromVerticalMovement(state: EditorState): boolean {
+/** Arrow entry reads one movement target off the main range, so it needs a lone caret. */
+function canEnterFromArrowMovement(state: EditorState): boolean {
     return canEnterRenderedTable(state) && state.selection.ranges.length === 1 && state.selection.main.empty;
 }
 
@@ -253,7 +254,7 @@ function resolveVerticalEntryContext(
 }
 
 function activateTableAtVerticalTarget(view: EditorView, direction: VerticalEntryDirection): boolean {
-    if (!canEnterFromVerticalMovement(view.state)) {
+    if (!canEnterFromArrowMovement(view.state)) {
         return false;
     }
 
@@ -282,8 +283,47 @@ function activateTableAtVerticalTarget(view: EditorView, direction: VerticalEntr
     return true;
 }
 
-const tableVerticalEntryKeymap = Prec.highest(
+function activateTableAtHorizontalTarget(view: EditorView, direction: HorizontalEntryDirection): boolean {
+    if (!canEnterFromArrowMovement(view.state)) {
+        return false;
+    }
+
+    const current = view.state.selection.main;
+    const lineIsLeftToRight = view.textDirectionAt(current.head) === Direction.LTR;
+    const movesForward = direction === 'right' ? lineIsLeftToRight : !lineIsLeftToRight;
+    const target = view.moveByChar(current, movesForward);
+    if (target.head === current.head) {
+        return false;
+    }
+
+    const ctx = resolveTableContextAtPos(view.state, target.head, TABLE_ENTRY_SYNTAX_TREE_TIMEOUT_MS);
+    if (!ctx || (movesForward ? current.head >= ctx.from : current.head <= ctx.to)) {
+        return false;
+    }
+
+    const spec = prepareEdgeCellEntry(
+        ctx,
+        movesForward ? { row: 'first', col: 'first' } : { row: 'last', col: 'last' },
+        movesForward ? 'start' : 'end'
+    );
+    if (!spec) {
+        return false;
+    }
+
+    view.dispatch(spec);
+    return true;
+}
+
+const tableArrowEntryKeymap = Prec.highest(
     keymap.of([
+        {
+            key: 'ArrowLeft',
+            run: (view) => activateTableAtHorizontalTarget(view, 'left'),
+        },
+        {
+            key: 'ArrowRight',
+            run: (view) => activateTableAtHorizontalTarget(view, 'right'),
+        },
         {
             key: 'ArrowUp',
             run: (view) => activateTableAtVerticalTarget(view, 'up'),
@@ -295,4 +335,4 @@ const tableVerticalEntryKeymap = Prec.highest(
     ])
 );
 
-export const mainEditorTableEntryExtension: Extension = [tableBoundaryDeletionFilter, tableVerticalEntryKeymap];
+export const mainEditorTableEntryExtension: Extension = [tableBoundaryDeletionFilter, tableArrowEntryKeymap];

--- a/src/contentScript/tableRuntime/navigation/tableNavigation.ts
+++ b/src/contentScript/tableRuntime/navigation/tableNavigation.ts
@@ -18,8 +18,9 @@ export interface NavigateCellOptions {
     exitTableAtBoundary?: boolean;
 }
 
-function exitTable(view: EditorView, resolvedActiveCell: ResolvedActiveCell, direction: 'up' | 'down'): void {
-    exitTableToAdjacentLine(view, resolvedActiveCell.ctx, direction === 'up' ? 'before' : 'after', [
+function exitTable(view: EditorView, resolvedActiveCell: ResolvedActiveCell, direction: NavigationDirection): void {
+    const exitsBefore = direction === 'previous' || direction === 'up';
+    exitTableToAdjacentLine(view, resolvedActiveCell.ctx, exitsBefore ? 'before' : 'after', [
         clearActiveCellEffect.of(undefined),
     ]);
 }
@@ -47,7 +48,7 @@ export function navigateCell(
     });
 
     if (target.kind === 'blocked') {
-        if (options.exitTableAtBoundary && (direction === 'up' || direction === 'down')) {
+        if (options.exitTableAtBoundary) {
             exitTable(view, resolvedActiveCell, direction);
         }
         return true;


### PR DESCRIPTION
The table entry/exit from PRs #185 and #187 and only handled up/down arrow, also handle cursor moving into/out of table via left/right arrow movement