### PR TITLE
fix: suppress arrow key repeat while a cell entry request is in flight

### DIFF
--- a/docs/Architecture/Interaction-and-Navigation.md
+++ b/docs/Architecture/Interaction-and-Navigation.md
@@ -38,7 +38,8 @@ Rules that hold across both halves:
   physical key bindings, so word- and line-wise deletes are covered while IME and soft-keyboard `input.type` stays under
   CodeMirror's platform behavior.
 - A cell editor holds one caret, so only one may enter: a multi-cursor deletion enters the first table in document order
-  and drops the rest, as do repeat deletions arriving before the requested cell opens.
+  and drops the rest. Once entry is requested, key repeat is suppressed until the nested editor takes focus, so a held
+  key cannot walk the main caret through the hidden Markdown.
 - For a ragged table the target is the edge cell that has a source range; normalization squares the table only after
   that cell is activated.
 - Arrow entry requires a lone empty caret in rendered mode with no live cell selection — anything else stays with the

--- a/src/contentScript/__tests__/mainEditorTableEntry.test.ts
+++ b/src/contentScript/__tests__/mainEditorTableEntry.test.ts
@@ -580,3 +580,58 @@ describe('mainEditorTableEntry horizontal movement', () => {
         expectCellOpen(view, { tableFrom, section: 'header', row: 0, col: 0 }, 'start');
     });
 });
+
+describe('mainEditorTableEntry key repeat', () => {
+    it('pins the caret when ArrowRight repeats while the entry request is in flight', () => {
+        const prefix = 'above\n';
+        const doc = `${prefix}\n${TABLE}`;
+        const view = mountView(doc, prefix.length);
+
+        pressKey(view, 'ArrowRight');
+        const headAfterEntry = view.state.selection.main.head;
+        pressKey(view, 'ArrowRight');
+        pressKey(view, 'ArrowRight');
+
+        expect(view.state.selection.main.head).toBe(headAfterEntry);
+        expectCellOpen(view, { tableFrom: prefix.length + 1, section: 'header', row: 0, col: 0 }, 'start');
+    });
+
+    it('pins the caret when ArrowDown repeats while the entry request is in flight', () => {
+        const prefix = 'above';
+        const doc = `${prefix}\n${TABLE}`;
+        const view = mountView(doc, prefix.length);
+        mockVerticalTarget(view, prefix.length + 1);
+
+        pressKey(view, 'ArrowDown');
+        const headAfterEntry = view.state.selection.main.head;
+        pressKey(view, 'ArrowDown');
+
+        expect(view.state.selection.main.head).toBe(headAfterEntry);
+        expectCellOpen(view, { tableFrom: prefix.length + 1, section: 'header', row: 0, col: 0 }, 'start');
+    });
+
+    it('pins the caret when an arrow follows a deletion that entered the table', () => {
+        const doc = `${TABLE}\n\nbelow`;
+        const view = mountView(doc, TABLE.length + 2);
+
+        pressKey(view, 'Backspace');
+        pressKey(view, 'Backspace');
+        const headAfterEntry = view.state.selection.main.head;
+        pressKey(view, 'ArrowRight');
+        pressKey(view, 'ArrowRight');
+
+        expect(view.state.selection.main.head).toBe(headAfterEntry);
+        expectBoundaryCellOpen(view, 'end');
+    });
+
+    it('leaves arrow keys to the main editor when no request is in flight', () => {
+        const doc = `above\n\n${TABLE}`;
+        const view = mountView(doc, 0);
+
+        pressKey(view, 'ArrowRight');
+        pressKey(view, 'ArrowRight');
+
+        expect(view.state.selection.main.head).toBe(2);
+        expect(getPendingOpenCellRequest(view.state)).toBeNull();
+    });
+});

--- a/src/contentScript/tableRuntime/activeCell/cellActivation.ts
+++ b/src/contentScript/tableRuntime/activeCell/cellActivation.ts
@@ -165,6 +165,10 @@ export function activateTableCell(
  *
  * Shared by the dispatching entry points and by the boundary-deletion transaction
  * filter, which can only return a spec.
+ *
+ * The request suppresses navigation keys: until the nested editor mounts and takes focus,
+ * the main editor still owns the keyboard with the caret parked in the table's replaced
+ * range, so key repeat would otherwise walk it through the hidden Markdown.
  */
 export function prepareCellEntryTransaction(params: {
     ctx: TableContext;
@@ -180,5 +184,6 @@ export function prepareCellEntryTransaction(params: {
         target: { resolvedCell },
         normalizeIfNeeded: true,
         initialCursorPos: params.initialCursorPos,
+        suppressKeys: true,
     });
 }

--- a/src/contentScript/tableRuntime/navigation/mainEditorTableEntry.ts
+++ b/src/contentScript/tableRuntime/navigation/mainEditorTableEntry.ts
@@ -6,7 +6,11 @@ import { isEffectiveRawMode } from '../../tableState/sourceMode';
 import type { TableContext } from '../../tableModel/tableContext';
 import { prepareCellEntryTransaction } from '../activeCell/cellActivation';
 import { getResolvedActiveCell } from '../activeCell/resolvedActiveCell';
-import { getPendingOpenCellRequest, type PreparedOpenCellRequestTransaction } from '../openCellRequest';
+import {
+    getPendingOpenCellRequest,
+    shouldSuppressNavigationKeys,
+    type PreparedOpenCellRequestTransaction,
+} from '../openCellRequest';
 import { resolveTableContextAtPos } from '../tableResolution';
 import type { CellCoords } from '../../tableModel/types';
 import type { InitialCursorPos } from '../../shared/cursorPlacement';
@@ -254,6 +258,10 @@ function resolveVerticalEntryContext(
 }
 
 function activateTableAtVerticalTarget(view: EditorView, direction: VerticalEntryDirection): boolean {
+    if (shouldSuppressNavigationKeys(view.state)) {
+        return true;
+    }
+
     if (!canEnterFromArrowMovement(view.state)) {
         return false;
     }
@@ -284,6 +292,10 @@ function activateTableAtVerticalTarget(view: EditorView, direction: VerticalEntr
 }
 
 function activateTableAtHorizontalTarget(view: EditorView, direction: HorizontalEntryDirection): boolean {
+    if (shouldSuppressNavigationKeys(view.state)) {
+        return true;
+    }
+
     if (!canEnterFromArrowMovement(view.state)) {
         return false;
     }
@@ -314,6 +326,16 @@ function activateTableAtHorizontalTarget(view: EditorView, direction: Horizontal
     return true;
 }
 
+/**
+ * Arrow entry runs ahead of the main editor's own motion commands.
+ *
+ * Both handlers swallow the key while an entry request is in flight. The request settles a
+ * frame or more after dispatch, and until the nested editor mounts and takes focus the main
+ * editor still owns the keyboard with the caret parked in the table's replaced range, so key
+ * repeat would otherwise walk it through the hidden Markdown. This mirrors the Tab/Enter
+ * suppression in `openCellRequestKeymap` and the repeat-deletion guard in this module's
+ * transaction filter.
+ */
 const tableArrowEntryKeymap = Prec.highest(
     keymap.of([
         {


### PR DESCRIPTION
Entry requests now set suppressKeys, and the arrow entry commands swallow the key while one is pending. Without it, key repeat fell through to CodeMirror's own motion and walked the main caret through the table's hidden Markdown until the nested editor took focus.