### PR TITLE
refactor: eliminate main editor focus helper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,7 @@ Start here when exploring the codebase:
 
 - **Sync transactions**: Always use `syncAnnotation` when forwarding changes between main and nested editors. Without it, changes trigger infinite re-render loops.
 - **Block decorations**: Must be provided via `StateField`, not `ViewPlugin`. CodeMirror requires decorations affecting layout to come from state.
+- **Main editor focus**: Restore focus with `view.focus()`, not a bare `contentDOM.focus()`. CodeMirror writes the DOM selection only while focused, so when a nested cell editor held focus during the dispatch, only `view.focus()` syncs the new selection and paints the caret. It suppresses the DOM observer and prevents scrolling internally.
 - **Build command**: Use `npm run dist`, not `npm run build` or `npx tsc`.
 
 ## Build, Test, and Development Commands

--- a/src/contentScript/__tests__/tableCommands.test.ts
+++ b/src/contentScript/__tests__/tableCommands.test.ts
@@ -1,3 +1,7 @@
+/**
+ * @vitest-environment jsdom
+ */
+
 import { EditorView } from '@codemirror/view';
 import { vi, type Mock } from 'vitest';
 import type { ActiveCell } from '../tableState/activeCellState';
@@ -25,11 +29,7 @@ describe('tableCommands', () => {
     let mockGetResolvedActiveCell: Mock;
 
     beforeEach(() => {
-        mockView = {
-            contentDOM: {
-                focus: vi.fn(),
-            },
-        } as unknown as EditorView;
+        mockView = {} as unknown as EditorView;
         mockRunStructuralMutationAndReopen = runStructuralMutationAndReopen as Mock;
         mockRunStructuralMutationAndReopen.mockClear();
         mockGetResolvedActiveCell = getResolvedActiveCell as Mock;
@@ -77,9 +77,6 @@ describe('tableCommands', () => {
                     afterDispatch: expect.any(Function),
                 })
             );
-            const afterDispatch = mockRunStructuralMutationAndReopen.mock.calls[0][0].afterDispatch as () => void;
-            afterDispatch();
-            expect(mockView.contentDOM.focus).toHaveBeenCalledWith({ preventScroll: true });
         });
 
         it('routes non-row structural operations through shared reopen defaults', () => {
@@ -101,20 +98,40 @@ describe('tableCommands', () => {
     });
 
     describe('defaults', () => {
-        it('getDefaultStructuralReopenOptions focuses the main editor after dispatch', () => {
-            const options = getDefaultStructuralReopenOptions(mockView);
+        let view: EditorView;
 
-            options.afterDispatch?.();
+        beforeEach(() => {
+            const parent = document.createElement('div');
+            document.body.appendChild(parent);
+            view = new EditorView({
+                parent,
+                doc: ['| H1 | H2 |', '| --- | --- |', '| a1 | a2 |'].join('\n'),
+            });
+            view.contentDOM.blur();
+        });
 
-            expect(mockView.contentDOM.focus).toHaveBeenCalledWith({ preventScroll: true });
+        afterEach(() => {
+            const parent = view.dom.parentElement;
+            view.destroy();
+            parent?.remove();
+        });
+
+        it('getDefaultStructuralReopenOptions hands focus back to the main editor after dispatch', () => {
+            expect(document.activeElement).not.toBe(view.contentDOM);
+
+            getDefaultStructuralReopenOptions(view).afterDispatch?.();
+
+            expect(document.activeElement).toBe(view.contentDOM);
         });
 
         it('getDefaultRowInsertOpenOptions adds start cursor placement on top of structural defaults', () => {
-            const options = getDefaultRowInsertOpenOptions(mockView);
+            const options = getDefaultRowInsertOpenOptions(view);
 
             expect(options.initialCursorPos).toBe('start');
+
             options.afterDispatch?.();
-            expect(mockView.contentDOM.focus).toHaveBeenCalledWith({ preventScroll: true });
+
+            expect(document.activeElement).toBe(view.contentDOM);
         });
     });
 

--- a/src/contentScript/shared/mainEditorFocus.ts
+++ b/src/contentScript/shared/mainEditorFocus.ts
@@ -1,8 +1,0 @@
-import type { EditorView } from '@codemirror/view';
-
-/**
- * Focus the main editor without scrolling the viewport.
- */
-export function focusMainEditorWithoutScroll(view: EditorView): void {
-    view.contentDOM.focus({ preventScroll: true });
-}

--- a/src/contentScript/tableRuntime/interaction/outsideTableInteraction.ts
+++ b/src/contentScript/tableRuntime/interaction/outsideTableInteraction.ts
@@ -1,6 +1,5 @@
 import type { StateEffect } from '@codemirror/state';
 import { EditorView, ViewPlugin } from '@codemirror/view';
-import { focusMainEditorWithoutScroll } from '../../shared/mainEditorFocus';
 import { CLASS_CELL_EDITOR } from '../../shared/tableDomClasses';
 import { clearActiveCellEffect, getActiveCell } from '../../tableState/activeCellState';
 import { clearCellSelectionEffect, getCellSelection } from '../../tableState/cellSelectionState';
@@ -70,12 +69,13 @@ function moveCaretAndClearTableState(
         effects: buildClearEffects(live),
         scrollIntoView: !options.preserveContextMenu,
     });
-    if (!options.preserveContextMenu) {
+    // A right-click only claims focus when the nested editor we just destroyed held it;
+    // otherwise focus stays put so the menu anchors to whatever was clicked. Either way
+    // view.focus() is required rather than a bare contentDOM.focus(): the main editor was
+    // unfocused during the dispatch above, so CodeMirror has not written the new selection
+    // to the DOM. view.focus() syncs it from state (painting the caret) without scrolling.
+    if (!options.preserveContextMenu || live.hasNestedEditor) {
         view.focus();
-    } else if (live.hasNestedEditor) {
-        // The nested editor we just destroyed held focus; restore it to the
-        // main editor without scrolling so the caret is painted.
-        focusMainEditorWithoutScroll(view);
     }
 }
 

--- a/src/contentScript/tableRuntime/interaction/outsideTableInteraction.ts
+++ b/src/contentScript/tableRuntime/interaction/outsideTableInteraction.ts
@@ -70,10 +70,7 @@ function moveCaretAndClearTableState(
         scrollIntoView: !options.preserveContextMenu,
     });
     // A right-click only claims focus when the nested editor we just destroyed held it;
-    // otherwise focus stays put so the menu anchors to whatever was clicked. Either way
-    // view.focus() is required rather than a bare contentDOM.focus(): the main editor was
-    // unfocused during the dispatch above, so CodeMirror has not written the new selection
-    // to the DOM. view.focus() syncs it from state (painting the caret) without scrolling.
+    // otherwise focus stays put so the menu anchors to whatever was clicked.
     if (!options.preserveContextMenu || live.hasNestedEditor) {
         view.focus();
     }

--- a/src/contentScript/tableRuntime/navigation/tableExit.ts
+++ b/src/contentScript/tableRuntime/navigation/tableExit.ts
@@ -9,15 +9,6 @@ export type TableExitSide = 'before' | 'after';
  * Moves the caret to the line adjacent to a table, applies `effects`, and hands focus
  * back to the main editor. Returns false when the table sits against a document edge
  * and there is no adjacent line, leaving the caller to decide what to do instead.
- *
- * Focus must be restored with `view.focus()`, not a bare `contentDOM.focus()`. Callers
- * reach this while the caret is parked inside the table's replaced range — often with a
- * nested editor still holding focus — so CodeMirror has not written the new selection to
- * the DOM (it only controls the DOM selection while focused). `view.focus()` suppresses
- * the DOM observer across the focus call and syncs the DOM selection from state; focusing
- * the content element directly lets the observer read the stale DOM selection back and
- * jump the caret to an unrelated part of the document. `view.focus()` prevents scrolling
- * internally, so the viewport still stays put.
  */
 export function exitTableToAdjacentLine(
     view: EditorView,

--- a/src/contentScript/tableRuntime/operations/structuralOperations.ts
+++ b/src/contentScript/tableRuntime/operations/structuralOperations.ts
@@ -1,7 +1,6 @@
 import { EditorView } from '@codemirror/view';
 import type { StructuralTableCommand } from '../../tableModel/structuralCommandSemantics';
 import type { ResolvedActiveCell } from '../activeCell/resolvedActiveCell';
-import { focusMainEditorWithoutScroll } from '../../shared/mainEditorFocus';
 import { buildRootTableInsertRewrite } from './rootTableInsertRewrite';
 import { runStructuralMutationAndReopen, type StructuralReopenOptions } from './runStructuralMutation';
 import { activateInsertedTableEffect } from '../../tableState/insertedTableActivation';
@@ -13,7 +12,7 @@ const DEFAULT_INSERTED_TABLE_SELECTION_OFFSET = 2;
 
 export function getDefaultStructuralReopenOptions(view: EditorView): StructuralReopenOptions {
     return {
-        afterDispatch: () => focusMainEditorWithoutScroll(view),
+        afterDispatch: () => view.focus(),
     };
 }
 

--- a/src/contentScript/tableRuntime/sourceModeController.ts
+++ b/src/contentScript/tableRuntime/sourceModeController.ts
@@ -3,7 +3,6 @@ import { EditorView } from '@codemirror/view';
 import { clearActiveCellEffect, getActiveCell } from '../tableState/activeCellState';
 import { isSearchForceSourceModeEnabled } from '../tableState/searchForceSourceMode';
 import { exitSourceModeEffect, isSourceModeEnabled, toggleSourceModeEffect } from '../tableState/sourceMode';
-import { focusMainEditorWithoutScroll } from '../shared/mainEditorFocus';
 import { requestViewAnimationFrame } from '../shared/domContext';
 
 function focusMainEditorForExplicitSourceModeEntry(view: EditorView): void {
@@ -17,7 +16,7 @@ function focusMainEditorForExplicitSourceModeEntry(view: EditorView): void {
             return;
         }
 
-        focusMainEditorWithoutScroll(view);
+        view.focus();
     });
 }
 


### PR DESCRIPTION
Remove the unnecessary focus helper and replace its usage with the standard `view.focus()` method. Update documentation to clarify focus handling in the main editor.

This change also fixes two minor bugs:

- invisible cursor when right clicking an image outside of the table while a nested editor was open

- invisible cursor on exit from source mode