### PR TITLE
feat: restore table boundary spacing when text is typed into it

### DIFF
--- a/docs/Architecture/Interaction-and-Navigation.md
+++ b/docs/Architecture/Interaction-and-Navigation.md
@@ -51,6 +51,11 @@ Rules that hold across both halves:
   separator was all it covered; neither consumes the required separation. A newline sitting directly against a table
   edge is protected the same way even when surplus blank lines remain, since removing it would leave the caret parked
   on the widget edge. Surplus blank lines further out are ordinary text and still delete one press at a time.
+- Typing or pasting into that blank line is answered instead of blocked: `tableRuntime/tableBoundaryMaintenance.ts`
+  folds a replacement newline into the same transaction, so the host never sees the unseparated document and one undo
+  takes both back. The decision is made against the post-change document, so a rewrite that already spaced the table -
+  a table paste, or padding for a neighbouring table - cannot pad it twice. Composition (`input.type.compose`) is left
+  alone to keep IME input intact; cell entry normalization repairs that boundary later.
 - Arrow entry requires a lone empty caret in rendered mode with no live cell selection — anything else stays with the
   main editor. Vertical entry also has to recover the table a movement _skipped_, since CodeMirror scans past block
   widgets; see `resolveSkippedTableBlock`.

--- a/docs/Architecture/Table-Runtime-Invariants.md
+++ b/docs/Architecture/Table-Runtime-Invariants.md
@@ -39,6 +39,14 @@ The table runtime behaves like a cross-file state machine. These invariants defi
 - Explicit open requests take priority over generic lifecycle reactions such as close, clear, reposition, or cursor restoration.
 - Lifecycle inference is only a fallback for cases without a command-level destination, such as source-mode exit or undo/redo repositioning.
 
+## Boundary Spacing
+
+- A rendered table keeps `REQUIRED_TABLE_BOUNDARY_BLANK_LINES` blank lines between itself and its neighbouring text.
+- The invariant is enforced at three points: table insertion and paste, cell entry normalization, and boundary
+  maintenance for typed or pasted text. Repairs belong in the transaction that broke it, never in a later dispatch.
+- Deletion protects the separation instead of repairing it, since the caret has somewhere to go.
+- Maintenance decides from the post-change document, so enforcement points cannot stack.
+
 ## Widget Rebuilds
 
 - Decoration policy owns only the table projection decision: keep, map, rebuild, or hide widgets.

--- a/src/contentScript/__tests__/tableBoundaryMaintenance.test.ts
+++ b/src/contentScript/__tests__/tableBoundaryMaintenance.test.ts
@@ -1,0 +1,157 @@
+import { history, redo, undo } from '@codemirror/commands';
+import { EditorState, type Extension, type StateEffect, type Transaction } from '@codemirror/state';
+import { describe, expect, it } from 'vitest';
+import { createMainEditorActiveCellGuard } from '../editorBridge/mainEditorGuard';
+import { activeCellField, setActiveCellEffect } from '../tableState/activeCellState';
+import { cellSelectionField } from '../tableState/cellSelectionState';
+import { insertedTableActivationField } from '../tableState/insertedTableActivation';
+import { searchForceSourceModeField, setSearchForceSourceModeEffect } from '../tableState/searchForceSourceMode';
+import { sourceModeField, toggleSourceModeEffect } from '../tableState/sourceMode';
+import { openCellRequestField } from '../tableRuntime/openCellRequest';
+import { resolvedActiveCellField } from '../tableRuntime/activeCell/resolvedActiveCell';
+import { tableBoundaryMaintenanceExtension } from '../tableRuntime/tableBoundaryMaintenance';
+import { createMarkdownState } from './testMarkdownState';
+
+const TABLE = ['| H1 | H2 |', '| --- | --- |', '| a1 | a2 |'].join('\n');
+
+const runtimeState: Extension[] = [
+    activeCellField,
+    resolvedActiveCellField,
+    cellSelectionField,
+    insertedTableActivationField,
+    searchForceSourceModeField,
+    sourceModeField,
+    openCellRequestField,
+];
+
+function createState(doc: string, options: { effects?: StateEffect<unknown>[] } = {}): EditorState {
+    const state = createMarkdownState(doc, [
+        ...runtimeState,
+        history(),
+        tableBoundaryMaintenanceExtension,
+        // Mirrors production ordering: the guard's paste rewrites run before maintenance
+        // inspects the result.
+        createMainEditorActiveCellGuard(() => false),
+    ]);
+
+    return options.effects?.length ? state.update({ effects: options.effects }).state : state;
+}
+
+/** Applies `text` at `pos` the way the editor reports typed or pasted input. */
+function input(state: EditorState, pos: number, text: string, userEvent = 'input.type'): Transaction {
+    return state.update({
+        changes: { from: pos, insert: text },
+        selection: { anchor: pos + text.length },
+        userEvent,
+    });
+}
+
+/** Offset of the empty line between two blocks of `doc`. */
+function blankLinePos(doc: string, followingText: string): number {
+    return doc.indexOf(followingText) - 1;
+}
+
+describe('table boundary maintenance', () => {
+    it('restores the blank line when text is typed above a table', () => {
+        const doc = `intro\n\n${TABLE}\n`;
+        const transaction = input(createState(doc), blankLinePos(doc, TABLE), 'x');
+
+        expect(transaction.state.doc.toString()).toBe(`intro\nx\n\n${TABLE}\n`);
+    });
+
+    it('restores the blank line when text is typed below a table', () => {
+        const doc = `\n${TABLE}\n\nafter`;
+        const transaction = input(createState(doc), blankLinePos(doc, 'after'), 'x');
+
+        expect(transaction.state.doc.toString()).toBe(`\n${TABLE}\n\nx\nafter`);
+    });
+
+    it('keeps the caret with the typed text', () => {
+        const doc = `intro\n\n${TABLE}\n`;
+        const pos = blankLinePos(doc, TABLE);
+        const transaction = input(createState(doc), pos, 'xy');
+
+        expect(transaction.state.selection.main.head).toBe(pos + 'xy'.length);
+        expect(transaction.state.doc.lineAt(transaction.state.selection.main.head).text).toBe('xy');
+    });
+
+    it('pads both sides when the filled line separates two tables', () => {
+        const doc = `\n${TABLE}\n\n${TABLE}\n`;
+        const transaction = input(createState(doc), doc.lastIndexOf(TABLE) - 1, 'x');
+
+        expect(transaction.state.doc.toString()).toBe(`\n${TABLE}\n\nx\n\n${TABLE}\n`);
+    });
+
+    it('leaves whitespace-only input alone', () => {
+        const doc = `intro\n\n${TABLE}\n`;
+        const transaction = input(createState(doc), blankLinePos(doc, TABLE), '  ');
+
+        expect(transaction.state.doc.toString()).toBe(`intro\n  \n${TABLE}\n`);
+    });
+
+    it('leaves a new line break alone', () => {
+        const doc = `intro\n\n${TABLE}\n`;
+        const transaction = input(createState(doc), blankLinePos(doc, TABLE), '\n');
+
+        expect(transaction.state.doc.toString()).toBe(`intro\n\n\n${TABLE}\n`);
+    });
+
+    it('leaves a blank line that is not the table separator alone', () => {
+        const doc = `intro\n\n\n${TABLE}\n`;
+        const transaction = input(createState(doc), doc.indexOf('\n\n') + 1, 'x');
+
+        expect(transaction.state.doc.toString()).toBe(`intro\nx\n\n${TABLE}\n`);
+    });
+
+    it('leaves typing that reaches no table alone', () => {
+        const doc = `intro\n\nafter`;
+        const transaction = input(createState(doc), blankLinePos(doc, 'after'), 'x');
+
+        expect(transaction.state.doc.toString()).toBe(`intro\nx\nafter`);
+    });
+
+    it.each([
+        { label: 'source mode', effect: toggleSourceModeEffect.of(true) },
+        { label: 'search-forced raw mode', effect: setSearchForceSourceModeEffect.of(true) },
+        {
+            label: 'an active cell',
+            effect: setActiveCellEffect.of({ tableFrom: 7, section: 'header', row: 0, col: 0 }),
+        },
+    ])('leaves the document unchanged in $label', ({ effect }) => {
+        const doc = `intro\n\n${TABLE}\n`;
+        const state = createState(doc, { effects: [effect as StateEffect<unknown>] });
+        const transaction = input(state, blankLinePos(doc, TABLE), 'x');
+
+        expect(transaction.state.doc.toString()).toBe(`intro\nx\n${TABLE}\n`);
+    });
+
+    it('leaves composition input alone', () => {
+        const doc = `intro\n\n${TABLE}\n`;
+        const transaction = input(createState(doc), blankLinePos(doc, TABLE), 'x', 'input.type.compose');
+
+        expect(transaction.state.doc.toString()).toBe(`intro\nx\n${TABLE}\n`);
+    });
+
+    it('takes back the typed text and the padding in one undo', () => {
+        const doc = `intro\n\n${TABLE}\n`;
+        const state = input(createState(doc), blankLinePos(doc, TABLE), 'x').state;
+
+        let undone = state;
+        undo({ state, dispatch: (transaction) => (undone = transaction.state) });
+
+        expect(undone.doc.toString()).toBe(doc);
+
+        let redone = undone;
+        redo({ state: undone, dispatch: (transaction) => (redone = transaction.state) });
+
+        expect(redone.doc.toString()).toBe(`intro\nx\n\n${TABLE}\n`);
+    });
+
+    it('spaces a table pasted onto the separator exactly once', () => {
+        const doc = `intro\n\n${TABLE}\n`;
+        const transaction = input(createState(doc), blankLinePos(doc, TABLE), TABLE, 'input.paste');
+        const text = transaction.state.doc.toString();
+
+        expect(text).toBe(`intro\n\n${TABLE}\n\n${TABLE}\n`);
+    });
+});

--- a/src/contentScript/__tests__/tableBoundaryMaintenance.test.ts
+++ b/src/contentScript/__tests__/tableBoundaryMaintenance.test.ts
@@ -1,5 +1,5 @@
 import { history, redo, undo } from '@codemirror/commands';
-import { EditorState, type Extension, type StateEffect, type Transaction } from '@codemirror/state';
+import { Annotation, EditorState, type Extension, type StateEffect, type Transaction } from '@codemirror/state';
 import { describe, expect, it } from 'vitest';
 import { createMainEditorActiveCellGuard } from '../editorBridge/mainEditorGuard';
 import { activeCellField, setActiveCellEffect } from '../tableState/activeCellState';
@@ -73,6 +73,21 @@ describe('table boundary maintenance', () => {
 
         expect(transaction.state.selection.main.head).toBe(pos + 'xy'.length);
         expect(transaction.state.doc.lineAt(transaction.state.selection.main.head).text).toBe('xy');
+    });
+
+    it('preserves arbitrary annotations when padding the transaction', () => {
+        const inputOrigin = Annotation.define<string>();
+        const doc = `intro\n\n${TABLE}\n`;
+        const pos = blankLinePos(doc, TABLE);
+        const transaction = createState(doc).update({
+            changes: { from: pos, insert: 'x' },
+            selection: { anchor: pos + 1 },
+            annotations: inputOrigin.of('host-input'),
+            userEvent: 'input.type',
+        });
+
+        expect(transaction.annotation(inputOrigin)).toBe('host-input');
+        expect(transaction.state.doc.toString()).toBe(`intro\nx\n\n${TABLE}\n`);
     });
 
     it('pads both sides when the filled line separates two tables', () => {

--- a/src/contentScript/editorBridge/mainEditorGuardPolicy.ts
+++ b/src/contentScript/editorBridge/mainEditorGuardPolicy.ts
@@ -5,7 +5,7 @@ import { rebuildTableWidgetsEffect } from '../tableState/tableWidgetEffects';
 import { sanitizeCellChanges } from './cellTextCodec';
 import { syncAnnotation } from './syncAnnotation';
 import { getResolvedActiveCell, type ResolvedActiveCell } from '../tableRuntime/activeCell/resolvedActiveCell';
-import { isFullDocumentReplace } from '../shared/transactionUtils';
+import { changesOverlapRange, isFullDocumentReplace } from '../shared/transactionUtils';
 import { normalizeBeforeEditAnnotation } from '../tableRuntime/tableCanonicalForm';
 import {
     buildMultiCellPasteRewrite,
@@ -98,19 +98,6 @@ function decidePasteTransaction(tr: Transaction, nestedEditorOpen: boolean): Gua
     }
 
     return nestedEditorOpen ? decideNestedEditorPaste(tr, change.insertedText) : decideRootEditorPaste(tr, change);
-}
-
-function changesOverlapRange(tr: Transaction, from: number, to: number): boolean {
-    let overlaps = false;
-    tr.changes.iterChanges((fromA, toA) => {
-        if (overlaps) {
-            return;
-        }
-        if (fromA < to && toA > from) {
-            overlaps = true;
-        }
-    });
-    return overlaps;
 }
 
 function clearActiveCellDecision(tr: Transaction): GuardDecision {

--- a/src/contentScript/shared/transactionUtils.ts
+++ b/src/contentScript/shared/transactionUtils.ts
@@ -27,3 +27,17 @@ export function isFullDocumentReplace(tr: Transaction): boolean {
 
     return isFullReplace && changeCount === 1;
 }
+
+/** True when any change strictly overlaps `[from, to)`. Touching an endpoint does not count. */
+export function changesOverlapRange(tr: Transaction, from: number, to: number): boolean {
+    let overlaps = false;
+    tr.changes.iterChanges((fromA, toA) => {
+        if (overlaps) {
+            return;
+        }
+        if (fromA < to && toA > from) {
+            overlaps = true;
+        }
+    });
+    return overlaps;
+}

--- a/src/contentScript/tableRuntime/navigation/mainEditorTableEntry.ts
+++ b/src/contentScript/tableRuntime/navigation/mainEditorTableEntry.ts
@@ -7,14 +7,22 @@ import {
     type TransactionSpec,
 } from '@codemirror/state';
 import { BlockType, Direction, keymap, type BlockInfo, type EditorView } from '@codemirror/view';
-import { getActiveCell } from '../../tableState/activeCellState';
-import { fromUnifiedRow, getCellSelection } from '../../tableState/cellSelectionState';
+import { fromUnifiedRow } from '../../tableState/cellSelectionState';
 import { isEffectiveRawMode } from '../../tableState/sourceMode';
 import type { TableContext } from '../../tableModel/tableContext';
 import { prepareCellEntryTransaction } from '../activeCell/cellActivation';
 import { getResolvedActiveCell } from '../activeCell/resolvedActiveCell';
 import { getPendingOpenCellRequest, shouldSuppressNavigationKeys } from '../openCellRequest';
+import { hasPlainRenderedTableCaret } from '../renderedTableCaret';
 import { isBlankLineContent, REQUIRED_TABLE_BOUNDARY_BLANK_LINES } from '../tableBoundarySpacing';
+import {
+    resolveAdjoiningTable,
+    scanNewlinesBackward,
+    scanNewlinesForward,
+    TABLE_LOOKUP_TIMEOUT_MS,
+    type AdjoiningTable,
+    type TableSide,
+} from '../tableBoundaryResolution';
 import { resolveTableContextAtPos } from '../tableResolution';
 import type { CellCoords } from '../../tableModel/types';
 import type { InitialCursorPos } from '../../shared/cursorPlacement';
@@ -22,7 +30,6 @@ import type { InitialCursorPos } from '../../shared/cursorPlacement';
 type DeletionDirection = 'backward' | 'forward';
 /** A native cut with no selection removes whole lines, so it is not a directed deletion. */
 type DeletionKind = DeletionDirection | 'linewiseCut';
-type TableSide = 'before' | 'after';
 type VerticalEntryDirection = 'up' | 'down';
 type HorizontalEntryDirection = 'left' | 'right';
 /** Which end of a grid axis an entry lands on. */
@@ -33,11 +40,6 @@ interface EdgeCellTarget {
     col: GridEdge;
 }
 
-interface BoundaryEntryTarget {
-    ctx: TableContext;
-    side: TableSide;
-}
-
 /** An old-document range a deletion removes, and whether it also inserts. */
 interface DeletedSpan {
     from: number;
@@ -45,33 +47,15 @@ interface DeletedSpan {
     insertsText: boolean;
 }
 
-interface NewlineScan {
-    count: number;
-    edge: number;
-}
-
-// A rendered widget implies that table parsing has already completed. Keyboard
-// entry must never block waiting for syntax work on the keyboard event path.
-const TABLE_ENTRY_SYNTAX_TREE_TIMEOUT_MS = 0;
-
 /**
  * Newlines between a table and its neighbouring text that a deletion may not consume:
  * the required blank lines plus the line break that ends the adjoining line.
  */
 const PROTECTED_BOUNDARY_NEWLINES = REQUIRED_TABLE_BOUNDARY_BLANK_LINES + 1;
 
-function canEnterRenderedTable(state: EditorState): boolean {
-    return (
-        !isEffectiveRawMode(state) &&
-        !getCellSelection(state) &&
-        !getActiveCell(state) &&
-        !getPendingOpenCellRequest(state)
-    );
-}
-
 /** Arrow entry reads one movement target off the main range, so it needs a lone caret. */
 function canEnterFromArrowMovement(state: EditorState): boolean {
-    return canEnterRenderedTable(state) && state.selection.ranges.length === 1 && state.selection.main.empty;
+    return hasPlainRenderedTableCaret(state) && state.selection.ranges.length === 1 && state.selection.main.empty;
 }
 
 function resolveDeletionKind(transaction: Transaction): DeletionKind | null {
@@ -181,47 +165,7 @@ function resolveDeletionTargetTable(
         return null;
     }
 
-    return resolveTableContextAtPos(state, targetPos, TABLE_ENTRY_SYNTAX_TREE_TIMEOUT_MS);
-}
-
-/** Newlines before `pos`, crossing only blank-line whitespace and stopping at `limit`. */
-function scanNewlinesBackward(state: EditorState, pos: number, limit: number): NewlineScan {
-    let cursor = pos;
-    let count = 0;
-    let edge = pos;
-    while (count < limit && cursor > 0) {
-        const character = state.doc.sliceString(cursor - 1, cursor);
-        if (character === '\n') {
-            cursor--;
-            edge = cursor;
-            count++;
-        } else if (isBlankLineContent(character)) {
-            cursor--;
-        } else {
-            break;
-        }
-    }
-    return { count, edge };
-}
-
-/** Newlines after `pos`, crossing only blank-line whitespace and stopping at `limit`. */
-function scanNewlinesForward(state: EditorState, pos: number, limit: number): NewlineScan {
-    let cursor = pos;
-    let count = 0;
-    let edge = pos;
-    while (count < limit && cursor < state.doc.length) {
-        const character = state.doc.sliceString(cursor, cursor + 1);
-        if (character === '\n') {
-            cursor++;
-            edge = cursor;
-            count++;
-        } else if (isBlankLineContent(character)) {
-            cursor++;
-        } else {
-            break;
-        }
-    }
-    return { count, edge };
+    return resolveTableContextAtPos(state, targetPos, TABLE_LOOKUP_TIMEOUT_MS);
 }
 
 /**
@@ -238,31 +182,8 @@ function resolveOverlappingChange(transaction: Transaction, from: number, to: nu
     return overlapping;
 }
 
-/**
- * The table that the newline span `[from, to)` separates from its neighbour, or null.
- *
- * A span between two tables separates both, so the table the deletion moves toward wins.
- */
-function resolveAdjoiningTable(
-    state: EditorState,
-    from: number,
-    to: number,
-    direction: DeletionDirection
-): BoundaryEntryTarget | null {
-    const sides: TableSide[] = direction === 'backward' ? ['before', 'after'] : ['after', 'before'];
-    for (const side of sides) {
-        const boundary = side === 'before' ? from : to;
-        const ctx = resolveTableContextAtPos(state, boundary, TABLE_ENTRY_SYNTAX_TREE_TIMEOUT_MS);
-        if (ctx && (side === 'before' ? ctx.to === boundary : ctx.from === boundary)) {
-            return { ctx, side };
-        }
-    }
-
-    return null;
-}
-
 /** The newlines beside the table edge that a deletion moving away from it must leave in place. */
-function resolveProtectedSeparator(state: EditorState, target: BoundaryEntryTarget): { from: number; to: number } {
+function resolveProtectedSeparator(state: EditorState, target: AdjoiningTable): { from: number; to: number } {
     const { ctx, side } = target;
     return side === 'after'
         ? { from: scanNewlinesBackward(state, ctx.from, PROTECTED_BOUNDARY_NEWLINES).edge, to: ctx.from }
@@ -288,8 +209,10 @@ function resolveBoundarySeparatorTable(
     transaction: Transaction,
     head: number,
     direction: DeletionDirection
-): BoundaryEntryTarget | null {
+): AdjoiningTable | null {
     const state = transaction.startState;
+    // A deletion reaches the table it moves toward first, so that side wins a tie.
+    const preferredSide: TableSide = direction === 'backward' ? 'before' : 'after';
     const deletedFrom = deletedCharOffset(head, direction);
     if (deletedFrom < 0 || deletedFrom >= state.doc.length) {
         return null;
@@ -303,7 +226,7 @@ function resolveBoundarySeparatorTable(
         return null;
     }
 
-    const edgeAdjacent = resolveAdjoiningTable(state, deletedFrom, deletedFrom + 1, direction);
+    const edgeAdjacent = resolveAdjoiningTable(state, deletedFrom, deletedFrom + 1, preferredSide);
     if (edgeAdjacent) {
         return edgeAdjacent;
     }
@@ -315,7 +238,7 @@ function resolveBoundarySeparatorTable(
         return null;
     }
 
-    return resolveAdjoiningTable(state, backward.edge, forward.edge, direction);
+    return resolveAdjoiningTable(state, backward.edge, forward.edge, preferredSide);
 }
 
 /**
@@ -331,7 +254,7 @@ function prepareSeparatorPreservingDeletion(
     transaction: Transaction,
     range: SelectionRange,
     direction: DeletionDirection,
-    target: BoundaryEntryTarget
+    target: AdjoiningTable
 ): TransactionSpec | null {
     const state = transaction.startState;
     // Mapping multiple ranges would be surprising and is not needed for entry.
@@ -405,7 +328,7 @@ function prepareTableBoundaryDeletion(
 function hasUncuttableLine(transaction: Transaction): boolean {
     const state = transaction.startState;
     return state.selection.ranges.some((range) => {
-        if (resolveTableContextAtPos(state, range.head, TABLE_ENTRY_SYNTAX_TREE_TIMEOUT_MS)) {
+        if (resolveTableContextAtPos(state, range.head, TABLE_LOOKUP_TIMEOUT_MS)) {
             return true;
         }
 
@@ -430,7 +353,7 @@ const tableBoundaryDeletionFilter = EditorState.transactionFilter.of((transactio
         return [];
     }
 
-    if (!canEnterRenderedTable(transaction.startState)) {
+    if (!hasPlainRenderedTableCaret(transaction.startState)) {
         return transaction;
     }
 
@@ -513,7 +436,7 @@ function resolveSkippedTableBlock(
         return null;
     }
 
-    return resolveTableContextAtPos(view.state, skippedBlock.from, TABLE_ENTRY_SYNTAX_TREE_TIMEOUT_MS);
+    return resolveTableContextAtPos(view.state, skippedBlock.from, TABLE_LOOKUP_TIMEOUT_MS);
 }
 
 /**
@@ -530,7 +453,7 @@ function resolveVerticalEntryContext(
         return null;
     }
 
-    const directCtx = resolveTableContextAtPos(view.state, targetPos, TABLE_ENTRY_SYNTAX_TREE_TIMEOUT_MS);
+    const directCtx = resolveTableContextAtPos(view.state, targetPos, TABLE_LOOKUP_TIMEOUT_MS);
     if (directCtx && entersTableFromExpectedSide(currentPos, directCtx, direction)) {
         return directCtx;
     }
@@ -590,7 +513,7 @@ function activateTableAtHorizontalTarget(view: EditorView, direction: Horizontal
         return false;
     }
 
-    const ctx = resolveTableContextAtPos(view.state, target.head, TABLE_ENTRY_SYNTAX_TREE_TIMEOUT_MS);
+    const ctx = resolveTableContextAtPos(view.state, target.head, TABLE_LOOKUP_TIMEOUT_MS);
     if (!ctx || (movesForward ? current.head >= ctx.from : current.head <= ctx.to)) {
         return false;
     }

--- a/src/contentScript/tableRuntime/renderedTableCaret.ts
+++ b/src/contentScript/tableRuntime/renderedTableCaret.ts
@@ -1,0 +1,20 @@
+import type { EditorState } from '@codemirror/state';
+import { getActiveCell } from '../tableState/activeCellState';
+import { getCellSelection } from '../tableState/cellSelectionState';
+import { isEffectiveRawMode } from '../tableState/sourceMode';
+import { getPendingOpenCellRequest } from './openCellRequest';
+
+/**
+ * True when the main editor holds a plain caret over rendered tables.
+ *
+ * Raw mode, a cell selection, an active cell, and an in-flight entry request each hand table
+ * editing to another owner, so runtime policies acting on a table's behalf must stand down.
+ */
+export function hasPlainRenderedTableCaret(state: EditorState): boolean {
+    return (
+        !isEffectiveRawMode(state) &&
+        !getCellSelection(state) &&
+        !getActiveCell(state) &&
+        !getPendingOpenCellRequest(state)
+    );
+}

--- a/src/contentScript/tableRuntime/tableBoundaryMaintenance.ts
+++ b/src/contentScript/tableRuntime/tableBoundaryMaintenance.ts
@@ -1,0 +1,184 @@
+import {
+    Annotation,
+    ChangeSet,
+    EditorState,
+    StateEffect,
+    Transaction,
+    type Extension,
+    type Line,
+    type Text,
+    type TransactionSpec,
+} from '@codemirror/state';
+import { syncAnnotation } from '../editorBridge/syncAnnotation';
+import type { TableContext } from '../tableModel/tableContext';
+import { changesOverlapRange } from '../shared/transactionUtils';
+import { normalizeBeforeEditAnnotation } from './tableCanonicalForm';
+import { resolveAdjacentTables } from './tableBoundaryResolution';
+import { hasRequiredBlankLinesAfter, hasRequiredBlankLinesBefore, isBlankLineContent } from './tableBoundarySpacing';
+import { hasPlainRenderedTableCaret } from './renderedTableCaret';
+
+/** A newline inserted into the post-change document to restore a table's separation. */
+interface BoundaryPadding {
+    from: number;
+    insert: string;
+}
+
+const BOUNDARY_PADDING_NEWLINE = '\n';
+
+/**
+ * Transactions this filter inspects: user input that is not already a plugin rewrite.
+ *
+ * Composition is excluded because rewriting the document mid-composition breaks IME and
+ * soft-keyboard input; that boundary is repaired by the next ordinary edit or on cell entry.
+ * Deletions are excluded too - they are protected by `mainEditorTableEntry` instead, and
+ * undo must be able to reach the document as the user last left it.
+ */
+function isBoundaryMaintenanceCandidate(transaction: Transaction): boolean {
+    return (
+        transaction.docChanged &&
+        transaction.isUserEvent('input') &&
+        !transaction.isUserEvent('input.type.compose') &&
+        !transaction.annotation(syncAnnotation) &&
+        !transaction.annotation(normalizeBeforeEditAnnotation) &&
+        hasPlainRenderedTableCaret(transaction.startState)
+    );
+}
+
+function insertsNonWhitespace(inserted: Text): boolean {
+    return inserted.length > 0 && !isBlankLineContent(inserted.toString());
+}
+
+/**
+ * Blank lines this transaction writes text into, in start-state coordinates.
+ *
+ * A table's separation is made of blank lines, so the only way an insertion can consume it
+ * is by putting non-whitespace on one of them. Starting from the touched lines keeps table
+ * resolution - which parses the table it finds - off the common keystroke path.
+ */
+function collectFilledBlankLines(transaction: Transaction): Line[] {
+    const { doc } = transaction.startState;
+    const lines = new Map<number, Line>();
+
+    transaction.changes.iterChanges((fromA, toA, _fromB, _toB, inserted) => {
+        if (!insertsNonWhitespace(inserted)) {
+            return;
+        }
+        for (const pos of fromA === toA ? [fromA] : [fromA, toA]) {
+            const line = doc.lineAt(pos);
+            if (isBlankLineContent(line.text)) {
+                lines.set(line.from, line);
+            }
+        }
+    });
+
+    return [...lines.values()];
+}
+
+/** Tables separated from their neighbour by `line`. A blank line can sit between two. */
+function resolveTablesSeparatedBy(state: EditorState, line: Line): TableContext[] {
+    // The blank line's own breaks are the separation: one ends at its start, one begins at
+    // its end, and a table edge sits directly against them.
+    const { before, after } = resolveAdjacentTables(state, line.from - 1, line.to + 1);
+    return [before, after].filter((ctx): ctx is TableContext => ctx !== null);
+}
+
+/**
+ * Newlines this table needs once the transaction's changes are applied, or none.
+ *
+ * The decision is made against the post-change document rather than the input, so a rewrite
+ * that already spaced the table - a table paste, or this filter's own padding for a
+ * neighbouring table - cannot be padded twice.
+ */
+function resolveBoundaryPadding(transaction: Transaction, ctx: TableContext): BoundaryPadding[] {
+    // An edit reaching into the table's own text is a table edit, not a boundary one.
+    if (changesOverlapRange(transaction, ctx.from, ctx.to)) {
+        return [];
+    }
+
+    const doc = transaction.newDoc;
+    const from = transaction.changes.mapPos(ctx.from, 1);
+    const to = transaction.changes.mapPos(ctx.to, -1);
+    // Text merged onto a table's first or last line needs more than a blank line to undo;
+    // cell entry normalization repairs that shape.
+    if (doc.lineAt(from).from !== from || doc.lineAt(to).to !== to) {
+        return [];
+    }
+
+    const padding: BoundaryPadding[] = [];
+    if (!hasRequiredBlankLinesBefore(doc, from)) {
+        padding.push({ from, insert: BOUNDARY_PADDING_NEWLINE });
+    }
+    if (!hasRequiredBlankLinesAfter(doc, to)) {
+        padding.push({ from: to, insert: BOUNDARY_PADDING_NEWLINE });
+    }
+    return padding;
+}
+
+function collectBoundaryPadding(transaction: Transaction): BoundaryPadding[] {
+    const state = transaction.startState;
+    const tables = new Map<number, TableContext>();
+    for (const line of collectFilledBlankLines(transaction)) {
+        for (const ctx of resolveTablesSeparatedBy(state, line)) {
+            tables.set(ctx.from, ctx);
+        }
+    }
+
+    const padding = [...tables.values()].flatMap((ctx) => resolveBoundaryPadding(transaction, ctx));
+    // `ChangeSet.of` reads a spec list as sequential once it runs backwards, so keep the
+    // insertions in document order.
+    return padding.sort((a, b) => a.from - b.from);
+}
+
+/**
+ * The annotations a rewritten input transaction must keep. A filter cannot copy annotations
+ * wholesale, and dropping these would cost undo grouping and the transaction's origin.
+ */
+function preservedAnnotations(transaction: Transaction): Annotation<unknown>[] {
+    const annotations: Annotation<unknown>[] = [];
+    const userEvent = transaction.annotation(Transaction.userEvent);
+    if (userEvent !== undefined) {
+        annotations.push(Transaction.userEvent.of(userEvent));
+    }
+    const addToHistory = transaction.annotation(Transaction.addToHistory);
+    if (addToHistory !== undefined) {
+        annotations.push(Transaction.addToHistory.of(addToHistory));
+    }
+    const remote = transaction.annotation(Transaction.remote);
+    if (remote !== undefined) {
+        annotations.push(Transaction.remote.of(remote));
+    }
+    return annotations;
+}
+
+function buildPaddedTransaction(transaction: Transaction, padding: BoundaryPadding[]): TransactionSpec {
+    const changes = ChangeSet.of(padding, transaction.newDoc.length);
+    return {
+        changes: transaction.changes.compose(changes),
+        // Padding is always inserted on the far side of a table edge from the text that
+        // was typed, so the caret keeps its place beside that text.
+        selection: transaction.newSelection.map(changes, -1),
+        effects: StateEffect.mapEffects(transaction.effects, changes),
+        scrollIntoView: transaction.scrollIntoView,
+        annotations: preservedAnnotations(transaction),
+    };
+}
+
+/**
+ * Restores the blank line a table needs when typing or pasting fills it in.
+ *
+ * The separation a table keeps from its neighbours is protected against deletion by
+ * `mainEditorTableEntry` and repaired on cell entry by `tableCanonicalForm`; this closes the
+ * remaining hole, where the user writes text into the blank line instead of removing it.
+ * The padding is folded into the same transaction so the host never sees the unseparated
+ * document, and one undo takes both back.
+ */
+const tableBoundaryMaintenanceFilter = EditorState.transactionFilter.of((transaction) => {
+    if (!isBoundaryMaintenanceCandidate(transaction)) {
+        return transaction;
+    }
+
+    const padding = collectBoundaryPadding(transaction);
+    return padding.length ? buildPaddedTransaction(transaction, padding) : transaction;
+});
+
+export const tableBoundaryMaintenanceExtension: Extension = [tableBoundaryMaintenanceFilter];

--- a/src/contentScript/tableRuntime/tableBoundaryMaintenance.ts
+++ b/src/contentScript/tableRuntime/tableBoundaryMaintenance.ts
@@ -29,7 +29,7 @@ const BOUNDARY_PADDING_NEWLINE = '\n';
  * Transactions this filter inspects: user input that is not already a plugin rewrite.
  *
  * Composition is excluded because rewriting the document mid-composition breaks IME and
- * soft-keyboard input; that boundary is repaired by the next ordinary edit or on cell entry.
+ * soft-keyboard input; if composition fills the boundary, cell entry normalization repairs it later.
  * Deletions are excluded too - they are protected by `mainEditorTableEntry` instead, and
  * undo must be able to reach the document as the user last left it.
  */

--- a/src/contentScript/tableRuntime/tableBoundaryMaintenance.ts
+++ b/src/contentScript/tableRuntime/tableBoundaryMaintenance.ts
@@ -1,8 +1,6 @@
 import {
-    Annotation,
     ChangeSet,
     EditorState,
-    StateEffect,
     Transaction,
     type Extension,
     type Line,
@@ -129,38 +127,20 @@ function collectBoundaryPadding(transaction: Transaction): BoundaryPadding[] {
     return padding.sort((a, b) => a.from - b.from);
 }
 
-/**
- * The annotations a rewritten input transaction must keep. A filter cannot copy annotations
- * wholesale, and dropping these would cost undo grouping and the transaction's origin.
- */
-function preservedAnnotations(transaction: Transaction): Annotation<unknown>[] {
-    const annotations: Annotation<unknown>[] = [];
-    const userEvent = transaction.annotation(Transaction.userEvent);
-    if (userEvent !== undefined) {
-        annotations.push(Transaction.userEvent.of(userEvent));
-    }
-    const addToHistory = transaction.annotation(Transaction.addToHistory);
-    if (addToHistory !== undefined) {
-        annotations.push(Transaction.addToHistory.of(addToHistory));
-    }
-    const remote = transaction.annotation(Transaction.remote);
-    if (remote !== undefined) {
-        annotations.push(Transaction.remote.of(remote));
-    }
-    return annotations;
-}
-
-function buildPaddedTransaction(transaction: Transaction, padding: BoundaryPadding[]): TransactionSpec {
+function buildPaddedTransaction(transaction: Transaction, padding: BoundaryPadding[]): readonly TransactionSpec[] {
     const changes = ChangeSet.of(padding, transaction.newDoc.length);
-    return {
-        changes: transaction.changes.compose(changes),
-        // Padding is always inserted on the far side of a table edge from the text that
-        // was typed, so the caret keeps its place beside that text.
-        selection: transaction.newSelection.map(changes, -1),
-        effects: StateEffect.mapEffects(transaction.effects, changes),
-        scrollIntoView: transaction.scrollIntoView,
-        annotations: preservedAnnotations(transaction),
-    };
+    // Keeping the original transaction as the first spec preserves all annotations and lets
+    // CodeMirror map its effects through the sequential padding change.
+    return [
+        transaction,
+        {
+            changes,
+            sequential: true,
+            // Padding is always inserted on the far side of a table edge from the text that
+            // was typed, so the caret keeps its place beside that text.
+            selection: transaction.newSelection.map(changes, -1),
+        },
+    ];
 }
 
 /**

--- a/src/contentScript/tableRuntime/tableBoundaryResolution.ts
+++ b/src/contentScript/tableRuntime/tableBoundaryResolution.ts
@@ -1,0 +1,116 @@
+import type { EditorState } from '@codemirror/state';
+import type { TableContext } from '../tableModel/tableContext';
+import { isBlankLineContent } from './tableBoundarySpacing';
+import { resolveTableContextAtPos } from './tableResolution';
+
+/** Which side of a boundary a table sits on. */
+export type TableSide = 'before' | 'after';
+
+export interface AdjoiningTable {
+    ctx: TableContext;
+    side: TableSide;
+}
+
+export interface AdjacentTables {
+    /** Table ending exactly at the boundary's start. */
+    before: TableContext | null;
+    /** Table starting exactly at the boundary's end. */
+    after: TableContext | null;
+}
+
+export interface NewlineScan {
+    count: number;
+    edge: number;
+}
+
+// A rendered widget implies that table parsing has already completed. Keyboard handling
+// must never block waiting for syntax work on the keyboard event path.
+export const TABLE_LOOKUP_TIMEOUT_MS = 0;
+
+/** Newlines before `pos`, crossing only blank-line whitespace and stopping at `limit`. */
+export function scanNewlinesBackward(state: EditorState, pos: number, limit: number): NewlineScan {
+    let cursor = pos;
+    let count = 0;
+    let edge = pos;
+    while (count < limit && cursor > 0) {
+        const character = state.doc.sliceString(cursor - 1, cursor);
+        if (character === '\n') {
+            cursor--;
+            edge = cursor;
+            count++;
+        } else if (isBlankLineContent(character)) {
+            cursor--;
+        } else {
+            break;
+        }
+    }
+    return { count, edge };
+}
+
+/** Newlines after `pos`, crossing only blank-line whitespace and stopping at `limit`. */
+export function scanNewlinesForward(state: EditorState, pos: number, limit: number): NewlineScan {
+    let cursor = pos;
+    let count = 0;
+    let edge = pos;
+    while (count < limit && cursor < state.doc.length) {
+        const character = state.doc.sliceString(cursor, cursor + 1);
+        if (character === '\n') {
+            cursor++;
+            edge = cursor;
+            count++;
+        } else if (isBlankLineContent(character)) {
+            cursor++;
+        } else {
+            break;
+        }
+    }
+    return { count, edge };
+}
+
+function resolveTableEndingAt(state: EditorState, pos: number): TableContext | null {
+    if (pos < 0 || pos > state.doc.length) {
+        return null;
+    }
+    const ctx = resolveTableContextAtPos(state, pos, TABLE_LOOKUP_TIMEOUT_MS);
+    return ctx && ctx.to === pos ? ctx : null;
+}
+
+function resolveTableStartingAt(state: EditorState, pos: number): TableContext | null {
+    if (pos < 0 || pos > state.doc.length) {
+        return null;
+    }
+    const ctx = resolveTableContextAtPos(state, pos, TABLE_LOOKUP_TIMEOUT_MS);
+    return ctx && ctx.from === pos ? ctx : null;
+}
+
+/**
+ * The table that the span `[from, to)` separates from its neighbour, or null.
+ *
+ * A span between two tables separates both, so `preferred` decides which one wins. Table
+ * resolution parses the table it finds, so the preferred side is probed first and the other
+ * only when it misses.
+ */
+export function resolveAdjoiningTable(
+    state: EditorState,
+    from: number,
+    to: number,
+    preferred: TableSide
+): AdjoiningTable | null {
+    const sides: TableSide[] = preferred === 'before' ? ['before', 'after'] : ['after', 'before'];
+    for (const side of sides) {
+        const ctx = side === 'before' ? resolveTableEndingAt(state, from) : resolveTableStartingAt(state, to);
+        if (ctx) {
+            return { ctx, side };
+        }
+    }
+
+    return null;
+}
+
+/** Both tables the span `[from, to)` separates. A span can sit between two of them. */
+export function resolveAdjacentTables(state: EditorState, from: number, to: number): AdjacentTables {
+    return {
+        before: resolveTableEndingAt(state, from),
+        after: resolveTableStartingAt(state, to),
+    };
+}

--- a/src/contentScript/tableRuntime/tableBoundarySpacing.ts
+++ b/src/contentScript/tableRuntime/tableBoundarySpacing.ts
@@ -1,3 +1,5 @@
+import type { Text } from '@codemirror/state';
+
 export const REQUIRED_TABLE_BOUNDARY_BLANK_LINES = 1;
 
 /** True when text contains only whitespace and can therefore form a blank line. */
@@ -37,4 +39,40 @@ export function countLeadingBlankLinesAfterBoundary(text: string): number {
     }
 
     return blankLineCount;
+}
+
+/**
+ * True when `pos` already has the required blank lines above its line.
+ *
+ * The document start counts as separated: there is no neighbouring text to run into.
+ * Line lookups keep this cheap enough to run on every keystroke, unlike the slice-based
+ * counters above.
+ */
+export function hasRequiredBlankLinesBefore(doc: Text, pos: number): boolean {
+    let lineNumber = doc.lineAt(pos).number;
+    for (let remaining = REQUIRED_TABLE_BOUNDARY_BLANK_LINES; remaining > 0; remaining--) {
+        lineNumber--;
+        if (lineNumber < 1) {
+            return true;
+        }
+        if (!isBlankLineContent(doc.line(lineNumber).text)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+/** True when `pos` already has the required blank lines below its line. */
+export function hasRequiredBlankLinesAfter(doc: Text, pos: number): boolean {
+    let lineNumber = doc.lineAt(pos).number;
+    for (let remaining = REQUIRED_TABLE_BOUNDARY_BLANK_LINES; remaining > 0; remaining--) {
+        lineNumber++;
+        if (lineNumber > doc.lines) {
+            return true;
+        }
+        if (!isBlankLineContent(doc.line(lineNumber).text)) {
+            return false;
+        }
+    }
+    return true;
 }

--- a/src/contentScript/tableWidget/tableWidgetExtension.ts
+++ b/src/contentScript/tableWidget/tableWidgetExtension.ts
@@ -38,6 +38,7 @@ import {
 import { createNoteIdWatcher } from '../tableRuntime/noteIdWatcher';
 import { createUndoScrollPreservation } from '../tableRuntime/undoScrollPreservation';
 import { mainEditorTableEntryExtension } from '../tableRuntime/navigation/mainEditorTableEntry';
+import { tableBoundaryMaintenanceExtension } from '../tableRuntime/tableBoundaryMaintenance';
 import {
     closeOnOutsideMouseDown,
     outsideInteractionCapturePlugin,
@@ -120,6 +121,9 @@ async function registerTableWidgetExtension(
         insertedTableActivationField,
         cellSelectionField,
         mainEditorTableEntryExtension,
+        // Registered ahead of the guard so its paste rewrites are already spaced when
+        // boundary maintenance inspects the result.
+        tableBoundaryMaintenanceExtension,
         createMainEditorActiveCellGuard(() => isNestedEditorOpen(cm6View)),
         openCellRequestKeymap,
         openCellRequestTimeoutPlugin,


### PR DESCRIPTION
Closes the last gap in table boundary protection: deleting the blank line beside a table is blocked, but typing or pasting into it was not, leaving the table unseparated until the next cell entry silently normalized it.

## Changes

- **`tableBoundaryMaintenance.ts`** (new): a transaction filter that folds the replacement newline into the same transaction as the input, so the host never sees the unseparated document and one undo takes both back. Padding is inserted at the table edge, always on the far side of the caret from the typed text, so the caret stays put. The padding is appended as a sequential transaction spec so all annotations from the original input are preserved.
- **Refactor**: newline scanning, adjoining-table resolution, and the rendered-caret predicate move out of `mainEditorTableEntry.ts` into `tableBoundaryResolution.ts` / `renderedTableCaret.ts`; `changesOverlapRange` is shared with the guard policy.

## Notes

- The decision is made against the post-change document, so it cannot stack with the paste rewrite (the guard runs first).
- Composition input (`input.type.compose`) is left alone to keep IME input intact; cell entry normalization repairs that boundary later.
- A range *replacement* spanning the boundary blank line still passes through unpadded, consistent with the existing "an explicit selection is a deliberate range deletion" policy.

## Testing

15 new tests covering both sides, caret placement, annotation preservation, two adjacent tables, whitespace/Enter/non-adjacent-blank no-ops, raw mode + active cell + composition, single-step undo/redo, and a paste double-padding regression. Full suite 784 passing; lint, knip, and `npm run dist` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
