### PR TITLE
fix: protect table boundaries from linewise cuts

### DIFF
--- a/docs/Architecture/Interaction-and-Navigation.md
+++ b/docs/Architecture/Interaction-and-Navigation.md
@@ -36,8 +36,11 @@ Rules that hold across both halves:
 
 - Deletion protection keys off CodeMirror's semantic `delete.backward`/`delete.forward` transactions rather than
   physical key bindings, so word- and line-wise deletes are covered while IME and soft-keyboard `input.type` stays under
-  CodeMirror's platform behavior. A native cut with no explicit selection is CodeMirror's linewise `delete.cut`; it is
-  protected as a forward deletion, while an explicit cut selection remains a deliberate range deletion.
+  CodeMirror's platform behavior. A native cut with no explicit selection is CodeMirror's linewise `delete.cut`, which
+  removes whole lines: it is judged per line rather than per caret, and cancelled outright when any caret sits on a
+  table's source line or on a blank line the table needs, since a cut applied in part would leave a table half cut. The
+  caret does not move and the clipboard still holds the lines. An explicit cut selection remains a deliberate range
+  deletion.
 - A cell editor holds one caret, so only one may enter: a multi-cursor deletion enters the first table in document order
   and drops the rest. Once entry is requested, key repeat is suppressed until the nested editor takes focus, so a held
   key cannot walk the main caret through the hidden Markdown.

--- a/docs/Architecture/Interaction-and-Navigation.md
+++ b/docs/Architecture/Interaction-and-Navigation.md
@@ -36,7 +36,8 @@ Rules that hold across both halves:
 
 - Deletion protection keys off CodeMirror's semantic `delete.backward`/`delete.forward` transactions rather than
   physical key bindings, so word- and line-wise deletes are covered while IME and soft-keyboard `input.type` stays under
-  CodeMirror's platform behavior.
+  CodeMirror's platform behavior. A native cut with no explicit selection is CodeMirror's linewise `delete.cut`; it is
+  protected as a forward deletion, while an explicit cut selection remains a deliberate range deletion.
 - A cell editor holds one caret, so only one may enter: a multi-cursor deletion enters the first table in document order
   and drops the rest. Once entry is requested, key repeat is suppressed until the nested editor takes focus, so a held
   key cannot walk the main caret through the hidden Markdown.

--- a/src/contentScript/__tests__/mainEditorTableEntry.test.ts
+++ b/src/contentScript/__tests__/mainEditorTableEntry.test.ts
@@ -89,6 +89,26 @@ function pressKey(view: EditorView, key: string, modifiers: KeyboardEventInit = 
     );
 }
 
+function cutCurrentLine(view: EditorView): void {
+    const line = view.state.doc.lineAt(view.state.selection.main.head);
+    view.dispatch({
+        changes: { from: line.from, to: Math.min(view.state.doc.length, line.to + 1) },
+        userEvent: 'delete.cut',
+    });
+}
+
+function dispatchCutEvent(view: EditorView): void {
+    view.focus();
+    const event = new Event('cut', { bubbles: true, cancelable: true });
+    Object.defineProperty(event, 'clipboardData', {
+        value: {
+            clearData: vi.fn(),
+            setData: vi.fn(),
+        },
+    });
+    view.contentDOM.dispatchEvent(event);
+}
+
 function expectBoundaryCellOpen(view: EditorView, edge: 'start' | 'end'): void {
     const tableFrom = view.state.doc.toString().indexOf(TABLE);
     expect(getActiveCell(view.state)).toEqual(
@@ -127,6 +147,104 @@ function expectCellOpen(
 }
 
 describe('mainEditorTableEntry deletion protection', () => {
+    it('protects the boundary above a table from a native linewise cut', () => {
+        const tableFrom = AROUND_TABLE_DOC.indexOf(TABLE);
+        const view = mountView(AROUND_TABLE_DOC, tableFrom - 1);
+
+        dispatchCutEvent(view);
+
+        expect(view.state.doc.toString()).toBe(AROUND_TABLE_DOC);
+        expectBoundaryCellOpen(view, 'start');
+    });
+
+    it.each([
+        {
+            caret: 'blank line above the table',
+            pos: AROUND_TABLE_DOC.indexOf(TABLE) - 1,
+            expected: { kind: 'entry', edge: 'start' },
+        },
+        {
+            caret: 'table start',
+            pos: AROUND_TABLE_DOC.indexOf(TABLE),
+            expected: { kind: 'entry', edge: 'start' },
+        },
+        {
+            caret: 'table end',
+            pos: AROUND_TABLE_DOC.indexOf(TABLE) + TABLE.length,
+            expected: { kind: 'move', offset: 1 },
+        },
+        {
+            caret: 'blank line below the table',
+            pos: AROUND_TABLE_DOC.indexOf(TABLE) + TABLE.length + 1,
+            expected: { kind: 'move', offset: 1 },
+        },
+    ] as const)('linewise cut at $caret preserves the boundary', ({ pos, expected }) => {
+        const view = mountView(AROUND_TABLE_DOC, pos);
+
+        cutCurrentLine(view);
+
+        expect(view.state.doc.toString()).toBe(AROUND_TABLE_DOC);
+        if (expected.kind === 'entry') {
+            expectBoundaryCellOpen(view, expected.edge);
+        } else {
+            expect(view.state.selection.main.head).toBe(pos + expected.offset);
+            expect(getActiveCell(view.state)).toBeNull();
+            expect(getPendingOpenCellRequest(view.state)).toBeNull();
+        }
+    });
+
+    it('protects the final table row from linewise cut at the document end', () => {
+        const doc = `\n${TABLE}`;
+        const view = mountView(doc, doc.length);
+
+        cutCurrentLine(view);
+
+        expect(view.state.doc.toString()).toBe(doc);
+        expect(view.state.selection.main.head).toBe(doc.length);
+        expect(getActiveCell(view.state)).toBeNull();
+        expect(getPendingOpenCellRequest(view.state)).toBeNull();
+    });
+
+    it('allows linewise cut to remove a surplus blank line', () => {
+        const doc = `${BEFORE}\n\n\n${TABLE}\n`;
+        const view = mountView(doc, BEFORE.length + 1);
+
+        cutCurrentLine(view);
+
+        expect(view.state.doc.toString()).toBe(ABOVE_TABLE_DOC);
+        expect(getActiveCell(view.state)).toBeNull();
+        expect(getPendingOpenCellRequest(view.state)).toBeNull();
+    });
+
+    it.each([
+        { label: 'source mode', effect: toggleSourceModeEffect.of(true) },
+        { label: 'search-forced raw mode', effect: setSearchForceSourceModeEffect.of(true) },
+    ])('leaves linewise cut unchanged in $label', ({ effect }) => {
+        const doc = `${TABLE}\nafter`;
+        const view = mountView(doc, 0);
+        view.dispatch({ effects: effect });
+
+        cutCurrentLine(view);
+
+        expect(view.state.doc.toString()).toBe(`${TABLE.split('\n').slice(1).join('\n')}\nafter`);
+        expect(getActiveCell(view.state)).toBeNull();
+        expect(getPendingOpenCellRequest(view.state)).toBeNull();
+    });
+
+    it('leaves an explicit cut selection deliberate', () => {
+        const firstRowTo = TABLE.indexOf('\n') + 1;
+        const view = mountView(TABLE, { anchor: 0, head: firstRowTo });
+
+        view.dispatch({
+            changes: { from: 0, to: firstRowTo },
+            userEvent: 'delete.cut',
+        });
+
+        expect(view.state.doc.toString()).toBe(TABLE.slice(firstRowTo));
+        expect(getActiveCell(view.state)).toBeNull();
+        expect(getPendingOpenCellRequest(view.state)).toBeNull();
+    });
+
     it.each([
         {
             caret: 'blank line above the table',

--- a/src/contentScript/__tests__/mainEditorTableEntry.test.ts
+++ b/src/contentScript/__tests__/mainEditorTableEntry.test.ts
@@ -89,12 +89,18 @@ function pressKey(view: EditorView, key: string, modifiers: KeyboardEventInit = 
     );
 }
 
-function cutCurrentLine(view: EditorView): void {
-    const line = view.state.doc.lineAt(view.state.selection.main.head);
-    view.dispatch({
-        changes: { from: line.from, to: Math.min(view.state.doc.length, line.to + 1) },
-        userEvent: 'delete.cut',
-    });
+/** What CodeMirror's cut handler dispatches when no range is selected: one change per line. */
+function cutLines(view: EditorView): void {
+    const seen = new Set<number>();
+    const changes: { from: number; to: number }[] = [];
+    for (const range of view.state.selection.ranges) {
+        const line = view.state.doc.lineAt(range.from);
+        if (!seen.has(line.number)) {
+            seen.add(line.number);
+            changes.push({ from: line.from, to: Math.min(view.state.doc.length, line.to + 1) });
+        }
+    }
+    view.dispatch({ changes, userEvent: 'delete.cut' });
 }
 
 function dispatchCutEvent(view: EditorView): void {
@@ -154,50 +160,32 @@ describe('mainEditorTableEntry deletion protection', () => {
         dispatchCutEvent(view);
 
         expect(view.state.doc.toString()).toBe(AROUND_TABLE_DOC);
-        expectBoundaryCellOpen(view, 'start');
+        expect(view.state.selection.main.head).toBe(tableFrom - 1);
+        expect(getActiveCell(view.state)).toBeNull();
+        expect(getPendingOpenCellRequest(view.state)).toBeNull();
     });
 
     it.each([
-        {
-            caret: 'blank line above the table',
-            pos: AROUND_TABLE_DOC.indexOf(TABLE) - 1,
-            expected: { kind: 'entry', edge: 'start' },
-        },
-        {
-            caret: 'table start',
-            pos: AROUND_TABLE_DOC.indexOf(TABLE),
-            expected: { kind: 'entry', edge: 'start' },
-        },
-        {
-            caret: 'table end',
-            pos: AROUND_TABLE_DOC.indexOf(TABLE) + TABLE.length,
-            expected: { kind: 'move', offset: 1 },
-        },
-        {
-            caret: 'blank line below the table',
-            pos: AROUND_TABLE_DOC.indexOf(TABLE) + TABLE.length + 1,
-            expected: { kind: 'move', offset: 1 },
-        },
-    ] as const)('linewise cut at $caret preserves the boundary', ({ pos, expected }) => {
+        { caret: 'blank line above the table', pos: AROUND_TABLE_DOC.indexOf(TABLE) - 1 },
+        { caret: 'table start', pos: AROUND_TABLE_DOC.indexOf(TABLE) },
+        { caret: 'table end', pos: AROUND_TABLE_DOC.indexOf(TABLE) + TABLE.length },
+        { caret: 'blank line below the table', pos: AROUND_TABLE_DOC.indexOf(TABLE) + TABLE.length + 1 },
+    ] as const)('linewise cut at $caret is dropped and leaves the caret put', ({ pos }) => {
         const view = mountView(AROUND_TABLE_DOC, pos);
 
-        cutCurrentLine(view);
+        cutLines(view);
 
         expect(view.state.doc.toString()).toBe(AROUND_TABLE_DOC);
-        if (expected.kind === 'entry') {
-            expectBoundaryCellOpen(view, expected.edge);
-        } else {
-            expect(view.state.selection.main.head).toBe(pos + expected.offset);
-            expect(getActiveCell(view.state)).toBeNull();
-            expect(getPendingOpenCellRequest(view.state)).toBeNull();
-        }
+        expect(view.state.selection.main.head).toBe(pos);
+        expect(getActiveCell(view.state)).toBeNull();
+        expect(getPendingOpenCellRequest(view.state)).toBeNull();
     });
 
     it('protects the final table row from linewise cut at the document end', () => {
         const doc = `\n${TABLE}`;
         const view = mountView(doc, doc.length);
 
-        cutCurrentLine(view);
+        cutLines(view);
 
         expect(view.state.doc.toString()).toBe(doc);
         expect(view.state.selection.main.head).toBe(doc.length);
@@ -205,11 +193,58 @@ describe('mainEditorTableEntry deletion protection', () => {
         expect(getPendingOpenCellRequest(view.state)).toBeNull();
     });
 
+    it('protects a whitespace-only boundary line from a linewise cut', () => {
+        const doc = `${BEFORE}\n   \n${TABLE}\n`;
+        const view = mountView(doc, BEFORE.length + 2);
+
+        cutLines(view);
+
+        expect(view.state.doc.toString()).toBe(doc);
+    });
+
+    it.each([
+        { caret: 'line start', column: 0 },
+        { caret: 'line end', column: BEFORE.length },
+    ])('cuts the line above a table with the caret at $caret', ({ column }) => {
+        const view = mountView(AROUND_TABLE_DOC, column);
+
+        cutLines(view);
+
+        expect(view.state.doc.toString()).toBe(AROUND_TABLE_DOC.slice(BEFORE.length + 1));
+        expect(getActiveCell(view.state)).toBeNull();
+        expect(getPendingOpenCellRequest(view.state)).toBeNull();
+    });
+
+    it('drops a multi-caret linewise cut whole and keeps every caret', () => {
+        const doc = `alpha\n\n${TABLE}`;
+        const view = mountView(doc, 0);
+        view.dispatch({
+            selection: EditorSelection.create([EditorSelection.cursor(2), EditorSelection.cursor(doc.length)], 0),
+        });
+
+        cutLines(view);
+
+        expect(view.state.doc.toString()).toBe(doc);
+        expect(view.state.selection.ranges.map((range) => range.head)).toEqual([2, doc.length]);
+    });
+
+    it('allows a multi-caret linewise cut that leaves every table alone', () => {
+        const doc = `alpha\nbeta\n\n${TABLE}`;
+        const view = mountView(doc, 0);
+        view.dispatch({
+            selection: EditorSelection.create([EditorSelection.cursor(2), EditorSelection.cursor(8)], 0),
+        });
+
+        cutLines(view);
+
+        expect(view.state.doc.toString()).toBe(`\n${TABLE}`);
+    });
+
     it('allows linewise cut to remove a surplus blank line', () => {
         const doc = `${BEFORE}\n\n\n${TABLE}\n`;
         const view = mountView(doc, BEFORE.length + 1);
 
-        cutCurrentLine(view);
+        cutLines(view);
 
         expect(view.state.doc.toString()).toBe(ABOVE_TABLE_DOC);
         expect(getActiveCell(view.state)).toBeNull();
@@ -224,7 +259,7 @@ describe('mainEditorTableEntry deletion protection', () => {
         const view = mountView(doc, 0);
         view.dispatch({ effects: effect });
 
-        cutCurrentLine(view);
+        cutLines(view);
 
         expect(view.state.doc.toString()).toBe(`${TABLE.split('\n').slice(1).join('\n')}\nafter`);
         expect(getActiveCell(view.state)).toBeNull();

--- a/src/contentScript/tableRuntime/navigation/mainEditorTableEntry.ts
+++ b/src/contentScript/tableRuntime/navigation/mainEditorTableEntry.ts
@@ -77,7 +77,13 @@ function getDeletionDirection(transaction: Transaction): DeletionDirection | nul
         return 'backward';
     }
 
-    if (transaction.isUserEvent('delete.forward')) {
+    // With no explicit selection, CodeMirror implements native cut as a linewise
+    // deletion. Its range runs through the current line's trailing newline, so it
+    // reaches a table boundary in the same direction as a forward deletion.
+    if (
+        transaction.isUserEvent('delete.forward') ||
+        (transaction.isUserEvent('delete.cut') && transaction.startState.selection.ranges.every((range) => range.empty))
+    ) {
         return 'forward';
     }
 
@@ -387,6 +393,35 @@ function prepareTableBoundaryDeletion(
     return prepareSeparatorPreservingDeletion(transaction, range, direction, boundaryTarget);
 }
 
+/**
+ * Protects a table's final source row when a linewise cut starts at its end.
+ *
+ * Forward deletion normally discovers the protected separator at the caret. At the
+ * document end there is no character to probe, while CodeMirror's linewise cut still
+ * removes the entire final row behind the caret. A directly adjoining character can
+ * create the same shape in malformed, unspaced input, so use the table range itself as
+ * the fallback signal.
+ */
+function prepareTrailingTableLineCutProtection(
+    transaction: Transaction,
+    range: SelectionRange
+): TransactionSpec | null {
+    if (!transaction.isUserEvent('delete.cut') || !range.empty) {
+        return null;
+    }
+
+    const state = transaction.startState;
+    const ctx = resolveTableContextAtPos(state, range.head, TABLE_ENTRY_SYNTAX_TREE_TIMEOUT_MS);
+    if (ctx?.to !== range.head || !resolveOverlappingChange(transaction, range.head - 1, range.head)) {
+        return null;
+    }
+
+    return {
+        selection: { anchor: Math.min(range.head + 1, state.doc.length) },
+        scrollIntoView: transaction.scrollIntoView,
+    };
+}
+
 const tableBoundaryDeletionFilter = EditorState.transactionFilter.of((transaction) => {
     const direction = getDeletionDirection(transaction);
     if (!direction || !transaction.docChanged) {
@@ -404,9 +439,13 @@ const tableBoundaryDeletionFilter = EditorState.transactionFilter.of((transactio
 
     // Several carets can reach tables in one gesture. A deletion toward a table enters the
     // first in document order and drops the rest because a cell editor holds one caret. An
-    // away-from-table caret move requires a lone caret; multi-range deletion passes through.
+    // ordinary away-from-table caret move requires a lone caret; multi-range deletion passes
+    // through. Linewise cut is also stopped when it would remove a trailing table row, since
+    // that hidden structural deletion cannot safely be applied in part.
     for (const range of transaction.startState.selection.ranges) {
-        const spec = prepareTableBoundaryDeletion(transaction, range, direction);
+        const spec =
+            prepareTableBoundaryDeletion(transaction, range, direction) ??
+            prepareTrailingTableLineCutProtection(transaction, range);
         if (spec) {
             return spec;
         }

--- a/src/contentScript/tableRuntime/navigation/mainEditorTableEntry.ts
+++ b/src/contentScript/tableRuntime/navigation/mainEditorTableEntry.ts
@@ -20,6 +20,8 @@ import type { CellCoords } from '../../tableModel/types';
 import type { InitialCursorPos } from '../../shared/cursorPlacement';
 
 type DeletionDirection = 'backward' | 'forward';
+/** A native cut with no selection removes whole lines, so it is not a directed deletion. */
+type DeletionKind = DeletionDirection | 'linewiseCut';
 type TableSide = 'before' | 'after';
 type VerticalEntryDirection = 'up' | 'down';
 type HorizontalEntryDirection = 'left' | 'right';
@@ -72,19 +74,22 @@ function canEnterFromArrowMovement(state: EditorState): boolean {
     return canEnterRenderedTable(state) && state.selection.ranges.length === 1 && state.selection.main.empty;
 }
 
-function getDeletionDirection(transaction: Transaction): DeletionDirection | null {
+function resolveDeletionKind(transaction: Transaction): DeletionKind | null {
     if (transaction.isUserEvent('delete.backward')) {
         return 'backward';
     }
 
-    // With no explicit selection, CodeMirror implements native cut as a linewise
-    // deletion. Its range runs through the current line's trailing newline, so it
-    // reaches a table boundary in the same direction as a forward deletion.
-    if (
-        transaction.isUserEvent('delete.forward') ||
-        (transaction.isUserEvent('delete.cut') && transaction.startState.selection.ranges.every((range) => range.empty))
-    ) {
+    if (transaction.isUserEvent('delete.forward')) {
         return 'forward';
+    }
+
+    // CodeMirror cuts linewise when nothing is selected, so the caret's column has no
+    // bearing on what disappears.
+    if (
+        transaction.isUserEvent('delete.cut') &&
+        transaction.startState.selection.ranges.every((range) => range.empty)
+    ) {
+        return 'linewiseCut';
     }
 
     return null;
@@ -155,11 +160,6 @@ function resolveDeletionTargetTable(
     range: SelectionRange,
     direction: DeletionDirection
 ): TableContext | null {
-    // An explicit selection is a deliberate range deletion, a table-spanning one included.
-    if (!range.empty) {
-        return null;
-    }
-
     const state = transaction.startState;
     const deletedCharFrom = deletedCharOffset(range.head, direction);
     if (deletedCharFrom < 0 || deletedCharFrom >= state.doc.length) {
@@ -286,15 +286,11 @@ function resolveProtectedSeparator(state: EditorState, target: BoundaryEntryTarg
  */
 function resolveBoundarySeparatorTable(
     transaction: Transaction,
-    range: SelectionRange,
+    head: number,
     direction: DeletionDirection
 ): BoundaryEntryTarget | null {
-    if (!range.empty) {
-        return null;
-    }
-
     const state = transaction.startState;
-    const deletedFrom = deletedCharOffset(range.head, direction);
+    const deletedFrom = deletedCharOffset(head, direction);
     if (deletedFrom < 0 || deletedFrom >= state.doc.length) {
         return null;
     }
@@ -313,8 +309,8 @@ function resolveBoundarySeparatorTable(
     }
 
     const limit = PROTECTED_BOUNDARY_NEWLINES + 1;
-    const backward = scanNewlinesBackward(state, range.head, limit);
-    const forward = scanNewlinesForward(state, range.head, limit);
+    const backward = scanNewlinesBackward(state, head, limit);
+    const forward = scanNewlinesForward(state, head, limit);
     if (backward.count + forward.count > PROTECTED_BOUNDARY_NEWLINES) {
         return null;
     }
@@ -373,6 +369,11 @@ function prepareTableBoundaryDeletion(
     range: SelectionRange,
     direction: DeletionDirection
 ): TransactionSpec | null {
+    // An explicit selection is a deliberate range deletion, a table-spanning one included.
+    if (!range.empty) {
+        return null;
+    }
+
     const state = transaction.startState;
     const isBackward = direction === 'backward';
     const edges: EdgeCellTarget = isBackward ? { row: 'last', col: 'last' } : { row: 'first', col: 'first' };
@@ -381,7 +382,7 @@ function prepareTableBoundaryDeletion(
         return prepareEdgeCellEntry(state, deletionTarget, edges, isBackward ? 'end' : 'start');
     }
 
-    const boundaryTarget = resolveBoundarySeparatorTable(transaction, range, direction);
+    const boundaryTarget = resolveBoundarySeparatorTable(transaction, range.head, direction);
     if (!boundaryTarget) {
         return null;
     }
@@ -394,37 +395,33 @@ function prepareTableBoundaryDeletion(
 }
 
 /**
- * Protects a table's final source row when a linewise cut starts at its end.
+ * True when a linewise cut would take a line the table needs.
  *
- * Forward deletion normally discovers the protected separator at the caret. At the
- * document end there is no character to probe, while CodeMirror's linewise cut still
- * removes the entire final row behind the caret. A directly adjoining character can
- * create the same shape in malformed, unspaced input, so use the table range itself as
- * the fallback signal.
+ * A cut removes whole lines, so protection is decided per line rather than per character.
+ * Dropping a line that holds text leaves the blank lines around it in place, so only two
+ * shapes are unsafe: a line holding hidden table source, and a blank line that keeps a table
+ * clear of its neighbour.
  */
-function prepareTrailingTableLineCutProtection(
-    transaction: Transaction,
-    range: SelectionRange
-): TransactionSpec | null {
-    if (!transaction.isUserEvent('delete.cut') || !range.empty) {
-        return null;
-    }
-
+function hasUncuttableLine(transaction: Transaction): boolean {
     const state = transaction.startState;
-    const ctx = resolveTableContextAtPos(state, range.head, TABLE_ENTRY_SYNTAX_TREE_TIMEOUT_MS);
-    if (ctx?.to !== range.head || !resolveOverlappingChange(transaction, range.head - 1, range.head)) {
-        return null;
-    }
+    return state.selection.ranges.some((range) => {
+        if (resolveTableContextAtPos(state, range.head, TABLE_ENTRY_SYNTAX_TREE_TIMEOUT_MS)) {
+            return true;
+        }
 
-    return {
-        selection: { anchor: Math.min(range.head + 1, state.doc.length) },
-        scrollIntoView: transaction.scrollIntoView,
-    };
+        const line = state.doc.lineAt(range.head);
+        if (!isBlankLineContent(line.text)) {
+            return false;
+        }
+
+        // The line's own break is what separates the table; the caret may sit before it.
+        return Boolean(resolveBoundarySeparatorTable(transaction, line.to, 'forward'));
+    });
 }
 
 const tableBoundaryDeletionFilter = EditorState.transactionFilter.of((transaction) => {
-    const direction = getDeletionDirection(transaction);
-    if (!direction || !transaction.docChanged) {
+    const kind = resolveDeletionKind(transaction);
+    if (!kind || !transaction.docChanged) {
         return transaction;
     }
 
@@ -437,15 +434,18 @@ const tableBoundaryDeletionFilter = EditorState.transactionFilter.of((transactio
         return transaction;
     }
 
+    // A cut is one gesture over whole lines, so it is answered as a whole: dropping it in
+    // part would leave a table half cut. Cancelling keeps every caret where it was, and the
+    // clipboard still holds the lines.
+    if (kind === 'linewiseCut') {
+        return hasUncuttableLine(transaction) ? [] : transaction;
+    }
+
     // Several carets can reach tables in one gesture. A deletion toward a table enters the
     // first in document order and drops the rest because a cell editor holds one caret. An
-    // ordinary away-from-table caret move requires a lone caret; multi-range deletion passes
-    // through. Linewise cut is also stopped when it would remove a trailing table row, since
-    // that hidden structural deletion cannot safely be applied in part.
+    // away-from-table caret move requires a lone caret; multi-range deletion passes through.
     for (const range of transaction.startState.selection.ranges) {
-        const spec =
-            prepareTableBoundaryDeletion(transaction, range, direction) ??
-            prepareTrailingTableLineCutProtection(transaction, range);
+        const spec = prepareTableBoundaryDeletion(transaction, range, kind);
         if (spec) {
             return spec;
         }


### PR DESCRIPTION
## Summary

- treat a native cut with no selection as CodeMirror's linewise `delete.cut`, decided per line rather than per caret — the caret's column has no bearing on what a cut removes
- block a cut only when it would take a table's source line or a blank line the table needs for separation; a line holding text always cuts
- cancel a protected cut whole rather than dropping it per range, so every caret stays where it was
- add regression coverage and update the interaction architecture notes

Known trade-off: CodeMirror writes the clipboard after dispatching, so a blocked cut still copies. Making the two agree needs a DOM-level `cut` handler instead of a transaction filter; not done here.

## Testing

- `npm test`
- `npm run lint`
- `npm run knip`
- `npm run dist`
