### PR TITLE
fix: mitigate scroll jumps in cells with markdown links

### DIFF
--- a/src/contentScript/__tests__/decorationPlugins.test.ts
+++ b/src/contentScript/__tests__/decorationPlugins.test.ts
@@ -1,0 +1,41 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { EditorState } from '@codemirror/state';
+import { EditorView } from '@codemirror/view';
+import { afterEach, describe, expect, it } from 'vitest';
+import { linkDestinationWrapPlugin } from '../nestedEditor/decorationPlugins';
+import { createNestedEditorMarkdownExtension } from '../nestedEditor/nestedEditorMarkdown';
+import { CLASS_NESTED_EDITOR_URL } from '../shared/tableDomClasses';
+
+let mountedView: EditorView | null = null;
+
+afterEach(() => {
+    mountedView?.destroy();
+    mountedView = null;
+});
+
+describe('nested editor decoration plugins', () => {
+    it('wraps explicit link destinations without marking visible URL text', () => {
+        const parent = document.createElement('div');
+        const doc = [
+            '[label](https://formatted.example/path)',
+            'https://bare.example/path',
+            '<https://autolink.example/path>',
+            '![alt](https://image.example/path)',
+        ].join(' ');
+        mountedView = new EditorView({
+            parent,
+            state: EditorState.create({
+                doc,
+                extensions: [createNestedEditorMarkdownExtension(), linkDestinationWrapPlugin],
+            }),
+        });
+
+        const wrappedText = [...parent.querySelectorAll(`.${CLASS_NESTED_EDITOR_URL}`)].map(
+            (element) => element.textContent
+        );
+        expect(wrappedText).toEqual(['https://formatted.example/path']);
+    });
+});

--- a/src/contentScript/__tests__/decorationPlugins.test.ts
+++ b/src/contentScript/__tests__/decorationPlugins.test.ts
@@ -17,13 +17,14 @@ afterEach(() => {
 });
 
 describe('nested editor decoration plugins', () => {
-    it('wraps explicit link destinations without marking visible URL text', () => {
+    it('wraps link and image destinations without marking visible URL text', () => {
         const parent = document.createElement('div');
         const doc = [
             '[label](https://formatted.example/path)',
             'https://bare.example/path',
             '<https://autolink.example/path>',
             '![alt](https://image.example/path)',
+            '![resource](:/0123456789abcdef0123456789abcdef)',
         ].join(' ');
         mountedView = new EditorView({
             parent,
@@ -36,6 +37,10 @@ describe('nested editor decoration plugins', () => {
         const wrappedText = [...parent.querySelectorAll(`.${CLASS_NESTED_EDITOR_URL}`)].map(
             (element) => element.textContent
         );
-        expect(wrappedText).toEqual(['https://formatted.example/path']);
+        expect(wrappedText).toEqual([
+            'https://formatted.example/path',
+            'https://image.example/path',
+            ':/0123456789abcdef0123456789abcdef',
+        ]);
     });
 });

--- a/src/contentScript/nestedEditor/decorationPlugins.ts
+++ b/src/contentScript/nestedEditor/decorationPlugins.ts
@@ -1,50 +1,63 @@
 import { Decoration, DecorationSet, EditorView, MatchDecorator, ViewPlugin, ViewUpdate } from '@codemirror/view';
 import { syntaxTree } from '@codemirror/language';
 import { Range } from '@codemirror/state';
+import type { SyntaxNodeRef } from '@lezer/common';
+import { CLASS_NESTED_EDITOR_URL } from '../shared/tableDomClasses';
+
+const INLINE_CODE_NODE_NAME = 'InlineCode';
+const LINK_NODE_NAME = 'Link';
+const URL_NODE_NAME = 'URL';
+
+type SyntaxNodePredicate = (node: SyntaxNodeRef) => boolean;
+
+function computeSyntaxMarkDecorations(
+    view: EditorView,
+    className: string,
+    matches: SyntaxNodePredicate
+): DecorationSet {
+    const marks: Range<Decoration>[] = [];
+    const tree = syntaxTree(view.state);
+    for (const { from, to } of view.visibleRanges) {
+        tree.iterate({
+            from,
+            to,
+            enter: (node) => {
+                if (matches(node)) {
+                    marks.push(Decoration.mark({ class: className }).range(node.from, node.to));
+                }
+            },
+        });
+    }
+
+    return Decoration.set(marks);
+}
+
+function createSyntaxMarkPlugin(className: string, matches: SyntaxNodePredicate) {
+    return ViewPlugin.define(
+        (view) => ({
+            decorations: computeSyntaxMarkDecorations(view, className, matches),
+            update(update: ViewUpdate) {
+                if (update.docChanged || update.viewportChanged) {
+                    this.decorations = computeSyntaxMarkDecorations(update.view, className, matches);
+                }
+            },
+        }),
+        {
+            decorations: (plugin) => plugin.decorations,
+        }
+    );
+}
 
 /**
  * Decorates the entire `InlineCode` syntax node (including backticks) with a unified class.
  * allowing for a continuous border/background around the whole segment.
  */
-export const inlineCodePlugin = ViewPlugin.fromClass(
-    class {
-        decorations: DecorationSet;
+export const inlineCodePlugin = createSyntaxMarkPlugin('cm-inline-code', (node) => node.name === INLINE_CODE_NODE_NAME);
 
-        constructor(view: EditorView) {
-            this.decorations = this.computeDecorations(view);
-        }
-
-        update(update: ViewUpdate) {
-            if (update.docChanged || update.viewportChanged) {
-                this.decorations = this.computeDecorations(update.view);
-            }
-        }
-
-        computeDecorations(view: EditorView): DecorationSet {
-            const widgets: Range<Decoration>[] = [];
-            for (const { from, to } of view.visibleRanges) {
-                const tree = syntaxTree(view.state);
-
-                tree.iterate({
-                    from,
-                    to,
-                    enter: (node) => {
-                        if (node.name === 'InlineCode') {
-                            widgets.push(
-                                Decoration.mark({
-                                    class: 'cm-inline-code',
-                                }).range(node.from, node.to)
-                            );
-                        }
-                    },
-                });
-            }
-            return Decoration.set(widgets);
-        }
-    },
-    {
-        decorations: (v) => v.decorations,
-    }
+/** Aggressively wraps only destinations in `[label](destination)` links. */
+export const linkDestinationWrapPlugin = createSyntaxMarkPlugin(
+    CLASS_NESTED_EDITOR_URL,
+    (node) => node.name === URL_NODE_NAME && node.node.parent?.name === LINK_NODE_NAME
 );
 
 /**

--- a/src/contentScript/nestedEditor/decorationPlugins.ts
+++ b/src/contentScript/nestedEditor/decorationPlugins.ts
@@ -6,6 +6,7 @@ import { CLASS_NESTED_EDITOR_URL } from '../shared/tableDomClasses';
 
 const INLINE_CODE_NODE_NAME = 'InlineCode';
 const LINK_NODE_NAME = 'Link';
+const IMAGE_NODE_NAME = 'Image';
 const URL_NODE_NAME = 'URL';
 
 type SyntaxNodePredicate = (node: SyntaxNodeRef) => boolean;
@@ -61,15 +62,19 @@ function createSyntaxMarkPlugin(className: string, matches: SyntaxNodePredicate)
  */
 export const inlineCodePlugin = createSyntaxMarkPlugin('cm-inline-code', (node) => node.name === INLINE_CODE_NODE_NAME);
 
+const WRAPPED_DESTINATION_PARENTS = new Set([LINK_NODE_NAME, IMAGE_NODE_NAME]);
+
 /**
- * Marks only the destinations in `[label](destination)` links, so the theme rule for
- * `CLASS_NESTED_EDITOR_URL` in `nestedEditorTheme.ts` can wrap them aggressively.
- * That `overflow-wrap: anywhere` rule is the actual fix; this plugin only tags the ranges.
+ * Marks only the destinations in `[label](destination)` links and `![alt](destination)`
+ * images, so the theme rule for `CLASS_NESTED_EDITOR_URL` in `nestedEditorTheme.ts` can wrap
+ * them aggressively. That `overflow-wrap: anywhere` rule is the actual fix; this plugin only
+ * tags the ranges. Bare URLs are excluded: they render in full, so the rendered cell already
+ * reserves their width.
  */
-export const linkDestinationWrapPlugin = createSyntaxMarkPlugin(
-    CLASS_NESTED_EDITOR_URL,
-    (node) => node.name === URL_NODE_NAME && node.node.parent?.name === LINK_NODE_NAME
-);
+export const linkDestinationWrapPlugin = createSyntaxMarkPlugin(CLASS_NESTED_EDITOR_URL, (node) => {
+    const parentName = node.node.parent?.name;
+    return node.name === URL_NODE_NAME && parentName !== undefined && WRAPPED_DESTINATION_PARENTS.has(parentName);
+});
 
 /**
  * Decorates `==mark==` syntax with a highlight class.

--- a/src/contentScript/nestedEditor/decorationPlugins.ts
+++ b/src/contentScript/nestedEditor/decorationPlugins.ts
@@ -67,8 +67,7 @@ const WRAPPED_DESTINATION_PARENTS = new Set([LINK_NODE_NAME, IMAGE_NODE_NAME]);
 /**
  * Marks only the destinations in `[label](destination)` links and `![alt](destination)`
  * images, so the theme rule for `CLASS_NESTED_EDITOR_URL` in `nestedEditorTheme.ts` can wrap
- * them aggressively. That `overflow-wrap: anywhere` rule is the actual fix; this plugin only
- * tags the ranges. Bare URLs are excluded: they render in full, so the rendered cell already
+ * them aggressively. Bare URLs are excluded: they render in full, so the rendered cell already
  * reserves their width.
  */
 export const linkDestinationWrapPlugin = createSyntaxMarkPlugin(CLASS_NESTED_EDITOR_URL, (node) => {

--- a/src/contentScript/nestedEditor/decorationPlugins.ts
+++ b/src/contentScript/nestedEditor/decorationPlugins.ts
@@ -32,6 +32,13 @@ function computeSyntaxMarkDecorations(
     return Decoration.set(marks);
 }
 
+/**
+ * Builds a ViewPlugin that marks every syntax node matching `matches` with `className`.
+ *
+ * Decorations are only recomputed on doc/viewport changes, not on late parse completion.
+ * That is safe because `nestedEditorController` warms the parse tree with `ensureSyntaxTree`
+ * before mounting the view, so the first computation already sees a complete tree.
+ */
 function createSyntaxMarkPlugin(className: string, matches: SyntaxNodePredicate) {
     return ViewPlugin.define(
         (view) => ({
@@ -54,7 +61,11 @@ function createSyntaxMarkPlugin(className: string, matches: SyntaxNodePredicate)
  */
 export const inlineCodePlugin = createSyntaxMarkPlugin('cm-inline-code', (node) => node.name === INLINE_CODE_NODE_NAME);
 
-/** Aggressively wraps only destinations in `[label](destination)` links. */
+/**
+ * Marks only the destinations in `[label](destination)` links, so the theme rule for
+ * `CLASS_NESTED_EDITOR_URL` in `nestedEditorTheme.ts` can wrap them aggressively.
+ * That `overflow-wrap: anywhere` rule is the actual fix; this plugin only tags the ranges.
+ */
 export const linkDestinationWrapPlugin = createSyntaxMarkPlugin(
     CLASS_NESTED_EDITOR_URL,
     (node) => node.name === URL_NODE_NAME && node.node.parent?.name === LINK_NODE_NAME

--- a/src/contentScript/nestedEditor/nestedEditorController.ts
+++ b/src/contentScript/nestedEditor/nestedEditorController.ts
@@ -1,7 +1,7 @@
 import { ensureSyntaxTree } from '@codemirror/language';
 import { EditorSelection, EditorState, Transaction, type Extension } from '@codemirror/state';
 import { drawSelection, EditorView, ViewPlugin, ViewUpdate } from '@codemirror/view';
-import { inlineCodePlugin, insertPlugin, markPlugin } from './decorationPlugins';
+import { inlineCodePlugin, insertPlugin, linkDestinationWrapPlugin, markPlugin } from './decorationPlugins';
 import { createNestedEditorDomHandlers, createNestedEditorKeymap, mirrorLocalSelectionToMain } from './domHandlers';
 import { createJoplinSyntaxHighlighting } from './joplinHighlightStyle';
 import { createNestedEditorMarkdownExtension } from './nestedEditorMarkdown';
@@ -148,6 +148,7 @@ class NestedEditorController {
                 }),
                 createNestedEditorMarkdownExtension(),
                 inlineCodePlugin,
+                linkDestinationWrapPlugin,
                 markPlugin,
                 insertPlugin,
                 createJoplinSyntaxHighlighting(isDarkTheme),

--- a/src/contentScript/nestedEditor/nestedEditorTheme.ts
+++ b/src/contentScript/nestedEditor/nestedEditorTheme.ts
@@ -1,5 +1,6 @@
 import { EditorView } from '@codemirror/view';
 import { Extension } from '@codemirror/state';
+import { CLASS_NESTED_EDITOR_URL } from '../shared/tableDomClasses';
 
 /**
  * Creates a theme for the nested cell editor that adapts to light/dark mode.
@@ -57,6 +58,12 @@ export function createNestedEditorTheme(isDarkTheme: boolean): Extension {
         '.cm-inserted': {
             textDecoration: 'underline',
             textDecorationStyle: 'solid',
+        },
+        [`.${CLASS_NESTED_EDITOR_URL}`]: {
+            // URL source can be substantially wider than its rendered link label. Allowing
+            // breaks at any character keeps it from increasing the table's intrinsic width.
+            overflowWrap: 'anywhere',
+            wordBreak: 'normal',
         },
     });
 }

--- a/src/contentScript/nestedEditor/nestedEditorTheme.ts
+++ b/src/contentScript/nestedEditor/nestedEditorTheme.ts
@@ -63,7 +63,6 @@ export function createNestedEditorTheme(isDarkTheme: boolean): Extension {
             // URL source can be substantially wider than its rendered link label. Allowing
             // breaks at any character keeps it from increasing the table's intrinsic width.
             overflowWrap: 'anywhere',
-            wordBreak: 'normal',
         },
     });
 }

--- a/src/contentScript/shared/tableDomClasses.ts
+++ b/src/contentScript/shared/tableDomClasses.ts
@@ -2,3 +2,4 @@ export const CLASS_CELL_ACTIVE = 'cm-table-cell-active';
 export const CLASS_CELL_CONTENT = 'cm-table-cell-content';
 export const CLASS_CELL_EDITOR = 'cm-table-cell-editor';
 export const CLASS_CELL_EDITOR_HIDDEN = 'cm-table-cell-editor-hidden';
+export const CLASS_NESTED_EDITOR_URL = 'cm-nested-editor-url';


### PR DESCRIPTION
Enhance table layout stability by implementing aggressive wrapping for markdown links in the cell editor. This change reduces scroll jumps when activating or deactivating cells with links, while also addressing markdown image embeds.

Normal word wrapping behavior is maintained outside of links.