### PR TITLE
fix: scroll the page during a cell drag where the editor does not

### DIFF
--- a/docs/Architecture/Interaction-and-Navigation.md
+++ b/docs/Architecture/Interaction-and-Navigation.md
@@ -80,7 +80,8 @@ Commands that move the main-editor caret outside the selected table clear the se
 - Clicking a cell activates it or updates the current multi-cell selection.
 - Dragging from one cell to another with a desktop mouse creates a rectangular selection. A movement threshold keeps
   ordinary clicks distinct from drags. Touch and pen pointers retain native scrolling/tap behaviour and do not start
-  drag selection. Holding a cell drag near an edge auto-scrolls the table horizontally or the editor vertically;
+  drag selection. Holding a cell drag near an edge auto-scrolls the table horizontally, and vertically scrolls the
+  editor where it scrolls internally or the page where it does not (the web app);
   releasing a drag back over its anchor opens that cell's editor. A completed rectangular selection focuses the main
   editor on release so its keyboard and clipboard commands work even when focus started outside the editor.
 - Once a gesture becomes a rectangular selection it records itself in `cellDragField` until release. See

--- a/docs/Architecture/Interaction-and-Navigation.md
+++ b/docs/Architecture/Interaction-and-Navigation.md
@@ -80,9 +80,9 @@ Commands that move the main-editor caret outside the selected table clear the se
 - Clicking a cell activates it or updates the current multi-cell selection.
 - Dragging from one cell to another with a desktop mouse creates a rectangular selection. A movement threshold keeps
   ordinary clicks distinct from drags. Touch and pen pointers retain native scrolling/tap behaviour and do not start
-  drag selection. Holding a cell drag near an edge auto-scrolls the table horizontally, and vertically scrolls the
-  editor where it scrolls internally or the page where it does not (the web app);
-  releasing a drag back over its anchor opens that cell's editor. A completed rectangular selection focuses the main
+  drag selection. Holding a cell drag near an edge auto-scrolls the table horizontally and whichever element owns
+  vertical scrolling vertically — see [Table-Display.md](./Table-Display.md#host-scroll-modes).
+  Releasing a drag back over its anchor opens that cell's editor. A completed rectangular selection focuses the main
   editor on release so its keyboard and clipboard commands work even when focus started outside the editor.
 - Once a gesture becomes a rectangular selection it records itself in `cellDragField` until release. See
   [Table-Runtime-Invariants.md](./Table-Runtime-Invariants.md#cell-drag-ownership) for what that ownership means; the

--- a/docs/Architecture/Table-Display.md
+++ b/docs/Architecture/Table-Display.md
@@ -89,3 +89,19 @@ See [ADR-004](../ADR/004-global-source-mode.md) for the rationale behind global 
 ### Search Override
 
 `Ctrl+F` forces raw Markdown mode so native search highlighting works on hidden table text.
+
+## Host Scroll Modes
+
+Joplin hosts the editor two ways, and internal and external scrolling are mutually exclusive:
+
+- **Desktop** pins CodeMirror to a fixed-height container, so `scrollDOM` scrolls internally.
+- **Mobile and web** leave the editor's height unconstrained, so `scrollDOM` grows to the whole document and the
+  document root scrolls instead.
+
+`shared/editorViewport.ts` resolves both cases without a mode flag. `resolveViewportBounds` intersects the scroller
+rect with the window: a scroller that already sits inside the window survives unchanged, and one that spans the
+document is clipped back to the window. The floating toolbar uses those bounds to decide visibility and placement;
+cell-drag auto-scroll uses them for its edge zones and for clamping its hit test.
+
+Auto-scroll picks its scroll target from the same distinction, testing whether `scrollDOM` has any overflow to move
+and falling back to `document.scrollingElement` when it does not.

--- a/src/contentScript/__tests__/editorViewport.test.ts
+++ b/src/contentScript/__tests__/editorViewport.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { getViewportHeight, getViewportWidth, resolveViewportBounds } from '../shared/editorViewport';
+
+describe('resolveViewportBounds', () => {
+    it('keeps the scroller rect when the editor scrolls internally', () => {
+        // Desktop pins the editor to a fixed-height container, so the scroller already sits
+        // inside the window and the intersection leaves it untouched.
+        const bounds = resolveViewportBounds({ top: 40, bottom: 640 }, 1000);
+
+        expect(bounds).toEqual({ top: 40, bottom: 640, height: 600 });
+    });
+
+    it('falls back to the window when the scroller spans the whole document', () => {
+        // Mobile and web leave the editor's height unconstrained, so the scroller runs past
+        // both window edges and the window is the only limit left.
+        const bounds = resolveViewportBounds({ top: -200, bottom: 1400 }, 800);
+
+        expect(bounds).toEqual({ top: 0, bottom: 800, height: 800 });
+    });
+
+    it('clips to whichever edge is tighter on each side', () => {
+        const bounds = resolveViewportBounds({ top: -50, bottom: 300 }, 800);
+
+        expect(bounds).toEqual({ top: 0, bottom: 300, height: 300 });
+    });
+
+    it('reports a non-positive height once the scroller leaves the window', () => {
+        const bounds = resolveViewportBounds({ top: 900, bottom: 1200 }, 800);
+
+        expect(bounds.bottom).toBeLessThanOrEqual(bounds.top);
+    });
+});
+
+describe('getViewportHeight', () => {
+    it('prefers the visual viewport, which shrinks with an on-screen keyboard', () => {
+        expect(getViewportHeight({ visualViewport: { height: 420 }, innerHeight: 800 } as Window)).toBe(420);
+    });
+
+    it('falls back to the window where no visual viewport is exposed', () => {
+        expect(getViewportHeight({ innerHeight: 800 } as Window)).toBe(800);
+    });
+});
+
+describe('getViewportWidth', () => {
+    it('prefers the visual viewport', () => {
+        expect(getViewportWidth({ visualViewport: { width: 320 }, innerWidth: 600 } as Window)).toBe(320);
+    });
+
+    it('falls back to the window where no visual viewport is exposed', () => {
+        expect(getViewportWidth({ innerWidth: 600 } as Window)).toBe(600);
+    });
+});

--- a/src/contentScript/__tests__/mouseCellDragSelection.test.ts
+++ b/src/contentScript/__tests__/mouseCellDragSelection.test.ts
@@ -152,6 +152,20 @@ function setScrollDimensions(
     }
 }
 
+/** Makes the page itself the scroller, the way the web app's external scrolling behaves. */
+function makePageScroller(dimensions: { clientHeight: number; scrollHeight: number }): HTMLElement {
+    const page = document.documentElement;
+    setScrollDimensions(page, dimensions);
+    Object.defineProperty(page, 'scrollTop', { configurable: true, writable: true, value: 0 });
+    return page;
+}
+
+function resetPageScroller(): void {
+    for (const property of ['clientHeight', 'scrollHeight', 'scrollTop']) {
+        Reflect.deleteProperty(document.documentElement, property);
+    }
+}
+
 function mockAnimationFrames(): {
     cancelSpy: ReturnType<typeof vi.spyOn>;
     pendingCount: () => number;
@@ -205,6 +219,7 @@ beforeEach(() => {
 
 afterEach(() => {
     elementAtPoint = null;
+    resetPageScroller();
     while (mountedViews.length > 0) {
         mountedViews.pop()?.destroy();
     }
@@ -529,6 +544,63 @@ describe('mouse cell drag selection', () => {
                 clientY: 95,
             })
         );
+    });
+
+    it('scrolls the page when the editor does not scroll internally', () => {
+        const { view, widget, table, cells } = mountGestureView();
+        const frames = mockAnimationFrames();
+        // The web app grows scrollDOM to the whole document and scrolls the page around it.
+        vi.stubGlobal('innerHeight', 100);
+        const page = makePageScroller({ clientHeight: 100, scrollHeight: 300 });
+        setScrollDimensions(widget, { clientWidth: 100, scrollWidth: 100 });
+        setScrollDimensions(view.scrollDOM, { clientHeight: 300, scrollHeight: 300 });
+        vi.spyOn(widget, 'getBoundingClientRect').mockReturnValue(makeRect(0, 0, 100, 300));
+        vi.spyOn(table, 'getBoundingClientRect').mockReturnValue(makeRect(0, 0, 100, 300));
+        vi.spyOn(view.scrollDOM, 'getBoundingClientRect').mockReturnValue(makeRect(0, 0, 100, 300));
+
+        cells.header0.dispatchEvent(pointerEvent('pointerdown', { button: 0, clientX: 50, clientY: 10 }));
+        elementAtPoint = cells.body1;
+        document.dispatchEvent(pointerEvent('pointermove', { button: 0, clientX: 50, clientY: 95 }));
+
+        frames.runNext(16);
+
+        expect(page.scrollTop).toBeGreaterThan(0);
+        expect(view.scrollDOM.scrollTop).toBe(0);
+
+        document.dispatchEvent(pointerEvent('pointerup', { button: 0, clientX: 50, clientY: 95 }));
+    });
+
+    it('clamps the hit test to the window when the page is the scroller', () => {
+        const { view, widget, table, cells } = mountGestureView();
+        mockAnimationFrames();
+        vi.stubGlobal('innerHeight', 100);
+        makePageScroller({ clientHeight: 100, scrollHeight: 300 });
+        setScrollDimensions(widget, { clientWidth: 100, scrollWidth: 100 });
+        setScrollDimensions(view.scrollDOM, { clientHeight: 300, scrollHeight: 300 });
+        vi.spyOn(widget, 'getBoundingClientRect').mockReturnValue(makeRect(0, 0, 100, 300));
+        vi.spyOn(table, 'getBoundingClientRect').mockReturnValue(makeRect(0, 0, 100, 300));
+        vi.spyOn(view.scrollDOM, 'getBoundingClientRect').mockReturnValue(makeRect(0, 0, 100, 300));
+        // Only cells inside the window can be hit-tested; below it the browser returns nothing.
+        Object.defineProperty(document, 'elementFromPoint', {
+            configurable: true,
+            value: vi.fn((_x: number, y: number) => {
+                if (y <= 30) {
+                    return cells.header1;
+                }
+                return y <= 100 ? cells.body1 : null;
+            }),
+        });
+
+        cells.header0.dispatchEvent(pointerEvent('pointerdown', { button: 0, clientX: 50, clientY: 10 }));
+        document.dispatchEvent(pointerEvent('pointermove', { button: 0, clientX: 50, clientY: 20 }));
+        expect(getCellSelection(view.state)?.focus).toEqual({ section: 'header', row: 0, col: 1 });
+
+        // Below the window: the clamped hit test must land on the last row still on screen,
+        // not on a point inside the off-screen part of scrollDOM.
+        document.dispatchEvent(pointerEvent('pointermove', { button: 0, clientX: 50, clientY: 250 }));
+
+        expect(getCellSelection(view.state)?.focus).toEqual({ section: 'body', row: 0, col: 1 });
+        document.dispatchEvent(pointerEvent('pointerup', { button: 0, clientX: 50, clientY: 250 }));
     });
 
     it('tracks the nearest cell when the pointer drags past a fully visible table', () => {

--- a/src/contentScript/__tests__/toolbarPositioning.test.ts
+++ b/src/contentScript/__tests__/toolbarPositioning.test.ts
@@ -6,32 +6,17 @@ import {
     isObscuringTopPlacement,
     isTableOutsideViewport,
     resolveToolbarPlacementMode,
-    resolveViewportBounds,
     shouldPinAbove,
     TOOLBAR_VIEWPORT_PADDING_PX,
     type ToolbarRect,
-    type ViewportBounds,
 } from '../toolbar/toolbarPositioning';
+import type { ViewportBounds } from '../shared/editorViewport';
 
 function rect(partial: Partial<ToolbarRect>): ToolbarRect {
     return { top: 0, bottom: 0, left: 0, width: 0, height: 0, ...partial };
 }
 
 const TOOLBAR_HEIGHT = 30;
-
-describe('resolveViewportBounds', () => {
-    it('uses the scroller rect when the editor scrolls internally', () => {
-        const bounds = resolveViewportBounds(true, rect({ top: 40, bottom: 640, height: 600 }), 1000);
-
-        expect(bounds).toEqual({ top: 40, bottom: 640, height: 600 });
-    });
-
-    it('anchors to the page top when the surrounding view scrolls', () => {
-        const bounds = resolveViewportBounds(false, rect({ top: -200, bottom: 400, height: 600 }), 800);
-
-        expect(bounds).toEqual({ top: 0, bottom: 800, height: 800 });
-    });
-});
 
 describe('isTableOutsideViewport', () => {
     const viewport: ViewportBounds = { top: 100, bottom: 500, height: 400 };

--- a/src/contentScript/shared/editorViewport.ts
+++ b/src/contentScript/shared/editorViewport.ts
@@ -1,0 +1,35 @@
+/** Vertical bounds of the band the reader can actually see, in client coordinates. */
+export interface ViewportBounds {
+    top: number;
+    bottom: number;
+    height: number;
+}
+
+/** Height of the area the editor's window shows, allowing for a shrunken visual viewport. */
+export function getViewportHeight(viewWindow: Window): number {
+    return viewWindow.visualViewport?.height ?? viewWindow.innerHeight;
+}
+
+/** Width of the area the editor's window shows, allowing for a shrunken visual viewport. */
+export function getViewportWidth(viewWindow: Window): number {
+    return viewWindow.visualViewport?.width ?? viewWindow.innerWidth;
+}
+
+/**
+ * Intersects the editor's scroller with the window to leave the visible band.
+ *
+ * CodeMirror scrolls internally only where something constrains its height, as the desktop app
+ * does by pinning the editor to a fixed-height container. Where nothing does — Joplin mobile and
+ * web, whose editor document has no height constraint at all — `scrollDOM` grows to the whole
+ * document and the window is the only limit. Intersecting covers both: a scroller that already
+ * sits inside the window survives the intersection unchanged.
+ */
+export function resolveViewportBounds(
+    scrollRect: { top: number; bottom: number },
+    viewportHeight: number
+): ViewportBounds {
+    const top = Math.max(scrollRect.top, 0);
+    const bottom = Math.min(scrollRect.bottom, viewportHeight);
+
+    return { top, bottom, height: bottom - top };
+}

--- a/src/contentScript/tableRuntime/interaction/mouseCellDragAutoScroll.ts
+++ b/src/contentScript/tableRuntime/interaction/mouseCellDragAutoScroll.ts
@@ -1,5 +1,6 @@
 import type { EditorView } from '@codemirror/view';
 import { getViewWindow, requestViewAnimationFrame } from '../../shared/domContext';
+import { getViewportHeight, resolveViewportBounds } from '../../shared/editorViewport';
 import { clamp } from '../../shared/numberUtils';
 
 const EDGE_SCROLL_ZONE_PX = 48;
@@ -9,6 +10,8 @@ const EDGE_SCROLL_MAX_FRAME_MS = 50;
 // A zero-length frame would produce a zero delta, which the loop cannot tell apart
 // from having reached a scroll boundary.
 const EDGE_SCROLL_MIN_FRAME_MS = 1;
+// Subpixel layout can leave scrollHeight a hair above clientHeight with nothing to scroll.
+const INTERNAL_SCROLL_TOLERANCE_PX = 1;
 
 export interface AutoScrollContext {
     /** The table widget: the horizontal scroller, and the range the pointer's X is measured against. */
@@ -22,27 +25,20 @@ export interface AutoScrollContext {
 }
 
 /**
- * Vertical bounds of the band a drag scrolls toward, in client coordinates.
+ * The element a vertical drag scroll has to move.
  *
- * CodeMirror scrolls internally on desktop, but the web app scrolls the page instead and lets
- * `scrollDOM` grow to the full document height. Intersecting the two leaves the visible band
- * either way: the desktop scroller already sits inside the window, so this returns its rect.
+ * Internal and external scrolling are mutually exclusive: `scrollDOM` scrolls only where
+ * something constrains the editor's height, and where nothing does it grows to the whole
+ * document and the document root scrolls instead. Exactly one of the two can move.
  */
-export function resolveVerticalScrollBounds(view: EditorView): { top: number; bottom: number } {
-    const scrollRect = view.scrollDOM.getBoundingClientRect();
-    const viewWindow = getViewWindow(view);
-    const viewportHeight = viewWindow.visualViewport?.height ?? viewWindow.innerHeight;
+function getVerticalScroller(view: EditorView): HTMLElement {
+    const scrollDOM = view.scrollDOM;
+    if (scrollDOM.scrollHeight > scrollDOM.clientHeight + INTERNAL_SCROLL_TOLERANCE_PX) {
+        return scrollDOM;
+    }
 
-    return {
-        top: Math.max(scrollRect.top, 0),
-        bottom: Math.min(scrollRect.bottom, viewportHeight),
-    };
-}
-
-/** The element that scrolls the page when the editor does not scroll internally. */
-function getPageScroller(view: EditorView): HTMLElement | null {
     const doc = view.dom.ownerDocument;
-    return (doc.scrollingElement ?? doc.documentElement) as HTMLElement | null;
+    return (doc.scrollingElement as HTMLElement | null) ?? doc.documentElement;
 }
 
 /**
@@ -125,7 +121,10 @@ export class CellDragAutoScroller {
         const pointer = context.pointer();
         const widgetRect = context.widget.getBoundingClientRect();
         const tableRect = context.table.getBoundingClientRect();
-        const verticalBounds = resolveVerticalScrollBounds(this.view);
+        const verticalBounds = resolveViewportBounds(
+            this.view.scrollDOM.getBoundingClientRect(),
+            getViewportHeight(getViewWindow(this.view))
+        );
 
         const horizontalIntensity = calculateEdgeScrollIntensity(
             pointer.x,
@@ -153,15 +152,15 @@ export class CellDragAutoScroller {
         this.lastTimestamp = timestamp;
         const maxDelta = (EDGE_SCROLL_MAX_SPEED_PX_PER_SECOND * elapsedMs) / 1000;
 
-        // The widget is the table's horizontal scroller. Vertically the editor's own scroller
-        // wins where it can move, and the page takes over where it cannot — which is every
-        // frame in the web app, whose editor does not scroll internally at all.
-        const verticalDelta = verticalIntensity * maxDelta;
-        const pageScroller = getPageScroller(this.view);
+        // The widget is the table's horizontal scroller; whichever element owns vertical
+        // scrolling is the vertical one. If either has nothing left to move, that axis
+        // simply reports no movement.
         const didScrollHorizontally = applyScrollDelta(context.widget, 'horizontal', horizontalIntensity * maxDelta);
-        const didScrollVertically =
-            applyScrollDelta(this.view.scrollDOM, 'vertical', verticalDelta) ||
-            (pageScroller !== null && applyScrollDelta(pageScroller, 'vertical', verticalDelta));
+        const didScrollVertically = applyScrollDelta(
+            getVerticalScroller(this.view),
+            'vertical',
+            verticalIntensity * maxDelta
+        );
         if (!didScrollHorizontally && !didScrollVertically) {
             this.lastTimestamp = null;
             return;

--- a/src/contentScript/tableRuntime/interaction/mouseCellDragAutoScroll.ts
+++ b/src/contentScript/tableRuntime/interaction/mouseCellDragAutoScroll.ts
@@ -22,6 +22,30 @@ export interface AutoScrollContext {
 }
 
 /**
+ * Vertical bounds of the band a drag scrolls toward, in client coordinates.
+ *
+ * CodeMirror scrolls internally on desktop, but the web app scrolls the page instead and lets
+ * `scrollDOM` grow to the full document height. Intersecting the two leaves the visible band
+ * either way: the desktop scroller already sits inside the window, so this returns its rect.
+ */
+export function resolveVerticalScrollBounds(view: EditorView): { top: number; bottom: number } {
+    const scrollRect = view.scrollDOM.getBoundingClientRect();
+    const viewWindow = getViewWindow(view);
+    const viewportHeight = viewWindow.visualViewport?.height ?? viewWindow.innerHeight;
+
+    return {
+        top: Math.max(scrollRect.top, 0),
+        bottom: Math.min(scrollRect.bottom, viewportHeight),
+    };
+}
+
+/** The element that scrolls the page when the editor does not scroll internally. */
+function getPageScroller(view: EditorView): HTMLElement | null {
+    const doc = view.dom.ownerDocument;
+    return (doc.scrollingElement ?? doc.documentElement) as HTMLElement | null;
+}
+
+/**
  * Returns edge-scroll intensity from -1 (toward the start edge) to 1 (toward
  * the end edge). Positions outside the range stay at full intensity.
  */
@@ -101,7 +125,7 @@ export class CellDragAutoScroller {
         const pointer = context.pointer();
         const widgetRect = context.widget.getBoundingClientRect();
         const tableRect = context.table.getBoundingClientRect();
-        const scrollRect = this.view.scrollDOM.getBoundingClientRect();
+        const verticalBounds = resolveVerticalScrollBounds(this.view);
 
         const horizontalIntensity = calculateEdgeScrollIntensity(
             pointer.x,
@@ -111,13 +135,13 @@ export class CellDragAutoScroller {
         );
         let verticalIntensity = calculateEdgeScrollIntensity(
             pointer.y,
-            scrollRect.top,
-            scrollRect.bottom,
+            verticalBounds.top,
+            verticalBounds.bottom,
             EDGE_SCROLL_ZONE_PX
         );
         if (
-            (verticalIntensity < 0 && tableRect.top >= scrollRect.top) ||
-            (verticalIntensity > 0 && tableRect.bottom <= scrollRect.bottom)
+            (verticalIntensity < 0 && tableRect.top >= verticalBounds.top) ||
+            (verticalIntensity > 0 && tableRect.bottom <= verticalBounds.bottom)
         ) {
             verticalIntensity = 0;
         }
@@ -129,10 +153,15 @@ export class CellDragAutoScroller {
         this.lastTimestamp = timestamp;
         const maxDelta = (EDGE_SCROLL_MAX_SPEED_PX_PER_SECOND * elapsedMs) / 1000;
 
-        // The widget is the table's horizontal scroller; the editor's scrollDOM is the vertical
-        // one. If either ever stops being scrollable, that axis simply reports no movement.
+        // The widget is the table's horizontal scroller. Vertically the editor's own scroller
+        // wins where it can move, and the page takes over where it cannot — which is every
+        // frame in the web app, whose editor does not scroll internally at all.
+        const verticalDelta = verticalIntensity * maxDelta;
+        const pageScroller = getPageScroller(this.view);
         const didScrollHorizontally = applyScrollDelta(context.widget, 'horizontal', horizontalIntensity * maxDelta);
-        const didScrollVertically = applyScrollDelta(this.view.scrollDOM, 'vertical', verticalIntensity * maxDelta);
+        const didScrollVertically =
+            applyScrollDelta(this.view.scrollDOM, 'vertical', verticalDelta) ||
+            (pageScroller !== null && applyScrollDelta(pageScroller, 'vertical', verticalDelta));
         if (!didScrollHorizontally && !didScrollVertically) {
             this.lastTimestamp = null;
             return;

--- a/src/contentScript/tableRuntime/interaction/mouseCellDragSelection.ts
+++ b/src/contentScript/tableRuntime/interaction/mouseCellDragSelection.ts
@@ -7,10 +7,11 @@ import { resolveTableContextAtPos } from '../tableResolution';
 import { clearCellSelectionEffect, getCellSelection } from '../../tableState/cellSelectionState';
 import { flushNestedEditorState, refocusNestedEditor } from '../../nestedEditor/nestedEditorController';
 import { getViewWindow } from '../../shared/domContext';
+import { getViewportHeight, resolveViewportBounds } from '../../shared/editorViewport';
 import { clamp } from '../../shared/numberUtils';
 import { isPrimaryMouseButton, isPrimaryMousePointer } from '../../shared/mouseEvents';
 import { SELECTOR_CELL, getWidgetSelector, readCellCoords } from '../../tableWidget/domHelpers';
-import { CellDragAutoScroller, resolveVerticalScrollBounds } from './mouseCellDragAutoScroll';
+import { CellDragAutoScroller } from './mouseCellDragAutoScroll';
 
 const DRAG_START_DISTANCE_PX = 5;
 const DRAG_START_DISTANCE_SQUARED = DRAG_START_DISTANCE_PX * DRAG_START_DISTANCE_PX;
@@ -292,7 +293,7 @@ class MouseCellDragSelectionController {
         const widgetRect = gesture.widget.getBoundingClientRect();
         const scrollRect = this.view.scrollDOM.getBoundingClientRect();
         // Vertically the scroller rect is not the visible band when the page scrolls instead.
-        const verticalBounds = resolveVerticalScrollBounds(this.view);
+        const verticalBounds = resolveViewportBounds(scrollRect, getViewportHeight(getViewWindow(this.view)));
         const left = Math.max(tableRect.left, widgetRect.left, scrollRect.left);
         const right = Math.min(tableRect.right, widgetRect.right, scrollRect.right);
         const top = Math.max(tableRect.top, widgetRect.top, verticalBounds.top);

--- a/src/contentScript/tableRuntime/interaction/mouseCellDragSelection.ts
+++ b/src/contentScript/tableRuntime/interaction/mouseCellDragSelection.ts
@@ -10,7 +10,7 @@ import { getViewWindow } from '../../shared/domContext';
 import { clamp } from '../../shared/numberUtils';
 import { isPrimaryMouseButton, isPrimaryMousePointer } from '../../shared/mouseEvents';
 import { SELECTOR_CELL, getWidgetSelector, readCellCoords } from '../../tableWidget/domHelpers';
-import { CellDragAutoScroller } from './mouseCellDragAutoScroll';
+import { CellDragAutoScroller, resolveVerticalScrollBounds } from './mouseCellDragAutoScroll';
 
 const DRAG_START_DISTANCE_PX = 5;
 const DRAG_START_DISTANCE_SQUARED = DRAG_START_DISTANCE_PX * DRAG_START_DISTANCE_PX;
@@ -291,10 +291,12 @@ class MouseCellDragSelectionController {
         const tableRect = gesture.table.getBoundingClientRect();
         const widgetRect = gesture.widget.getBoundingClientRect();
         const scrollRect = this.view.scrollDOM.getBoundingClientRect();
+        // Vertically the scroller rect is not the visible band when the page scrolls instead.
+        const verticalBounds = resolveVerticalScrollBounds(this.view);
         const left = Math.max(tableRect.left, widgetRect.left, scrollRect.left);
         const right = Math.min(tableRect.right, widgetRect.right, scrollRect.right);
-        const top = Math.max(tableRect.top, widgetRect.top, scrollRect.top);
-        const bottom = Math.min(tableRect.bottom, widgetRect.bottom, scrollRect.bottom);
+        const top = Math.max(tableRect.top, widgetRect.top, verticalBounds.top);
+        const bottom = Math.min(tableRect.bottom, widgetRect.bottom, verticalBounds.bottom);
         if (right <= left || bottom <= top) {
             return null;
         }

--- a/src/contentScript/toolbar/tableToolbarPlugin.ts
+++ b/src/contentScript/toolbar/tableToolbarPlugin.ts
@@ -19,13 +19,17 @@ import {
     isObscuringTopPlacement,
     isTableOutsideViewport,
     resolveToolbarPlacementMode,
-    resolveViewportBounds,
     shouldPinAbove,
     TOOLBAR_OFFSET_PX,
     TOOLBAR_VIEWPORT_PADDING_PX,
     type ToolbarPlacement,
-    type ViewportBounds,
 } from './toolbarPositioning';
+import {
+    getViewportHeight,
+    getViewportWidth,
+    resolveViewportBounds,
+    type ViewportBounds,
+} from '../shared/editorViewport';
 
 /** Everything resolved once per `autoUpdate` registration and reused by every reposition. */
 interface PositioningContext {
@@ -315,16 +319,10 @@ export class TableToolbarPlugin {
     }
 
     private readGeometry(ctx: PositioningContext): ToolbarGeometry {
-        const visualViewport = ctx.viewWindow.visualViewport;
-
         return {
             toolbarRect: this.dom.getBoundingClientRect(),
             tableRect: ctx.referenceElement.getBoundingClientRect(),
-            viewport: resolveViewportBounds(
-                ctx.isInternalScroll,
-                ctx.scrollDOM.getBoundingClientRect(),
-                visualViewport?.height ?? ctx.viewWindow.innerHeight
-            ),
+            viewport: resolveViewportBounds(ctx.scrollDOM.getBoundingClientRect(), getViewportHeight(ctx.viewWindow)),
         };
     }
 
@@ -379,7 +377,7 @@ export class TableToolbarPlugin {
                   tableRect,
                   toolbarRect,
                   viewport,
-                  viewportWidth: ctx.viewWindow.visualViewport?.width ?? ctx.viewWindow.innerWidth,
+                  viewportWidth: getViewportWidth(ctx.viewWindow),
                   pinAbove,
               });
 

--- a/src/contentScript/toolbar/toolbarPositioning.ts
+++ b/src/contentScript/toolbar/toolbarPositioning.ts
@@ -1,3 +1,4 @@
+import type { ViewportBounds } from '../shared/editorViewport';
 import { clamp } from '../shared/numberUtils';
 
 export const TOOLBAR_OFFSET_PX = 5;
@@ -10,13 +11,6 @@ export interface ToolbarRect {
     bottom: number;
     left: number;
     width: number;
-    height: number;
-}
-
-/** Vertical bounds of the area the toolbar must stay inside, in viewport coordinates. */
-export interface ViewportBounds {
-    top: number;
-    bottom: number;
     height: number;
 }
 
@@ -35,23 +29,6 @@ export interface ToolbarPlacement extends ToolbarPoint {
  * anchor to is off-screen, so the toolbar sticks to the viewport edge instead.
  */
 export type ToolbarPlacementMode = 'top-start' | 'bottom-start' | 'pinned';
-
-/**
- * Desktop uses internal CodeMirror scrolling, so the visible area is the scroller rect.
- * Mobile scrolls the surrounding WebView, so the visible area is the window/visual viewport
- * anchored to the top of the page.
- */
-export function resolveViewportBounds(
-    isInternalScroll: boolean,
-    scrollDOMRect: ToolbarRect,
-    externalViewportHeight: number
-): ViewportBounds {
-    if (isInternalScroll) {
-        return { top: scrollDOMRect.top, bottom: scrollDOMRect.bottom, height: scrollDOMRect.height };
-    }
-
-    return { top: 0, bottom: externalViewportHeight, height: externalViewportHeight };
-}
 
 /** True when the table has scrolled entirely past either viewport edge. */
 export function isTableOutsideViewport(tableRect: ToolbarRect, viewport: ViewportBounds): boolean {


### PR DESCRIPTION
Joplin hosts CodeMirror two ways, and only one of them scrolls internally:

- **Desktop** pins the editor to a fixed-height container, so `scrollDOM` scrolls.
- **Mobile and web** leave the editor's height unconstrained, so `scrollDOM` grows to the whole document and the document root scrolls instead.

Vertical drag auto-scroll only ever drove `scrollDOM`, so on mobile and web it had nothing to move, and its edge zone sat off-screen along with the scroller's bottom. The clamped hit test had the same problem, aiming at points outside the window.

### Fix

Take the vertical band as the scroller rect intersected with the window, and drive whichever element actually owns vertical scrolling. Internal and external scrolling are mutually exclusive, so `getVerticalScroller` tests `scrollDOM` for overflow and falls back to `document.scrollingElement` when it has none. Both are no-ops on desktop, where `scrollDOM` sits inside the window and scrolls itself.

### Refactor

The floating toolbar already answered the same "which band can the reader see" question, branching on an `isInternalScroll` flag. `shared/editorViewport.ts` now owns the single answer for both features. The flag survives for the two things it still decides: viewport listener attachment, and fixed-vs-absolute pinning.

### Verification

`npm test` (847 tests), `npm run lint`, `npm run knip`, `prettier --check`, and `npm run dist` all pass. Both regression tests were confirmed to fail against the unfixed code.
