### PR TITLE
fix: protect table boundary spacing from deletion

### DIFF
--- a/docs/Architecture/Interaction-and-Navigation.md
+++ b/docs/Architecture/Interaction-and-Navigation.md
@@ -43,10 +43,10 @@ Rules that hold across both halves:
 - For a ragged table the target is the edge cell that has a source range; the entry transaction squares the table and
   remaps that cell in one step.
 - The blank line a table needs on each side counts as part of its boundary. A deletion toward the table enters its edge
-  cell, while a deletion away from it becomes a one-position caret move; neither consumes the required separator. A
-  newline sitting directly against a table edge is protected the same way even when surplus blank lines remain, since
-  removing it would leave the caret parked on the widget edge. Surplus blank lines further out are ordinary text and
-  still delete one press at a time.
+  cell, while a deletion away from it is trimmed to spare the separator - becoming a one-position caret move when the
+  separator was all it covered; neither consumes the required separation. A newline sitting directly against a table
+  edge is protected the same way even when surplus blank lines remain, since removing it would leave the caret parked
+  on the widget edge. Surplus blank lines further out are ordinary text and still delete one press at a time.
 - Arrow entry requires a lone empty caret in rendered mode with no live cell selection — anything else stays with the
   main editor. Vertical entry also has to recover the table a movement _skipped_, since CodeMirror scans past block
   widgets; see `resolveSkippedTableBlock`.

--- a/docs/Architecture/Interaction-and-Navigation.md
+++ b/docs/Architecture/Interaction-and-Navigation.md
@@ -42,8 +42,10 @@ Rules that hold across both halves:
   key cannot walk the main caret through the hidden Markdown.
 - For a ragged table the target is the edge cell that has a source range; the entry transaction squares the table and
   remaps that cell in one step.
-- The blank line a table needs on each side counts as part of its boundary: a deletion that would drop the separation
-  below `REQUIRED_TABLE_BOUNDARY_BLANK_LINES` enters the edge cell instead. Surplus blank lines are ordinary text and
+- The blank line a table needs on each side counts as part of its boundary. A deletion toward the table enters its edge
+  cell, while a deletion away from it becomes a one-position caret move; neither consumes the required separator. A
+  newline sitting directly against a table edge is protected the same way even when surplus blank lines remain, since
+  removing it would leave the caret parked on the widget edge. Surplus blank lines further out are ordinary text and
   still delete one press at a time.
 - Arrow entry requires a lone empty caret in rendered mode with no live cell selection — anything else stays with the
   main editor. Vertical entry also has to recover the table a movement _skipped_, since CodeMirror scans past block

--- a/src/contentScript/__tests__/mainEditorTableEntry.test.ts
+++ b/src/contentScript/__tests__/mainEditorTableEntry.test.ts
@@ -37,6 +37,7 @@ function docAboveTable(table: string = TABLE): string {
 
 const BELOW_TABLE_DOC = docBelowTable();
 const ABOVE_TABLE_DOC = docAboveTable();
+const AROUND_TABLE_DOC = `${BEFORE}\n\n${TABLE}\n\n${AFTER}`;
 
 /** The table's offset in the document as it stands, which entry may have normalized. */
 function currentTableFrom(view: EditorView, table: string = TABLE): number {
@@ -126,6 +127,236 @@ function expectCellOpen(
 }
 
 describe('mainEditorTableEntry deletion protection', () => {
+    it.each([
+        {
+            caret: 'blank line above the table',
+            key: 'Backspace',
+            pos: AROUND_TABLE_DOC.indexOf(TABLE) - 1,
+            expected: { kind: 'move', offset: -1 },
+        },
+        {
+            caret: 'blank line above the table',
+            key: 'Delete',
+            pos: AROUND_TABLE_DOC.indexOf(TABLE) - 1,
+            expected: { kind: 'entry', edge: 'start' },
+        },
+        {
+            caret: 'table start',
+            key: 'Backspace',
+            pos: AROUND_TABLE_DOC.indexOf(TABLE),
+            expected: { kind: 'move', offset: -1 },
+        },
+        {
+            caret: 'table start',
+            key: 'Delete',
+            pos: AROUND_TABLE_DOC.indexOf(TABLE),
+            expected: { kind: 'entry', edge: 'start' },
+        },
+        {
+            caret: 'blank line below the table',
+            key: 'Backspace',
+            pos: AROUND_TABLE_DOC.indexOf(TABLE) + TABLE.length + 1,
+            expected: { kind: 'entry', edge: 'end' },
+        },
+        {
+            caret: 'blank line below the table',
+            key: 'Delete',
+            pos: AROUND_TABLE_DOC.indexOf(TABLE) + TABLE.length + 1,
+            expected: { kind: 'move', offset: 1 },
+        },
+        {
+            caret: 'table end',
+            key: 'Backspace',
+            pos: AROUND_TABLE_DOC.indexOf(TABLE) + TABLE.length,
+            expected: { kind: 'entry', edge: 'end' },
+        },
+        {
+            caret: 'table end',
+            key: 'Delete',
+            pos: AROUND_TABLE_DOC.indexOf(TABLE) + TABLE.length,
+            expected: { kind: 'move', offset: 1 },
+        },
+    ] as const)('$key at $caret preserves the boundary', ({ key, pos, expected }) => {
+        const view = mountView(AROUND_TABLE_DOC, pos);
+
+        pressKey(view, key);
+
+        expect(view.state.doc.toString()).toBe(AROUND_TABLE_DOC);
+        if (expected.kind === 'entry') {
+            expectBoundaryCellOpen(view, expected.edge);
+        } else {
+            expect(view.state.selection.main.head).toBe(pos + expected.offset);
+            expect(getActiveCell(view.state)).toBeNull();
+            expect(getPendingOpenCellRequest(view.state)).toBeNull();
+        }
+    });
+
+    it.each([
+        {
+            side: 'above',
+            key: 'Backspace',
+            start: AROUND_TABLE_DOC.indexOf(TABLE),
+            positions: [AROUND_TABLE_DOC.indexOf(TABLE) - 1, AROUND_TABLE_DOC.indexOf(TABLE) - 2],
+        },
+        {
+            side: 'below',
+            key: 'Delete',
+            start: AROUND_TABLE_DOC.indexOf(TABLE) + TABLE.length,
+            positions: [
+                AROUND_TABLE_DOC.indexOf(TABLE) + TABLE.length + 1,
+                AROUND_TABLE_DOC.indexOf(TABLE) + TABLE.length + 2,
+            ],
+        },
+    ] as const)('walks the caret out from the table boundary $side without deleting', ({ key, start, positions }) => {
+        const view = mountView(AROUND_TABLE_DOC, start);
+
+        for (const position of positions) {
+            pressKey(view, key);
+            expect(view.state.doc.toString()).toBe(AROUND_TABLE_DOC);
+            expect(view.state.selection.main.head).toBe(position);
+            expect(getActiveCell(view.state)).toBeNull();
+            expect(getPendingOpenCellRequest(view.state)).toBeNull();
+        }
+    });
+
+    it.each([
+        {
+            side: 'above',
+            key: 'Backspace',
+            start: AROUND_TABLE_DOC.indexOf(TABLE) - 1,
+            expectedDoc: `${BEFORE.slice(0, -1)}\n\n${TABLE}\n\n${AFTER}`,
+            expectedCaret: BEFORE.length - 1,
+        },
+        {
+            side: 'below',
+            key: 'Delete',
+            start: AROUND_TABLE_DOC.indexOf(TABLE) + TABLE.length + 1,
+            expectedDoc: `${BEFORE}\n\n${TABLE}\n\n${AFTER.slice(1)}`,
+            expectedCaret: AROUND_TABLE_DOC.indexOf(TABLE) + TABLE.length + 2,
+        },
+    ] as const)(
+        'deletes text on the next $key after moving away $side',
+        ({ key, start, expectedDoc, expectedCaret }) => {
+            const view = mountView(AROUND_TABLE_DOC, start);
+
+            pressKey(view, key);
+            pressKey(view, key);
+
+            expect(view.state.doc.toString()).toBe(expectedDoc);
+            expect(view.state.selection.main.head).toBe(expectedCaret);
+            expect(getActiveCell(view.state)).toBeNull();
+            expect(getPendingOpenCellRequest(view.state)).toBeNull();
+        }
+    );
+
+    it.each([
+        { key: 'Delete', offset: 0 },
+        { key: 'Backspace', offset: 1 },
+        { key: 'Delete', offset: 1 },
+        { key: 'Backspace', offset: 2 },
+    ] as const)('deletes a surplus blank line from run offset $offset with $key', ({ key, offset }) => {
+        const doc = `${BEFORE}\n\n\n${TABLE}\n`;
+        const view = mountView(doc, BEFORE.length + offset);
+
+        pressKey(view, key);
+
+        expect(view.state.doc.toString()).toBe(ABOVE_TABLE_DOC);
+        expect(getActiveCell(view.state)).toBeNull();
+        expect(getPendingOpenCellRequest(view.state)).toBeNull();
+    });
+
+    it('enters the first cell when Delete would consume the newline against the table', () => {
+        const doc = `${BEFORE}\n\n\n${TABLE}\n`;
+        const view = mountView(doc, doc.indexOf(TABLE) - 1);
+
+        pressKey(view, 'Delete');
+
+        expect(view.state.doc.toString()).toBe(doc);
+        expectBoundaryCellOpen(view, 'start');
+    });
+
+    it('moves off the table start instead of consuming the newline against it', () => {
+        const doc = `${BEFORE}\n\n\n${TABLE}\n`;
+        const tableFrom = doc.indexOf(TABLE);
+        const view = mountView(doc, tableFrom);
+
+        pressKey(view, 'Backspace');
+
+        expect(view.state.doc.toString()).toBe(doc);
+        expect(view.state.selection.main.head).toBe(tableFrom - 1);
+        expect(getActiveCell(view.state)).toBeNull();
+        expect(getPendingOpenCellRequest(view.state)).toBeNull();
+    });
+
+    it.each([
+        {
+            key: 'Backspace',
+            edge: 'end',
+            expectedTable: 0,
+            caretOffset: 2,
+        },
+        {
+            key: 'Delete',
+            edge: 'start',
+            expectedTable: 1,
+            caretOffset: 2,
+        },
+    ] as const)(
+        'enters the edge cell with $key once a surplus run between two tables is trimmed',
+        ({ key, edge, expectedTable, caretOffset }) => {
+            const doc = `\n${TABLE}\n\n\n\n${TABLE}\n`;
+            const firstTableFrom = doc.indexOf(TABLE);
+            const view = mountView(doc, firstTableFrom + TABLE.length + caretOffset);
+
+            // The surplus blank lines are ordinary text: each press removes one until only
+            // the required separation is left.
+            pressKey(view, key);
+            expect(view.state.doc.toString()).toBe(`\n${TABLE}\n\n\n${TABLE}\n`);
+            expect(getPendingOpenCellRequest(view.state)).toBeNull();
+
+            pressKey(view, key);
+
+            expect(view.state.doc.toString()).toBe(`\n${TABLE}\n\n\n${TABLE}\n`);
+            const currentFirstTableFrom = view.state.doc.toString().indexOf(TABLE);
+            const tableFrom =
+                expectedTable === 0
+                    ? currentFirstTableFrom
+                    : view.state.doc.toString().indexOf(TABLE, currentFirstTableFrom + TABLE.length);
+            expectCellOpen(
+                view,
+                edge === 'start'
+                    ? { tableFrom, section: 'header', row: 0, col: 0 }
+                    : { tableFrom, section: 'body', row: 1, col: 1 },
+                edge
+            );
+        }
+    );
+
+    it.each([
+        { key: 'Backspace', edge: 'end', expectedTable: 0 },
+        { key: 'Delete', edge: 'start', expectedTable: 1 },
+    ] as const)(
+        'enters the table toward $key from a separator shared by two tables',
+        ({ key, edge, expectedTable }) => {
+            const doc = `\n${TABLE}\n\n${TABLE}\n`;
+            const firstTableFrom = doc.indexOf(TABLE);
+            const secondTableFrom = doc.indexOf(TABLE, firstTableFrom + TABLE.length);
+            const tableFrom = expectedTable === 0 ? firstTableFrom : secondTableFrom;
+            const view = mountView(doc, firstTableFrom + TABLE.length + 1);
+
+            pressKey(view, key);
+
+            expect(view.state.doc.toString()).toBe(doc);
+            expectCellOpen(
+                view,
+                edge === 'start'
+                    ? { tableFrom, section: 'header', row: 0, col: 0 }
+                    : { tableFrom, section: 'body', row: 1, col: 1 },
+                edge
+            );
+        }
+    );
+
     it('opens the final cell when Backspace reaches the table from below', () => {
         const doc = BELOW_TABLE_DOC;
         const view = mountView(doc, doc.indexOf(AFTER));
@@ -404,6 +635,24 @@ describe('mainEditorTableEntry deletion protection', () => {
         expect(view.state.doc.toString()).toBe(doc);
         expect(view.state.selection.ranges).toHaveLength(1);
         expectBoundaryCellOpen(view, 'end');
+    });
+
+    it('leaves away-from-table boundary deletion unchanged for multiple carets', () => {
+        const tableFrom = AROUND_TABLE_DOC.indexOf(TABLE);
+        const view = mountView(AROUND_TABLE_DOC, tableFrom);
+        view.dispatch({
+            selection: EditorSelection.create([
+                EditorSelection.cursor(tableFrom),
+                EditorSelection.cursor(AROUND_TABLE_DOC.length),
+            ]),
+        });
+
+        pressKey(view, 'Backspace');
+
+        expect(view.state.doc.toString()).toBe(`${BEFORE}\n${TABLE}\n\n${AFTER.slice(0, -1)}`);
+        expect(view.state.selection.ranges).toHaveLength(2);
+        expect(getActiveCell(view.state)).toBeNull();
+        expect(getPendingOpenCellRequest(view.state)).toBeNull();
     });
 
     it('enters the first table in document order when carets reach two of them', () => {

--- a/src/contentScript/__tests__/mainEditorTableEntry.test.ts
+++ b/src/contentScript/__tests__/mainEditorTableEntry.test.ts
@@ -194,6 +194,41 @@ describe('mainEditorTableEntry deletion protection', () => {
     it.each([
         {
             side: 'above',
+            key: 'Delete',
+            doc: `${BEFORE}\n \t \n${TABLE}\n`,
+            pos: BEFORE.length,
+            edge: 'start',
+        },
+        {
+            side: 'below',
+            key: 'Backspace',
+            doc: `\n${TABLE}\n \t \n${AFTER}`,
+            pos: `\n${TABLE}\n \t \n`.length,
+            edge: 'end',
+        },
+    ] as const)('protects a whitespace-only blank line $side the table', ({ key, doc, pos, edge }) => {
+        const view = mountView(doc, pos);
+
+        pressKey(view, key);
+
+        expect(view.state.doc.toString()).toBe(doc);
+        expectBoundaryCellOpen(view, edge);
+    });
+
+    it('deletes a surplus whitespace-only blank line before protecting the boundary', () => {
+        const doc = `${BEFORE}\n \n \t\n${TABLE}\n`;
+        const view = mountView(doc, BEFORE.length);
+
+        pressKey(view, 'Delete');
+
+        expect(view.state.doc.toString()).toBe(`${BEFORE} \n \t\n${TABLE}\n`);
+        expect(getActiveCell(view.state)).toBeNull();
+        expect(getPendingOpenCellRequest(view.state)).toBeNull();
+    });
+
+    it.each([
+        {
+            side: 'above',
             key: 'Backspace',
             start: AROUND_TABLE_DOC.indexOf(TABLE),
             positions: [AROUND_TABLE_DOC.indexOf(TABLE) - 1, AROUND_TABLE_DOC.indexOf(TABLE) - 2],
@@ -686,6 +721,39 @@ describe('mainEditorTableEntry deletion protection', () => {
         expect(getActiveCell(view.state)).toBeNull();
         expect(getPendingOpenCellRequest(view.state)).toBeNull();
     });
+
+    it.each([
+        {
+            side: 'above',
+            doc: `${BEFORE}\n \t \n${TABLE}\n`,
+            selection: `${BEFORE}\n \t \n`.length,
+            changes: { from: 0, to: `${BEFORE}\n \t \n`.length },
+            userEvent: 'delete.backward',
+            expectedDoc: `\n \t \n${TABLE}\n`,
+            expectedCaret: 0,
+        },
+        {
+            side: 'below',
+            doc: `\n${TABLE}\n \t \n${AFTER}`,
+            selection: `\n${TABLE}`.length,
+            changes: { from: `\n${TABLE}`.length, to: `\n${TABLE}\n \t \n${AFTER}`.length },
+            userEvent: 'delete.forward',
+            expectedDoc: `\n${TABLE}\n \t \n`,
+            expectedCaret: `\n${TABLE}\n \t \n`.length,
+        },
+    ] as const)(
+        'preserves a whitespace-only separator during a multi-character deletion $side the table',
+        ({ doc, selection, changes, userEvent, expectedDoc, expectedCaret }) => {
+            const view = mountView(doc, selection);
+
+            view.dispatch({ changes, userEvent });
+
+            expect(view.state.doc.toString()).toBe(expectedDoc);
+            expect(view.state.selection.main.head).toBe(expectedCaret);
+            expect(getActiveCell(view.state)).toBeNull();
+            expect(getPendingOpenCellRequest(view.state)).toBeNull();
+        }
+    );
 
     it('enters the first table in document order when carets reach two of them', () => {
         const doc = `\n${TABLE}\n\nbetween\n\n${TABLE}\n\n${AFTER}`;

--- a/src/contentScript/__tests__/mainEditorTableEntry.test.ts
+++ b/src/contentScript/__tests__/mainEditorTableEntry.test.ts
@@ -655,6 +655,38 @@ describe('mainEditorTableEntry deletion protection', () => {
         expect(getPendingOpenCellRequest(view.state)).toBeNull();
     });
 
+    // No shipped key deletes past a boundary in one press, so drive the filter directly.
+    it('keeps the separator and applies the rest of a multi-character deletion above a table', () => {
+        const doc = `${BEFORE}\n\n\n${TABLE}\n`;
+        const view = mountView(doc, doc.indexOf(TABLE));
+
+        view.dispatch({
+            changes: { from: 0, to: doc.indexOf(TABLE) },
+            userEvent: 'delete.backward',
+        });
+
+        expect(view.state.doc.toString()).toBe(`\n\n${TABLE}\n`);
+        expect(view.state.selection.main.head).toBe(0);
+        expect(getActiveCell(view.state)).toBeNull();
+        expect(getPendingOpenCellRequest(view.state)).toBeNull();
+    });
+
+    it('keeps the separator and applies the rest of a multi-character deletion below a table', () => {
+        const doc = `\n${TABLE}\n\n\n${AFTER}`;
+        const tableTo = doc.indexOf(TABLE) + TABLE.length;
+        const view = mountView(doc, tableTo);
+
+        view.dispatch({
+            changes: { from: tableTo, to: doc.length },
+            userEvent: 'delete.forward',
+        });
+
+        expect(view.state.doc.toString()).toBe(`\n${TABLE}\n\n`);
+        expect(view.state.selection.main.head).toBe(tableTo + 2);
+        expect(getActiveCell(view.state)).toBeNull();
+        expect(getPendingOpenCellRequest(view.state)).toBeNull();
+    });
+
     it('enters the first table in document order when carets reach two of them', () => {
         const doc = `\n${TABLE}\n\nbetween\n\n${TABLE}\n\n${AFTER}`;
         const view = mountView(doc, doc.indexOf('between'));

--- a/src/contentScript/tableRuntime/navigation/mainEditorTableEntry.ts
+++ b/src/contentScript/tableRuntime/navigation/mainEditorTableEntry.ts
@@ -36,6 +36,13 @@ interface BoundaryEntryTarget {
     side: TableSide;
 }
 
+/** An old-document range a deletion removes, and whether it also inserts. */
+interface DeletedSpan {
+    from: number;
+    to: number;
+    insertsText: boolean;
+}
+
 // A rendered widget implies that table parsing has already completed. Keyboard
 // entry must never block waiting for syntax work on the keyboard event path.
 const TABLE_ENTRY_SYNTAX_TREE_TIMEOUT_MS = 0;
@@ -70,6 +77,11 @@ function getDeletionDirection(transaction: Transaction): DeletionDirection | nul
     }
 
     return null;
+}
+
+/** Offset of the character a one-step deletion at `head` removes. */
+function deletedCharOffset(head: number, direction: DeletionDirection): number {
+    return direction === 'forward' ? head : head - 1;
 }
 
 function resolveSourceEdgeCellCoords(ctx: TableContext, edges: EdgeCellTarget): CellCoords | null {
@@ -138,7 +150,7 @@ function resolveDeletionTargetTable(
     }
 
     const state = transaction.startState;
-    const deletedCharFrom = range.head + (direction === 'forward' ? 0 : -1);
+    const deletedCharFrom = deletedCharOffset(range.head, direction);
     if (deletedCharFrom < 0 || deletedCharFrom >= state.doc.length) {
         return null;
     }
@@ -186,15 +198,18 @@ function countNewlinesForward(state: EditorState, pos: number, limit: number): n
     return count;
 }
 
-/** True when a changed old-document range strictly overlaps `[from, to)`. */
-function changesOverlapRange(transaction: Transaction, from: number, to: number): boolean {
-    let overlaps = false;
-    transaction.changes.iterChangedRanges((changedFrom, changedTo) => {
+/**
+ * The changed old-document range strictly overlapping `[from, to)`, or null.
+ * Change ranges are disjoint, so at most one can overlap a single character.
+ */
+function resolveOverlappingChange(transaction: Transaction, from: number, to: number): DeletedSpan | null {
+    let overlapping: DeletedSpan | null = null;
+    transaction.changes.iterChanges((changedFrom, changedTo, _insertedFrom, _insertedTo, inserted) => {
         if (changedFrom < to && changedTo > from) {
-            overlaps = true;
+            overlapping = { from: changedFrom, to: changedTo, insertsText: inserted.length > 0 };
         }
     });
-    return overlaps;
+    return overlapping;
 }
 
 /**
@@ -218,6 +233,14 @@ function resolveAdjoiningTable(
     }
 
     return null;
+}
+
+/** The newlines beside the table edge that a deletion moving away from it must leave in place. */
+function resolveProtectedSeparator(state: EditorState, target: BoundaryEntryTarget): { from: number; to: number } {
+    const { ctx, side } = target;
+    return side === 'after'
+        ? { from: ctx.from - countNewlinesBackward(state, ctx.from, PROTECTED_BOUNDARY_NEWLINES), to: ctx.from }
+        : { from: ctx.to, to: ctx.to + countNewlinesForward(state, ctx.to, PROTECTED_BOUNDARY_NEWLINES) };
 }
 
 /**
@@ -245,16 +268,16 @@ function resolveBoundarySeparatorTable(
     }
 
     const state = transaction.startState;
-    const deletedFrom = range.head + (direction === 'forward' ? 0 : -1);
+    const deletedFrom = deletedCharOffset(range.head, direction);
     if (deletedFrom < 0 || deletedFrom >= state.doc.length) {
         return null;
     }
     if (state.doc.sliceString(deletedFrom, deletedFrom + 1) !== '\n') {
         return null;
     }
-    // `touchesRange` includes changes adjacent to either endpoint. Boundary protection only
-    // applies when the deletion actually consumes this newline.
-    if (!changesOverlapRange(transaction, deletedFrom, deletedFrom + 1)) {
+    // Boundary protection only applies when the deletion actually consumes this newline,
+    // not when it merely stops next to it.
+    if (!resolveOverlappingChange(transaction, deletedFrom, deletedFrom + 1)) {
         return null;
     }
 
@@ -273,17 +296,63 @@ function resolveBoundarySeparatorTable(
     return resolveAdjoiningTable(state, runFrom, runTo, direction);
 }
 
+/**
+ * Replacement for a deletion moving away from a table boundary: keep the separator, apply
+ * whatever else the deletion covered, and otherwise make the one-position move the key asked
+ * for so it is not dead.
+ *
+ * A deletion command removes one contiguous range anchored at the caret, so the separator sits
+ * at its caret-facing end and trimming it leaves the rest contiguous. A deletion that also
+ * inserts is not shaped like that, so it passes through untouched.
+ */
+function prepareSeparatorPreservingDeletion(
+    transaction: Transaction,
+    range: SelectionRange,
+    direction: DeletionDirection,
+    target: BoundaryEntryTarget
+): TransactionSpec | null {
+    const state = transaction.startState;
+    // Mapping multiple ranges would be surprising and is not needed for entry.
+    if (state.selection.ranges.length > 1) {
+        return null;
+    }
+
+    const separatorFrom = deletedCharOffset(range.head, direction);
+    const deleted = resolveOverlappingChange(transaction, separatorFrom, separatorFrom + 1);
+    if (!deleted || deleted.insertsText) {
+        return null;
+    }
+
+    const isBackward = direction === 'backward';
+    const protectedSeparator = resolveProtectedSeparator(state, target);
+    const trimmedFrom = isBackward ? deleted.from : Math.max(deleted.from, protectedSeparator.to);
+    const trimmedTo = isBackward ? Math.min(deleted.to, protectedSeparator.from) : deleted.to;
+    if (trimmedTo <= trimmedFrom) {
+        return {
+            selection: { anchor: range.head + (isBackward ? -1 : 1) },
+            scrollIntoView: transaction.scrollIntoView,
+        };
+    }
+
+    return {
+        changes: { from: trimmedFrom, to: trimmedTo },
+        selection: { anchor: trimmedFrom },
+        scrollIntoView: transaction.scrollIntoView,
+    };
+}
+
 /** Replacement transaction for a deletion that reaches a table boundary, or null to pass it through. */
 function prepareTableBoundaryDeletion(
     transaction: Transaction,
     range: SelectionRange,
     direction: DeletionDirection
 ): TransactionSpec | null {
+    const state = transaction.startState;
     const isBackward = direction === 'backward';
     const edges: EdgeCellTarget = isBackward ? { row: 'last', col: 'last' } : { row: 'first', col: 'first' };
     const deletionTarget = resolveDeletionTargetTable(transaction, range, direction);
     if (deletionTarget) {
-        return prepareEdgeCellEntry(transaction.startState, deletionTarget, edges, isBackward ? 'end' : 'start');
+        return prepareEdgeCellEntry(state, deletionTarget, edges, isBackward ? 'end' : 'start');
     }
 
     const boundaryTarget = resolveBoundarySeparatorTable(transaction, range, direction);
@@ -291,23 +360,11 @@ function prepareTableBoundaryDeletion(
         return null;
     }
 
-    const movesTowardTable =
-        (isBackward && boundaryTarget.side === 'before') ||
-        (direction === 'forward' && boundaryTarget.side === 'after');
-    if (movesTowardTable) {
-        return prepareEdgeCellEntry(transaction.startState, boundaryTarget.ctx, edges, isBackward ? 'end' : 'start');
+    if (boundaryTarget.side === (isBackward ? 'before' : 'after')) {
+        return prepareEdgeCellEntry(state, boundaryTarget.ctx, edges, isBackward ? 'end' : 'start');
     }
 
-    if (transaction.startState.selection.ranges.length > 1) {
-        return null;
-    }
-
-    // Preserve the separator while making the one-position caret move requested by the key.
-    // Mapping multiple ranges would be surprising and is not needed for entry.
-    return {
-        selection: { anchor: range.head + (isBackward ? -1 : 1) },
-        scrollIntoView: transaction.scrollIntoView,
-    };
+    return prepareSeparatorPreservingDeletion(transaction, range, direction, boundaryTarget);
 }
 
 const tableBoundaryDeletionFilter = EditorState.transactionFilter.of((transaction) => {

--- a/src/contentScript/tableRuntime/navigation/mainEditorTableEntry.ts
+++ b/src/contentScript/tableRuntime/navigation/mainEditorTableEntry.ts
@@ -14,7 +14,7 @@ import type { TableContext } from '../../tableModel/tableContext';
 import { prepareCellEntryTransaction } from '../activeCell/cellActivation';
 import { getResolvedActiveCell } from '../activeCell/resolvedActiveCell';
 import { getPendingOpenCellRequest, shouldSuppressNavigationKeys } from '../openCellRequest';
-import { REQUIRED_TABLE_BOUNDARY_BLANK_LINES } from '../tableBoundarySpacing';
+import { isBlankLineContent, REQUIRED_TABLE_BOUNDARY_BLANK_LINES } from '../tableBoundarySpacing';
 import { resolveTableContextAtPos } from '../tableResolution';
 import type { CellCoords } from '../../tableModel/types';
 import type { InitialCursorPos } from '../../shared/cursorPlacement';
@@ -41,6 +41,11 @@ interface DeletedSpan {
     from: number;
     to: number;
     insertsText: boolean;
+}
+
+interface NewlineScan {
+    count: number;
+    edge: number;
 }
 
 // A rendered widget implies that table parsing has already completed. Keyboard
@@ -173,26 +178,44 @@ function resolveDeletionTargetTable(
     return resolveTableContextAtPos(state, targetPos, TABLE_ENTRY_SYNTAX_TREE_TIMEOUT_MS);
 }
 
-/** Number of consecutive newlines immediately before `pos`, capped at `limit`. */
-function countNewlinesBackward(state: EditorState, pos: number, limit: number): number {
+/** Newlines before `pos`, crossing only blank-line whitespace and stopping at `limit`. */
+function scanNewlinesBackward(state: EditorState, pos: number, limit: number): NewlineScan {
+    let cursor = pos;
     let count = 0;
-    while (count < limit && pos - count > 0 && state.doc.sliceString(pos - count - 1, pos - count) === '\n') {
-        count++;
+    let edge = pos;
+    while (count < limit && cursor > 0) {
+        const character = state.doc.sliceString(cursor - 1, cursor);
+        if (character === '\n') {
+            cursor--;
+            edge = cursor;
+            count++;
+        } else if (isBlankLineContent(character)) {
+            cursor--;
+        } else {
+            break;
+        }
     }
-    return count;
+    return { count, edge };
 }
 
-/** Number of consecutive newlines immediately after `pos`, capped at `limit`. */
-function countNewlinesForward(state: EditorState, pos: number, limit: number): number {
+/** Newlines after `pos`, crossing only blank-line whitespace and stopping at `limit`. */
+function scanNewlinesForward(state: EditorState, pos: number, limit: number): NewlineScan {
+    let cursor = pos;
     let count = 0;
-    while (
-        count < limit &&
-        pos + count < state.doc.length &&
-        state.doc.sliceString(pos + count, pos + count + 1) === '\n'
-    ) {
-        count++;
+    let edge = pos;
+    while (count < limit && cursor < state.doc.length) {
+        const character = state.doc.sliceString(cursor, cursor + 1);
+        if (character === '\n') {
+            cursor++;
+            edge = cursor;
+            count++;
+        } else if (isBlankLineContent(character)) {
+            cursor++;
+        } else {
+            break;
+        }
     }
-    return count;
+    return { count, edge };
 }
 
 /**
@@ -236,8 +259,8 @@ function resolveAdjoiningTable(
 function resolveProtectedSeparator(state: EditorState, target: BoundaryEntryTarget): { from: number; to: number } {
     const { ctx, side } = target;
     return side === 'after'
-        ? { from: ctx.from - countNewlinesBackward(state, ctx.from, PROTECTED_BOUNDARY_NEWLINES), to: ctx.from }
-        : { from: ctx.to, to: ctx.to + countNewlinesForward(state, ctx.to, PROTECTED_BOUNDARY_NEWLINES) };
+        ? { from: scanNewlinesBackward(state, ctx.from, PROTECTED_BOUNDARY_NEWLINES).edge, to: ctx.from }
+        : { from: ctx.to, to: scanNewlinesForward(state, ctx.to, PROTECTED_BOUNDARY_NEWLINES).edge };
 }
 
 /**
@@ -284,13 +307,13 @@ function resolveBoundarySeparatorTable(
     }
 
     const limit = PROTECTED_BOUNDARY_NEWLINES + 1;
-    const runFrom = range.head - countNewlinesBackward(state, range.head, limit);
-    const runTo = range.head + countNewlinesForward(state, range.head, limit);
-    if (runTo - runFrom > PROTECTED_BOUNDARY_NEWLINES) {
+    const backward = scanNewlinesBackward(state, range.head, limit);
+    const forward = scanNewlinesForward(state, range.head, limit);
+    if (backward.count + forward.count > PROTECTED_BOUNDARY_NEWLINES) {
         return null;
     }
 
-    return resolveAdjoiningTable(state, runFrom, runTo, direction);
+    return resolveAdjoiningTable(state, backward.edge, forward.edge, direction);
 }
 
 /**

--- a/src/contentScript/tableRuntime/navigation/mainEditorTableEntry.ts
+++ b/src/contentScript/tableRuntime/navigation/mainEditorTableEntry.ts
@@ -20,6 +20,7 @@ import type { CellCoords } from '../../tableModel/types';
 import type { InitialCursorPos } from '../../shared/cursorPlacement';
 
 type DeletionDirection = 'backward' | 'forward';
+type TableSide = 'before' | 'after';
 type VerticalEntryDirection = 'up' | 'down';
 type HorizontalEntryDirection = 'left' | 'right';
 /** Which end of a grid axis an entry lands on. */
@@ -28,6 +29,11 @@ type GridEdge = 'first' | 'last';
 interface EdgeCellTarget {
     row: GridEdge;
     col: GridEdge;
+}
+
+interface BoundaryEntryTarget {
+    ctx: TableContext;
+    side: TableSide;
 }
 
 // A rendered widget implies that table parsing has already completed. Keyboard
@@ -131,75 +137,177 @@ function resolveDeletionTargetTable(
         return null;
     }
 
+    const state = transaction.startState;
+    const deletedCharFrom = range.head + (direction === 'forward' ? 0 : -1);
+    if (deletedCharFrom < 0 || deletedCharFrom >= state.doc.length) {
+        return null;
+    }
+    // A newline can be table separation even when the table begins at the change's other
+    // endpoint. Let the boundary resolver decide whether it is protected or surplus.
+    if (state.doc.sliceString(deletedCharFrom, deletedCharFrom + 1) === '\n') {
+        return null;
+    }
+
     // CodeMirror's deletion commands remove one contiguous range anchored at the caret, so
     // the character next to the caret is always part of it - including word- and line-wise
     // deletion, which stops at the line boundary and reaches the table on the following
     // press. Probing that one position identifies the table being deleted into without
     // walking the change set; `touchesRange` then confirms this transaction is that deletion.
     const targetPos = range.head + (direction === 'forward' ? 1 : -1);
-    if (targetPos < 0 || targetPos > transaction.startState.doc.length) {
+    if (targetPos < 0 || targetPos > state.doc.length) {
         return null;
     }
     if (!transaction.changes.touchesRange(targetPos)) {
         return null;
     }
 
-    return resolveTableContextAtPos(transaction.startState, targetPos, TABLE_ENTRY_SYNTAX_TREE_TIMEOUT_MS);
+    return resolveTableContextAtPos(state, targetPos, TABLE_ENTRY_SYNTAX_TREE_TIMEOUT_MS);
 }
 
-/** Length of the run of newlines starting at `from` and extending in `direction`. */
-function measureNewlineRun(state: EditorState, from: number, direction: DeletionDirection): number {
-    const limit = PROTECTED_BOUNDARY_NEWLINES + 1;
-    const text =
-        direction === 'forward'
-            ? state.doc.sliceString(from, Math.min(state.doc.length, from + limit))
-            : state.doc.sliceString(Math.max(0, from - limit), from);
-    let run = 0;
-    while (run < text.length && text[direction === 'forward' ? run : text.length - 1 - run] === '\n') {
-        run++;
+/** Number of consecutive newlines immediately before `pos`, capped at `limit`. */
+function countNewlinesBackward(state: EditorState, pos: number, limit: number): number {
+    let count = 0;
+    while (count < limit && pos - count > 0 && state.doc.sliceString(pos - count - 1, pos - count) === '\n') {
+        count++;
     }
-    return run;
+    return count;
+}
+
+/** Number of consecutive newlines immediately after `pos`, capped at `limit`. */
+function countNewlinesForward(state: EditorState, pos: number, limit: number): number {
+    let count = 0;
+    while (
+        count < limit &&
+        pos + count < state.doc.length &&
+        state.doc.sliceString(pos + count, pos + count + 1) === '\n'
+    ) {
+        count++;
+    }
+    return count;
+}
+
+/** True when a changed old-document range strictly overlaps `[from, to)`. */
+function changesOverlapRange(transaction: Transaction, from: number, to: number): boolean {
+    let overlaps = false;
+    transaction.changes.iterChangedRanges((changedFrom, changedTo) => {
+        if (changedFrom < to && changedTo > from) {
+            overlaps = true;
+        }
+    });
+    return overlaps;
+}
+
+/**
+ * The table that the newline span `[from, to)` separates from its neighbour, or null.
+ *
+ * A span between two tables separates both, so the table the deletion moves toward wins.
+ */
+function resolveAdjoiningTable(
+    state: EditorState,
+    from: number,
+    to: number,
+    direction: DeletionDirection
+): BoundaryEntryTarget | null {
+    const sides: TableSide[] = direction === 'backward' ? ['before', 'after'] : ['after', 'before'];
+    for (const side of sides) {
+        const boundary = side === 'before' ? from : to;
+        const ctx = resolveTableContextAtPos(state, boundary, TABLE_ENTRY_SYNTAX_TREE_TIMEOUT_MS);
+        if (ctx && (side === 'before' ? ctx.to === boundary : ctx.from === boundary)) {
+            return { ctx, side };
+        }
+    }
+
+    return null;
 }
 
 /**
  * The table whose boundary separation this deletion would consume, or null.
  *
- * A table is kept clear of its neighbours by `REQUIRED_TABLE_BOUNDARY_BLANK_LINES`, and
- * entering a cell restores that spacing when it is missing. Deleting the last of those
- * newlines is therefore work the plugin immediately undoes, so the separator counts as
- * part of the table boundary and the deletion enters the edge cell instead. Surplus blank
- * lines are ordinary text and still delete normally, one press at a time.
+ * A table is kept clear of its neighbours by `REQUIRED_TABLE_BOUNDARY_BLANK_LINES`, and a
+ * newline counts as part of that boundary in either of two ways:
+ *
+ * - it sits directly against a table edge, so removing it merges the neighbouring line into
+ *   the table's own line and leaves the caret parked on the widget edge; or
+ * - it belongs to a run no longer than `PROTECTED_BOUNDARY_NEWLINES`, so removing it drops
+ *   the separation below the blank line the plugin would immediately restore.
+ *
+ * Deleting toward the table enters its edge cell; deleting away preserves the newline and
+ * moves the caret. Surplus blank lines in the middle of a longer run are ordinary text and
+ * still delete normally, one press at a time.
  */
 function resolveBoundarySeparatorTable(
     transaction: Transaction,
     range: SelectionRange,
     direction: DeletionDirection
-): TableContext | null {
+): BoundaryEntryTarget | null {
     if (!range.empty) {
         return null;
     }
 
     const state = transaction.startState;
-    const runLength = measureNewlineRun(state, range.head, direction);
-    if (runLength === 0 || runLength > PROTECTED_BOUNDARY_NEWLINES) {
+    const deletedFrom = range.head + (direction === 'forward' ? 0 : -1);
+    if (deletedFrom < 0 || deletedFrom >= state.doc.length) {
+        return null;
+    }
+    if (state.doc.sliceString(deletedFrom, deletedFrom + 1) !== '\n') {
+        return null;
+    }
+    // `touchesRange` includes changes adjacent to either endpoint. Boundary protection only
+    // applies when the deletion actually consumes this newline.
+    if (!changesOverlapRange(transaction, deletedFrom, deletedFrom + 1)) {
         return null;
     }
 
-    const isForward = direction === 'forward';
-    const runFrom = isForward ? range.head : range.head - runLength;
-    const runTo = isForward ? range.head + runLength : range.head;
-    if (!transaction.changes.touchesRange(runFrom, runTo)) {
+    const edgeAdjacent = resolveAdjoiningTable(state, deletedFrom, deletedFrom + 1, direction);
+    if (edgeAdjacent) {
+        return edgeAdjacent;
+    }
+
+    const limit = PROTECTED_BOUNDARY_NEWLINES + 1;
+    const runFrom = range.head - countNewlinesBackward(state, range.head, limit);
+    const runTo = range.head + countNewlinesForward(state, range.head, limit);
+    if (runTo - runFrom > PROTECTED_BOUNDARY_NEWLINES) {
         return null;
     }
 
-    // The run has to lead straight into the table, not merely toward one further away.
-    const boundary = isForward ? runTo : runFrom;
-    const ctx = resolveTableContextAtPos(state, boundary, TABLE_ENTRY_SYNTAX_TREE_TIMEOUT_MS);
-    if (!ctx || (isForward ? ctx.from !== boundary : ctx.to !== boundary)) {
+    return resolveAdjoiningTable(state, runFrom, runTo, direction);
+}
+
+/** Replacement transaction for a deletion that reaches a table boundary, or null to pass it through. */
+function prepareTableBoundaryDeletion(
+    transaction: Transaction,
+    range: SelectionRange,
+    direction: DeletionDirection
+): TransactionSpec | null {
+    const isBackward = direction === 'backward';
+    const edges: EdgeCellTarget = isBackward ? { row: 'last', col: 'last' } : { row: 'first', col: 'first' };
+    const deletionTarget = resolveDeletionTargetTable(transaction, range, direction);
+    if (deletionTarget) {
+        return prepareEdgeCellEntry(transaction.startState, deletionTarget, edges, isBackward ? 'end' : 'start');
+    }
+
+    const boundaryTarget = resolveBoundarySeparatorTable(transaction, range, direction);
+    if (!boundaryTarget) {
         return null;
     }
 
-    return ctx;
+    const movesTowardTable =
+        (isBackward && boundaryTarget.side === 'before') ||
+        (direction === 'forward' && boundaryTarget.side === 'after');
+    if (movesTowardTable) {
+        return prepareEdgeCellEntry(transaction.startState, boundaryTarget.ctx, edges, isBackward ? 'end' : 'start');
+    }
+
+    if (transaction.startState.selection.ranges.length > 1) {
+        return null;
+    }
+
+    // Preserve the separator while making the one-position caret move requested by the key.
+    // Mapping multiple ranges would be surprising and is not needed for entry.
+    return {
+        selection: { anchor: range.head + (isBackward ? -1 : 1) },
+        scrollIntoView: transaction.scrollIntoView,
+    };
 }
 
 const tableBoundaryDeletionFilter = EditorState.transactionFilter.of((transaction) => {
@@ -217,22 +325,11 @@ const tableBoundaryDeletionFilter = EditorState.transactionFilter.of((transactio
         return transaction;
     }
 
-    const isBackward = direction === 'backward';
-    const edges: EdgeCellTarget = isBackward ? { row: 'last', col: 'last' } : { row: 'first', col: 'first' };
-
-    // Several carets can reach tables in one gesture. Enter the first in document order and
-    // drop the rest of the deletion: a cell editor holds one caret, so the entry transaction
-    // collapses the other ranges regardless, and letting them through would edit the very
-    // Markdown this filter protects.
+    // Several carets can reach tables in one gesture. A deletion toward a table enters the
+    // first in document order and drops the rest because a cell editor holds one caret. An
+    // away-from-table caret move requires a lone caret; multi-range deletion passes through.
     for (const range of transaction.startState.selection.ranges) {
-        const ctx =
-            resolveDeletionTargetTable(transaction, range, direction) ??
-            resolveBoundarySeparatorTable(transaction, range, direction);
-        if (!ctx) {
-            continue;
-        }
-
-        const spec = prepareEdgeCellEntry(transaction.startState, ctx, edges, isBackward ? 'end' : 'start');
+        const spec = prepareTableBoundaryDeletion(transaction, range, direction);
         if (spec) {
             return spec;
         }

--- a/src/contentScript/tableRuntime/navigation/mainEditorTableEntry.ts
+++ b/src/contentScript/tableRuntime/navigation/mainEditorTableEntry.ts
@@ -166,9 +166,6 @@ function resolveDeletionTargetTable(
     // press. Probing that one position identifies the table being deleted into without
     // walking the change set; `touchesRange` then confirms this transaction is that deletion.
     const targetPos = range.head + (direction === 'forward' ? 1 : -1);
-    if (targetPos < 0 || targetPos > state.doc.length) {
-        return null;
-    }
     if (!transaction.changes.touchesRange(targetPos)) {
         return null;
     }

--- a/src/contentScript/tableRuntime/tableBoundarySpacing.ts
+++ b/src/contentScript/tableRuntime/tableBoundarySpacing.ts
@@ -1,5 +1,10 @@
 export const REQUIRED_TABLE_BOUNDARY_BLANK_LINES = 1;
 
+/** True when text contains only whitespace and can therefore form a blank line. */
+export function isBlankLineContent(text: string): boolean {
+    return text.trim().length === 0;
+}
+
 export function countTrailingBlankLinesBeforeBoundary(text: string): number {
     if (text.length === 0 || !text.endsWith('\n')) {
         return 0;
@@ -9,7 +14,7 @@ export function countTrailingBlankLinesBeforeBoundary(text: string): number {
     let index = lines.length - 2;
     let blankLineCount = 0;
 
-    while (index >= 0 && lines[index].trim().length === 0) {
+    while (index >= 0 && isBlankLineContent(lines[index])) {
         blankLineCount++;
         index--;
     }
@@ -26,7 +31,7 @@ export function countLeadingBlankLinesAfterBoundary(text: string): number {
     let index = 1;
     let blankLineCount = 0;
 
-    while (index < lines.length && lines[index].trim().length === 0) {
+    while (index < lines.length && isBlankLineContent(lines[index])) {
         blankLineCount++;
         index++;
     }


### PR DESCRIPTION
## Summary

- preserve the blank-line boundary when deleting away from a rendered table
- enter the edge cell when deleting toward a table boundary
- trim multi-character deletions around protected separators
- recognize whitespace-only blank lines using the same semantics as table canonicalization
- retain normal deletion behavior for surplus blank lines

## Verification

- npm test (65 files, 754 tests)
- npm run lint
- npm run dist
- npm run knip
- git diff --check

## Known limitation

With multiple carets, an away-from-table deletion currently passes through unchanged and can remove required boundary spacing.