### PR TITLE
fix: use Joplin's actual selection colors

### DIFF
--- a/src/contentScript/nestedEditor/nestedEditorTheme.ts
+++ b/src/contentScript/nestedEditor/nestedEditorTheme.ts
@@ -5,70 +5,83 @@ import { CLASS_NESTED_EDITOR_URL } from '../shared/tableDomClasses';
 /**
  * Creates a theme for the nested cell editor that adapts to light/dark mode.
  * Configures selection highlighting, scrolling behavior, and syntax decoration styles.
+ *
+ * The `dark` option propagates the host editor's `EditorView.darkTheme` facet to this view, which
+ * is what stamps CodeMirror's light/dark theme class onto the nested editor root.  Without it the
+ * nested root always reports "light" and shadows the host's `--rt-*` selection variables with the
+ * light values (see `tableWidget/richTableThemeVars.ts`).
  */
 export function createNestedEditorTheme(isDarkTheme: boolean): Extension {
-    return EditorView.theme({
-        '&': {
-            backgroundColor: 'transparent',
-        },
+    return EditorView.theme(
+        {
+            '&': {
+                backgroundColor: 'transparent',
+            },
 
-        // --- Selection rendering ---
-        // CM's drawSelection() paints .cm-selectionBackground; style its color here.
-        // Native ::selection suppression is handled on the root editor in
-        // rootEditorSelectionTheme.ts, which has higher specificity than Joplin's
-        // cascading `&.cm-focused ::selection` rule.
-        '&.cm-focused > .cm-scroller > .cm-selectionLayer .cm-selectionBackground': {
-            backgroundColor: 'var(--rt-nested-selection-bg) !important',
-        },
+            // --- Selection rendering ---
+            // CM's drawSelection() paints .cm-selectionBackground; style its color here.  The
+            // focused selector mirrors Joplin's own (theme.ts) and outranks the blurred rule
+            // above it on specificity, so ordering here is presentational only.
+            // Native ::selection suppression is handled on the root editor in
+            // rootEditorSelectionTheme.ts, which has higher specificity than Joplin's
+            // cascading `&.cm-focused ::selection` rule.
+            '& .cm-selectionLayer .cm-selectionBackground': {
+                backgroundColor: 'var(--rt-nested-selection-blurred-bg) !important',
+            },
+            '&.cm-focused > .cm-scroller > .cm-selectionLayer .cm-selectionBackground': {
+                backgroundColor: 'var(--rt-nested-selection-bg) !important',
+            },
 
-        // --- Joplin/CM environment resets ---
-        // These override Joplin's and CodeMirror's aggressive defaults that would
-        // otherwise break cell layout or mismatch the rendered cell appearance.
-        '.cm-scroller': {
-            overflow: 'hidden !important',
-        },
-        '.cm-content': {
-            padding: '0',
-            // CodeMirror injects font-size: 1.1875em on mobile to prevent iOS/Android auto-zoom.
-            // Override so the editor font matches the rendered cell (which uses inherit).
-            fontSize: 'inherit !important',
-            // CodeMirror's `lineWrapping` uses break-spaces/break-word; override to match
-            // rendered-table behavior (wrap at whitespace, but don't split short words).
-            // `break-spaces` makes a space at a wrap point occupy width and count toward
-            // intrinsic sizing, while the rendered cell (`white-space: normal`) lets it hang
-            // for free, so the same text measured wider and wrapped earlier in the editor,
-            // shifting column widths on activation. `pre-wrap` keeps source spaces intact
-            // while restoring hanging at wrap points.
-            whiteSpace: 'pre-wrap !important',
-            wordBreak: 'normal !important',
-            overflowWrap: 'normal !important',
-        },
-        '.cm-line': {
-            paddingLeft: '1px !important',
-            wordBreak: 'normal !important',
-            overflowWrap: 'normal !important',
-        },
+            // --- Joplin/CM environment resets ---
+            // These override Joplin's and CodeMirror's aggressive defaults that would
+            // otherwise break cell layout or mismatch the rendered cell appearance.
+            '.cm-scroller': {
+                overflow: 'hidden !important',
+            },
+            '.cm-content': {
+                padding: '0',
+                // CodeMirror injects font-size: 1.1875em on mobile to prevent iOS/Android auto-zoom.
+                // Override so the editor font matches the rendered cell (which uses inherit).
+                fontSize: 'inherit !important',
+                // CodeMirror's `lineWrapping` uses break-spaces/break-word; override to match
+                // rendered-table behavior (wrap at whitespace, but don't split short words).
+                // `break-spaces` makes a space at a wrap point occupy width and count toward
+                // intrinsic sizing, while the rendered cell (`white-space: normal`) lets it hang
+                // for free, so the same text measured wider and wrapped earlier in the editor,
+                // shifting column widths on activation. `pre-wrap` keeps source spaces intact
+                // while restoring hanging at wrap points.
+                whiteSpace: 'pre-wrap !important',
+                wordBreak: 'normal !important',
+                overflowWrap: 'normal !important',
+            },
+            '.cm-line': {
+                paddingLeft: '1px !important',
+                wordBreak: 'normal !important',
+                overflowWrap: 'normal !important',
+            },
 
-        // --- Syntax decoration styles ---
-        '.cm-inline-code': {
-            borderRadius: '4px',
-            border: `1px solid ${isDarkTheme ? 'rgba(200, 200, 200, 0.5)' : 'rgba(100, 100, 100, 0.5)'}`,
-            padding: '1px 0',
+            // --- Syntax decoration styles ---
+            '.cm-inline-code': {
+                borderRadius: '4px',
+                border: `1px solid ${isDarkTheme ? 'rgba(200, 200, 200, 0.5)' : 'rgba(100, 100, 100, 0.5)'}`,
+                padding: '1px 0',
+            },
+            '.cm-highlighted': {
+                backgroundColor: 'var(--rt-mark-bg)',
+                color: 'var(--rt-mark-color)',
+                padding: '1px 0',
+                borderRadius: '2px',
+            },
+            '.cm-inserted': {
+                textDecoration: 'underline',
+                textDecorationStyle: 'solid',
+            },
+            [`.${CLASS_NESTED_EDITOR_URL}`]: {
+                // URL source can be substantially wider than its rendered link label. Allowing
+                // breaks at any character keeps it from increasing the table's intrinsic width.
+                overflowWrap: 'anywhere',
+            },
         },
-        '.cm-highlighted': {
-            backgroundColor: 'var(--rt-mark-bg)',
-            color: 'var(--rt-mark-color)',
-            padding: '1px 0',
-            borderRadius: '2px',
-        },
-        '.cm-inserted': {
-            textDecoration: 'underline',
-            textDecorationStyle: 'solid',
-        },
-        [`.${CLASS_NESTED_EDITOR_URL}`]: {
-            // URL source can be substantially wider than its rendered link label. Allowing
-            // breaks at any character keeps it from increasing the table's intrinsic width.
-            overflowWrap: 'anywhere',
-        },
-    });
+        { dark: isDarkTheme }
+    );
 }

--- a/src/contentScript/tableWidget/richTableThemeVars.ts
+++ b/src/contentScript/tableWidget/richTableThemeVars.ts
@@ -15,6 +15,16 @@ const JOPLIN_SELECTION_COLORS = {
 } as const;
 
 /**
+ * Alpha applied to the multi-cell selection fill.
+ */
+const CELL_SELECTION_ALPHA = '60%';
+
+/**
+ * Fades a color toward transparent.
+ */
+const withAlpha = (color: string, alpha: string): string => `color-mix(in srgb, ${color} ${alpha}, transparent)`;
+
+/**
  * Maps Joplin theme variables to plugin-owned --rt-* custom properties.
  *
  * Defined on the main editor root so all plugin DOM (widget, nested editor, toolbar)
@@ -22,7 +32,7 @@ const JOPLIN_SELECTION_COLORS = {
  * one line here rather than hunting across multiple style files.
  *
  * --rt-border-color        borders, outlines, dividers
- * --rt-selection-bg        multi-cell selection overlay
+ * --rt-selection-bg        multi-cell selection background (painted on the cell, behind its text)
  * --rt-nested-selection-bg CodeMirror drawSelection layer inside a focused nested editor
  * --rt-nested-selection-blurred-bg  the same layer while the nested editor is unfocused
  * --rt-code-bg             inline code background
@@ -48,7 +58,6 @@ const JOPLIN_SELECTION_COLORS = {
 export const richTableThemeVars = EditorView.baseTheme({
     '&': {
         '--rt-border-color': 'var(--joplin-divider-color, #dddddd)',
-        '--rt-selection-bg': 'var(--joplin-selected-text-background-color, rgba(0, 120, 215, 0.15))',
         '--rt-code-bg': 'var(--joplin-code-background-color, rgb(243, 243, 243))',
         '--rt-code-color': 'var(--joplin-code-color, rgb(0, 0, 0))',
         '--rt-mark-bg': 'var(--joplin-mark-highlight-background-color, #F7D26E)',
@@ -61,10 +70,12 @@ export const richTableThemeVars = EditorView.baseTheme({
         '--rt-toolbar-hover-bg': 'var(--joplin-selected-color)',
     } as Record<string, string>,
     '&light': {
+        '--rt-selection-bg': withAlpha(JOPLIN_SELECTION_COLORS.light.focused, CELL_SELECTION_ALPHA),
         '--rt-nested-selection-bg': JOPLIN_SELECTION_COLORS.light.focused,
         '--rt-nested-selection-blurred-bg': JOPLIN_SELECTION_COLORS.light.blurred,
     } as Record<string, string>,
     '&dark': {
+        '--rt-selection-bg': withAlpha(JOPLIN_SELECTION_COLORS.dark.focused, CELL_SELECTION_ALPHA),
         '--rt-nested-selection-bg': JOPLIN_SELECTION_COLORS.dark.focused,
         '--rt-nested-selection-blurred-bg': JOPLIN_SELECTION_COLORS.dark.blurred,
     } as Record<string, string>,

--- a/src/contentScript/tableWidget/richTableThemeVars.ts
+++ b/src/contentScript/tableWidget/richTableThemeVars.ts
@@ -1,6 +1,20 @@
 import { EditorView } from '@codemirror/view';
 
 /**
+ * Joplin's editor text-selection colors, which no Joplin CSS variable exposes.
+ *
+ * Joplin only styles selection in dark mode (`packages/editor/CodeMirror/theme.ts`); in light
+ * mode it leaves the selection unstyled and CodeMirror's own base theme colors apply.  The light
+ * values below are therefore CodeMirror's defaults, restated here so both modes read from one
+ * place.  `--joplin-selected-color` is deliberately not used: it is the list-item selection
+ * color (light `#e5e5e5`, dark `#616161`), not the text-selection color.
+ */
+const JOPLIN_SELECTION_COLORS = {
+    light: { focused: '#d7d4f0', blurred: '#d9d9d9' },
+    dark: { focused: '#6b6b6b', blurred: '#444444' },
+} as const;
+
+/**
  * Maps Joplin theme variables to plugin-owned --rt-* custom properties.
  *
  * Defined on the main editor root so all plugin DOM (widget, nested editor, toolbar)
@@ -9,7 +23,8 @@ import { EditorView } from '@codemirror/view';
  *
  * --rt-border-color        borders, outlines, dividers
  * --rt-selection-bg        multi-cell selection overlay
- * --rt-nested-selection-bg CodeMirror drawSelection layer inside nested editor
+ * --rt-nested-selection-bg CodeMirror drawSelection layer inside a focused nested editor
+ * --rt-nested-selection-blurred-bg  the same layer while the nested editor is unfocused
  * --rt-code-bg             inline code background
  * --rt-code-color          inline code text
  * --rt-mark-bg             ==highlight== background
@@ -23,12 +38,17 @@ import { EditorView } from '@codemirror/view';
  *                          background-color-transparent2 is an overlay scrim that inverts to white
  *                          on dark themes, which reads as a glow rather than a shadow.)
  * --rt-toolbar-hover-bg    toolbar button hover background
+ *
+ * The `&light`/`&dark` blocks resolve to CodeMirror's own light/dark theme classes on the editor
+ * root, so they follow the `EditorView.darkTheme` facet.  They must stay after the `&` block:
+ * all three selectors are a single class, so source order decides the winner.  Any editor whose
+ * DOM these variables must resolve on has to report the same facet value as the host editor —
+ * see the `dark` option passed in `nestedEditor/nestedEditorTheme.ts`.
  */
 export const richTableThemeVars = EditorView.baseTheme({
     '&': {
         '--rt-border-color': 'var(--joplin-divider-color, #dddddd)',
         '--rt-selection-bg': 'var(--joplin-selected-text-background-color, rgba(0, 120, 215, 0.15))',
-        '--rt-nested-selection-bg': 'var(--joplin-selected-color, #6B6B6B)',
         '--rt-code-bg': 'var(--joplin-code-background-color, rgb(243, 243, 243))',
         '--rt-code-color': 'var(--joplin-code-color, rgb(0, 0, 0))',
         '--rt-mark-bg': 'var(--joplin-mark-highlight-background-color, #F7D26E)',
@@ -39,5 +59,13 @@ export const richTableThemeVars = EditorView.baseTheme({
         '--rt-toolbar-color': 'var(--joplin-color)',
         '--rt-toolbar-shadow': 'rgba(0, 0, 0, 0.2)',
         '--rt-toolbar-hover-bg': 'var(--joplin-selected-color)',
+    } as Record<string, string>,
+    '&light': {
+        '--rt-nested-selection-bg': JOPLIN_SELECTION_COLORS.light.focused,
+        '--rt-nested-selection-blurred-bg': JOPLIN_SELECTION_COLORS.light.blurred,
+    } as Record<string, string>,
+    '&dark': {
+        '--rt-nested-selection-bg': JOPLIN_SELECTION_COLORS.dark.focused,
+        '--rt-nested-selection-blurred-bg': JOPLIN_SELECTION_COLORS.dark.blurred,
     } as Record<string, string>,
 });


### PR DESCRIPTION
Align the selection colors in the editor with Joplin's actual colors, addressing the absence of corresponding theme variables.