### PR TITLE
ux: improve appearance of selections and snap selections to cover entire table

### DIFF
--- a/docs/Architecture/Interaction-and-Navigation.md
+++ b/docs/Architecture/Interaction-and-Navigation.md
@@ -1,152 +1,89 @@
 # Interaction and Navigation
 
-The main editor owns document state and history, while a transient nested editor owns interaction inside the active
-cell. Navigation coordinates the handoff between those editors and the table widget's multi-cell selection mode.
+The main editor owns document state, history, and table-level selections. A transient nested editor owns interaction
+inside the active cell. The table runtime coordinates transitions between them, while the widget renders interaction
+state.
 
-## Keyboard Navigation
+## Ownership
 
-The active cell hosts a separate editor instance, while inactive cells remain ordinary `<td>` or `<th>` elements. Key
-handling makes the cells behave like a single grid.
+| Area                    | Owner                                             | Responsibility                                                           |
+| :---------------------- | :------------------------------------------------ | :----------------------------------------------------------------------- |
+| Main-editor entry       | `tableRuntime/navigation/mainEditorTableEntry.ts` | Opens an edge cell when the caret moves into a rendered table.           |
+| Cell activation         | `tableRuntime/openCellRequest.ts`                 | Stores logical open intent until the widget and nested editor are ready. |
+| Nested-editor lifecycle | `tableRuntime/lifecycle/nestedEditorLifecycle.ts` | Resolves document positions and mounts or closes the cell editor.        |
+| Table exit              | `tableRuntime/navigation/tableExit.ts`            | Returns the caret and focus to the main editor.                          |
+| Selection state         | `tableRuntime/selection/` and `tableState/`       | Owns multi-cell and whole-table selection behavior.                      |
+| Interaction visuals     | `tableWidget/`                                    | Renders active cells, selection rectangles, and whole-table selection.   |
 
-| Key                 | Action        | At the cell boundary                                               |
-| :------------------ | :------------ | :----------------------------------------------------------------- |
-| **Tab**             | Next cell     | The final cell creates a row.                                      |
-| **Shift+Tab**       | Previous cell | The first cell is blocked.                                         |
-| **Enter**           | Cell below    | The final row creates a row.                                       |
-| **ArrowLeft/Right** | Move by char  | A cell edge moves horizontally; a table edge exits the table.      |
-| **ArrowUp/Down**    | Move by line  | A visual line edge moves vertically; a table edge exits the table. |
+## Cell Navigation
 
-### Crossing the Table Boundary
+The active cell contains a nested editor; inactive cells remain table elements. Navigation makes these separate editors
+behave like one grid.
 
-A rendered table is a block replacement in the main editor, so entry and exit must be handled explicitly rather than
-by normal caret movement.
+| Key                 | Action            | Boundary behavior                                     |
+| :------------------ | :---------------- | :---------------------------------------------------- |
+| **Tab**             | Next cell         | Creates a row after the final cell.                   |
+| **Shift+Tab**       | Previous cell     | Stops at the first cell.                              |
+| **Enter**           | Cell below        | Creates a row after the final row.                    |
+| **ArrowLeft/Right** | Move horizontally | Crosses into an adjacent cell or exits the table.     |
+| **ArrowUp/Down**    | Move vertically   | Crosses at a visual line boundary or exits the table. |
 
-- **Entry**: Arrow or deletion movement toward an adjacent table opens the nearest edge cell. Vertical entry preserves
-  the expected visual direction by choosing the first or last row as appropriate.
-- **Exit**: Arrow movement beyond the outermost cell closes the nested editor, places the main-editor caret on the
-  adjacent line, and restores main-editor focus. At a document edge, where no adjacent line exists, the movement is
-  blocked.
-- **Separation**: The blank line required between a rendered table and neighbouring content is protected from
-  incidental deletion. Ordinary typing or pasting into that boundary restores valid separation in the same main-editor
-  transaction, keeping the document valid and undo behavior atomic. Composition input is left unchanged and repaired
-  on a later cell entry.
-- **Eligibility**: Arrow entry applies only to a single empty caret in rendered mode when no cell selection is active.
-  Explicit range edits remain main-editor operations.
+Because a rendered table replaces its Markdown source as a block decoration, normal caret movement cannot enter or
+exit it directly:
 
-`tableRuntime/navigation/mainEditorTableEntry.ts` owns entry from the main editor, while
-`tableRuntime/navigation/tableExit.ts` owns exit from a nested editor. Boundary-preserving document edits are handled
-by `tableRuntime/tableBoundaryMaintenance.ts`.
+- Entry from the main editor opens the nearest edge cell. It applies only to an empty caret in rendered mode when no
+  cell selection is active.
+- Exit closes the nested editor, places the main-editor caret on the adjacent line, and restores main-editor focus.
+- The required blank-line separation around tables is maintained by
+  `tableRuntime/tableBoundaryMaintenance.ts` as part of the triggering transaction.
 
-### Navigation Requests
+Opening a cell can span document changes, widget rendering, and nested-editor mounting. The runtime therefore records
+the logical target and caret placement in editor state, then resolves current document positions when mounting. Cell
+navigation, table entry, row creation, and structural commands all use this request path.
 
-Opening a cell spans a main-editor transaction, widget rendering, and nested-editor mounting. The pending intent is
-therefore stored in editor state (`tableRuntime/openCellRequest.ts`) rather than module-global state. A request records
-the logical target and desired caret placement; the lifecycle resolves current document positions when it mounts the
-nested editor and then completes or fails the request.
+## Selection Architecture
 
-Cell navigation, table entry, row creation, and structural operations share this request path. This keeps document
-changes, active-cell state, and reopen intent coordinated.
+The interaction model has three selection scopes:
 
-### Scrolling
+### In-Cell Selection
 
-Opening a target cell relies on focusing its nested editor, allowing the browser to reveal it naturally. Other paths
-scroll explicitly, including table exit, multi-cell selection movement, anchor jumps, and raw-mode cursor visibility.
-
-## Selection Modes
-
-### Active-Cell Selection Sync
-
-While a nested editor is active, its visible selection is mirrored into the hidden main-editor selection. The main
-editor remains the integration point for document commands and Joplin toolbar actions. Cross-editor synchronization
-must use `syncAnnotation` to avoid feedback loops.
+The nested editor owns the visible text selection inside the active cell. It mirrors that selection into main-editor
+coordinates so document commands and Joplin toolbar actions continue to work. Cross-editor transactions use
+`syncAnnotation` to prevent feedback loops.
 
 ### Multi-Cell Selection
 
-Multi-cell selection is stored in main-editor state and rendered on the table widget rather than being owned by the
-nested editor. The main-editor caret tracks the focus cell for clipboard and command integration, but is hidden while
-the rectangular selection is visible.
+A rectangular cell selection is stored in main-editor state and rendered by the table widget. The main editor owns
+keyboard, clipboard, and history commands while this mode is active.
 
-- **Shift+Arrow** starts or extends the selection.
-- **Arrow** collapses the selection and leaves the table; **Enter/Tab** activates its focus cell.
+- **Shift+Arrow** starts or extends the rectangle.
+- **Arrow** collapses the selection and exits the table; **Enter/Tab** activates the focus cell.
 - **Escape** clears the selection.
-- **Delete/Backspace** clears selected content, or removes fully selected empty rows, columns, or the whole table.
-- **Copy/Cut/Paste** operates on the selected rectangle and may expand the table when pasting.
-- **Undo/Redo** is forwarded to main-editor history.
+- **Delete/Backspace** clears content or removes fully selected empty structures.
+- **Copy/Cut/Paste** operates on the rectangle and may expand the table.
+- **Undo/Redo** uses main-editor history.
 
-Commands that move the main-editor caret outside the selected table clear the selection.
-
-The selected rectangle is painted with the same fill as a whole-table selection (see below), because
-both are a selection over rendered cells and telling them apart by colour would say nothing useful.
-What distinguishes them is their extent: a cell selection stops at the rectangle, while a whole-table
-selection also floods the widget's own block.
-
-Creating a selection also hands focus to the main editor, which owns its keyboard and clipboard
-commands. Every gesture that starts one suppresses the browser's own focusing — shift-click
-preventDefaults its mousedown, and a keyboard selection tears down the nested editor that held focus
-— so without this focus would sit on the document body, and the selection would render as unfocused.
-`cellSelectionController.ts` does this as it dispatches; `cellSelectionFocusPlugin` catches the
-selections it does not create, such as the multi-cell paste a transaction filter rewrites a
-cell-editor paste into, which has no view to focus with.
-
-A running drag is the exception: it leaves whatever had focus alone — a cell editor in another
-table, or something outside the editor entirely — until the rectangle is final, and hands focus over
-on release. So that the rectangle being dragged does not render unfocused and then snap, a drag in
-progress asserts the focused tint for itself, in `tableWidget/cellSelectionVisuals.ts`.
+Mouse dragging can also create a rectangular selection. Drag ownership and deferred active-cell updates are described
+in [Table-Runtime-Invariants.md](./Table-Runtime-Invariants.md#cell-drag-ownership).
 
 ### Whole-Table Selection
 
-A selection in the main editor covers a rendered table as a single block; it cannot address anything inside one,
-because rows and columns are the multi-cell selection's job.
+A main-editor range that reaches a rendered table expands to cover the entire table block. Rows and columns remain the
+responsibility of multi-cell selection.
 
-- `tableRuntime/selection/tableSelectionSnap.ts` filters selection-only transactions, growing any range that reaches
-  a table until it contains the whole table. Contact is enough — an endpoint resting on a table edge has been dragged
-  onto the widget, because the positions either side of a table belong to its separating blank lines. Carets,
-  document changes, raw mode, and any state where a cell editor or cell selection owns the table are left alone.
-- `tableWidget/wholeTableSelectionVisuals.ts` marks the widget roots the selection covers end to end and paints them as
-  one selected block. CodeMirror's selection background sits behind editor text, which a rendered table's own opaque
-  surfaces — the header, inline code, `==highlight==`, images — would stand proud of, so the highlight is layered
-  instead: the selection colour on the widget root for the padding and the strip beside a narrow table, and over each
-  cell the fill `tableWidget/selectionTint.ts` shares with the multi-cell selection — a known ground, plus an overlay
-  compositing it up to the selection colour and taking the cell's content with it. The overlay hangs off the cells so
-  it scrolls with a wide table; the cell borders are tinted through their colour, since an overlay grown to reach them
-  would darken each shared one twice. A gridline where a selection ends mid-table is shared by cells that disagree
-  about its colour, and CSS settles that in favour of the cell further up and left — leaving a rectangle's top and
-  left edges drawn by their unselected neighbours — so the overlay redraws those two sides itself, in the same opaque
-  tinted colour. Both fills read `--rt-tint` and `--rt-selection-bg`, resolved once in
-  `tableWidget/richTableThemeVars.ts` so they can never disagree about focus. That resolution tests
-  `:focus-within` rather than `.cm-focused`, which tracks only the root editor's own content: a
-  nested cell editor holds focus on the plugin's behalf, most visibly through a cell drag.
-- `tableWidget/selectionOverlayColor.ts` solves for that overlay: the faintest layer that reproduces the selection
-  colour on the painted ground. Being faint and of the opposite tone to the text, it recolours every surface at the
-  ground's tone exactly while leaving the text legible — where the selection colour at some chosen alpha would wash
-  the text out and still not reach the opaque surfaces. The layer's colour and alpha are published separately so the
-  same tint can also be laid over a base no overlay covers, such as a border colour. Untinted, a gridline all but
-  vanishes: the divider colour is a light grey chosen to read on the editor background rather than on the darker
-  selection ground.
-- Painting the block ourselves also decouples the highlight from `drawSelection`, whose rects around a selected table
-  are unreliable — it measures through `coordsAtPos`, which `TableWidget.coordsAt` answers with cell rectangles. The
-  browser's native `::selection` is suppressed inside a widget for the same reason: `drawSelection` only neutralizes
-  it for text inside `.cm-line`.
+`tableRuntime/selection/tableSelectionSnap.ts` owns range expansion, while
+`tableWidget/wholeTableSelectionVisuals.ts` renders the selected block. Whole-table and multi-cell selections share
+the same cell-selection tint; their extent distinguishes them.
 
-## Mouse Interaction
+Moving the main-editor caret outside the selected table clears table-owned selection state.
 
-- Clicking a cell activates it or updates the current multi-cell selection.
-- Dragging from one cell to another with a desktop mouse creates a rectangular selection. A movement threshold keeps
-  ordinary clicks distinct from drags. Touch and pen pointers retain native scrolling/tap behaviour and do not start
-  drag selection. Holding a cell drag near an edge auto-scrolls the table horizontally and whichever element owns
-  vertical scrolling vertically — see [Table-Display.md](./Table-Display.md#host-scroll-modes).
-  Releasing a drag back over its anchor opens that cell's editor. A completed rectangular selection focuses the main
-  editor on release so its keyboard and clipboard commands work even when focus started outside the editor.
-- Once a gesture becomes a rectangular selection it records itself in `cellDragField` until release. See
-  [Table-Runtime-Invariants.md](./Table-Runtime-Invariants.md#cell-drag-ownership) for what that ownership means; the
-  gesture settles the deferred state on release, clearing the active cell unless the drag contracts back to its anchor.
-- A drag that starts anywhere in the active cell—including row-height padding outside the nested editor—keeps the
-  nested editor open while it stays in that cell. Drags beginning on editable content retain native text selection. When
-  the pointer travels a short margin past the cell's border into another cell, ownership switches to rectangular cell
-  selection with the active cell as its anchor; the margin keeps a graze past the border from converting the gesture.
-  Conversion ends the nested editor's native text drag by dispatching one mouse move with no button held, which is
-  how CodeMirror tears down its own drag and the interval driving its edge scrolling; nothing is suppressed for the
-  rest of the gesture.
-- Shift+Arrow reopens the anchor editor when it contracts a multi-cell selection back to that one cell.
+## Pointer, Links, and Scrolling
+
+- Clicking activates a cell or updates the current cell selection.
+- Mouse dragging selects a cell rectangle; touch and pen input retain native scrolling and tap behavior.
+- Drags near an edge auto-scroll the table or host scroll container. See
+  [Table-Display.md](./Table-Display.md#host-scroll-modes).
 - Links delegate to the content-script link opener and then to the main plugin.
 - Heading and footnote anchors scroll the main editor through `scrollToAnchor`.
+- Cell activation relies on nested-editor focus to reveal the target. Table exit, cell-selection movement, anchor
+  jumps, and raw-mode cursor movement scroll explicitly.

--- a/docs/Architecture/Interaction-and-Navigation.md
+++ b/docs/Architecture/Interaction-and-Navigation.md
@@ -102,7 +102,7 @@ because rows and columns are the multi-cell selection's job.
   a table until it contains the whole table. Contact is enough — an endpoint resting on a table edge has been dragged
   onto the widget, because the positions either side of a table belong to its separating blank lines. Carets,
   document changes, raw mode, and any state where a cell editor or cell selection owns the table are left alone.
-- `tableWidget/tableSelectionHighlight.ts` marks the widget roots the selection covers end to end and paints them as
+- `tableWidget/wholeTableSelectionVisuals.ts` marks the widget roots the selection covers end to end and paints them as
   one selected block. CodeMirror's selection background sits behind editor text, which a rendered table's own opaque
   surfaces — the header, inline code, `==highlight==`, images — would stand proud of, so the highlight is layered
   instead: the selection colour on the widget root for the padding and the strip beside a narrow table, and over each

--- a/docs/Architecture/Interaction-and-Navigation.md
+++ b/docs/Architecture/Interaction-and-Navigation.md
@@ -94,7 +94,11 @@ because rows and columns are the multi-cell selection's job.
 - `tableWidget/selectionOverlayColor.ts` solves for that overlay: the faintest layer that reproduces the selection
   colour on the painted ground. Being faint and of the opposite tone to the text, it recolours every surface at the
   ground's tone exactly while leaving the text legible — where the selection colour at some chosen alpha would wash
-  the text out and still not reach the opaque surfaces.
+  the text out and still not reach the opaque surfaces. The layer's colour and alpha are published separately, so the
+  same tint can be laid over a base an overlay cannot physically cover: the cell borders take it through their
+  colour, since `border-collapse` shares each inner one and an overlay grown to reach them would darken those twice.
+  Untinted they all but vanish, the divider colour being a light grey chosen to read on the editor background rather
+  than on the darker selection ground.
 - Painting the block ourselves also decouples the highlight from `drawSelection`, whose rects around a selected table
   are unreliable — it measures through `coordsAtPos`, which `TableWidget.coordsAt` answers with cell rectangles. The
   browser's native `::selection` is suppressed inside a widget for the same reason: `drawSelection` only neutralizes

--- a/docs/Architecture/Interaction-and-Navigation.md
+++ b/docs/Architecture/Interaction-and-Navigation.md
@@ -75,6 +75,18 @@ the rectangular selection is visible.
 
 Commands that move the main-editor caret outside the selected table clear the selection.
 
+The selected rectangle is painted with the same fill as a whole-table selection (see below), because
+both are a selection over rendered cells and telling them apart by colour would say nothing useful.
+What distinguishes them is their extent: a cell selection stops at the rectangle, while a whole-table
+selection also floods the widget's own block.
+
+Creating a selection also hands focus to the main editor, which owns its keyboard and clipboard
+commands. Every gesture that starts one suppresses the browser's own focusing — shift-click
+preventDefaults its mousedown, and a keyboard selection tears down the nested editor that held focus
+— so without this focus would sit on the document body, and the selection would render as unfocused.
+A running drag is the exception: it keeps its anchor cell's editor open for the length of the
+gesture and hands focus over on release.
+
 ### Whole-Table Selection
 
 A selection in the main editor covers a rendered table as a single block; it cannot address anything inside one,
@@ -85,20 +97,23 @@ because rows and columns are the multi-cell selection's job.
   onto the widget, because the positions either side of a table belong to its separating blank lines. Carets,
   document changes, raw mode, and any state where a cell editor or cell selection owns the table are left alone.
 - `tableWidget/tableSelectionHighlight.ts` marks the widget roots the selection covers end to end and paints them as
-  one selected block, switching between the focused and blurred colours with the main editor. CodeMirror's selection
-  background sits behind editor text, which a rendered table's own opaque surfaces — the header, inline code,
-  `==highlight==`, images — would stand proud of, so the highlight is layered instead: the selection colour on the
-  widget root for the padding and the strip beside a narrow table, a known ground on each cell, and an overlay that
-  composites that ground up to the selection colour, taking the cell's content with it. The overlay hangs off the
-  cells so it scrolls with a wide table.
+  one selected block. CodeMirror's selection background sits behind editor text, which a rendered table's own opaque
+  surfaces — the header, inline code, `==highlight==`, images — would stand proud of, so the highlight is layered
+  instead: the selection colour on the widget root for the padding and the strip beside a narrow table, and over each
+  cell the fill `tableWidget/selectionTint.ts` shares with the multi-cell selection — a known ground, plus an overlay
+  compositing it up to the selection colour and taking the cell's content with it. The overlay hangs off the cells so
+  it scrolls with a wide table; the cell borders are tinted through their colour, since an overlay grown to reach them
+  would darken each shared one twice. Both fills read `--rt-tint` and `--rt-selection-bg`, resolved once in
+  `tableWidget/richTableThemeVars.ts` so they can never disagree about focus. That resolution tests
+  `:focus-within` rather than `.cm-focused`, which tracks only the root editor's own content: a
+  nested cell editor holds focus on the plugin's behalf, most visibly through a cell drag.
 - `tableWidget/selectionOverlayColor.ts` solves for that overlay: the faintest layer that reproduces the selection
   colour on the painted ground. Being faint and of the opposite tone to the text, it recolours every surface at the
   ground's tone exactly while leaving the text legible — where the selection colour at some chosen alpha would wash
-  the text out and still not reach the opaque surfaces. The layer's colour and alpha are published separately, so the
-  same tint can be laid over a base an overlay cannot physically cover: the cell borders take it through their
-  colour, since `border-collapse` shares each inner one and an overlay grown to reach them would darken those twice.
-  Untinted they all but vanish, the divider colour being a light grey chosen to read on the editor background rather
-  than on the darker selection ground.
+  the text out and still not reach the opaque surfaces. The layer's colour and alpha are published separately so the
+  same tint can also be laid over a base no overlay covers, such as a border colour. Untinted, a gridline all but
+  vanishes: the divider colour is a light grey chosen to read on the editor background rather than on the darker
+  selection ground.
 - Painting the block ourselves also decouples the highlight from `drawSelection`, whose rects around a selected table
   are unreliable — it measures through `coordsAtPos`, which `TableWidget.coordsAt` answers with cell rectangles. The
   browser's native `::selection` is suppressed inside a widget for the same reason: `drawSelection` only neutralizes

--- a/docs/Architecture/Interaction-and-Navigation.md
+++ b/docs/Architecture/Interaction-and-Navigation.md
@@ -103,7 +103,10 @@ because rows and columns are the multi-cell selection's job.
   cell the fill `tableWidget/selectionTint.ts` shares with the multi-cell selection — a known ground, plus an overlay
   compositing it up to the selection colour and taking the cell's content with it. The overlay hangs off the cells so
   it scrolls with a wide table; the cell borders are tinted through their colour, since an overlay grown to reach them
-  would darken each shared one twice. Both fills read `--rt-tint` and `--rt-selection-bg`, resolved once in
+  would darken each shared one twice. A gridline where a selection ends mid-table is shared by cells that disagree
+  about its colour, and CSS settles that in favour of the cell further up and left — leaving a rectangle's top and
+  left edges drawn by their unselected neighbours — so the overlay redraws those two sides itself, in the same opaque
+  tinted colour. Both fills read `--rt-tint` and `--rt-selection-bg`, resolved once in
   `tableWidget/richTableThemeVars.ts` so they can never disagree about focus. That resolution tests
   `:focus-within` rather than `.cm-focused`, which tracks only the root editor's own content: a
   nested cell editor holds focus on the plugin's behalf, most visibly through a cell drag.

--- a/docs/Architecture/Interaction-and-Navigation.md
+++ b/docs/Architecture/Interaction-and-Navigation.md
@@ -84,8 +84,14 @@ Creating a selection also hands focus to the main editor, which owns its keyboar
 commands. Every gesture that starts one suppresses the browser's own focusing — shift-click
 preventDefaults its mousedown, and a keyboard selection tears down the nested editor that held focus
 — so without this focus would sit on the document body, and the selection would render as unfocused.
-A running drag is the exception: it keeps its anchor cell's editor open for the length of the
-gesture and hands focus over on release.
+`cellSelectionController.ts` does this as it dispatches; `cellSelectionFocusPlugin` catches the
+selections it does not create, such as the multi-cell paste a transaction filter rewrites a
+cell-editor paste into, which has no view to focus with.
+
+A running drag is the exception: it leaves whatever had focus alone — a cell editor in another
+table, or something outside the editor entirely — until the rectangle is final, and hands focus over
+on release. So that the rectangle being dragged does not render unfocused and then snap, a drag in
+progress asserts the focused tint for itself, in `tableWidget/cellSelectionVisuals.ts`.
 
 ### Whole-Table Selection
 

--- a/docs/Architecture/Interaction-and-Navigation.md
+++ b/docs/Architecture/Interaction-and-Navigation.md
@@ -75,6 +75,31 @@ the rectangular selection is visible.
 
 Commands that move the main-editor caret outside the selected table clear the selection.
 
+### Whole-Table Selection
+
+A selection in the main editor covers a rendered table as a single block; it cannot address anything inside one,
+because rows and columns are the multi-cell selection's job.
+
+- `tableRuntime/selection/tableSelectionSnap.ts` filters selection-only transactions, growing any range that reaches
+  a table until it contains the whole table. Contact is enough — an endpoint resting on a table edge has been dragged
+  onto the widget, because the positions either side of a table belong to its separating blank lines. Carets,
+  document changes, raw mode, and any state where a cell editor or cell selection owns the table are left alone.
+- `tableWidget/tableSelectionHighlight.ts` marks the widget roots the selection covers end to end and paints them as
+  one selected block, switching between the focused and blurred colours with the main editor. CodeMirror's selection
+  background sits behind editor text, which a rendered table's own opaque surfaces — the header, inline code,
+  `==highlight==`, images — would stand proud of, so the highlight is layered instead: the selection colour on the
+  widget root for the padding and the strip beside a narrow table, a known ground on each cell, and an overlay that
+  composites that ground up to the selection colour, taking the cell's content with it. The overlay hangs off the
+  cells so it scrolls with a wide table.
+- `tableWidget/selectionOverlayColor.ts` solves for that overlay: the faintest layer that reproduces the selection
+  colour on the painted ground. Being faint and of the opposite tone to the text, it recolours every surface at the
+  ground's tone exactly while leaving the text legible — where the selection colour at some chosen alpha would wash
+  the text out and still not reach the opaque surfaces.
+- Painting the block ourselves also decouples the highlight from `drawSelection`, whose rects around a selected table
+  are unreliable — it measures through `coordsAtPos`, which `TableWidget.coordsAt` answers with cell rectangles. The
+  browser's native `::selection` is suppressed inside a widget for the same reason: `drawSelection` only neutralizes
+  it for text inside `.cm-line`.
+
 ## Mouse Interaction
 
 - Clicking a cell activates it or updates the current multi-cell selection.

--- a/src/contentScript/__tests__/cellSelectionKeymap.test.ts
+++ b/src/contentScript/__tests__/cellSelectionKeymap.test.ts
@@ -14,7 +14,10 @@ import { GFM } from '@lezer/markdown';
 import { activeCellField, getActiveCell, setActiveCellEffect } from '../tableState/activeCellState';
 import { setCellSelectionEffect, getCellSelection, cellSelectionField } from '../tableState/cellSelectionState';
 import { cellDragField, endCellDragEffect, startCellDragEffect } from '../tableState/cellDragState';
-import { startCellSelectionFromActiveCell } from '../tableRuntime/selection/cellSelectionController';
+import {
+    setCellDragSelection,
+    startCellSelectionFromActiveCell,
+} from '../tableRuntime/selection/cellSelectionController';
 import { cellSelectionKeyCapturePlugin } from '../tableRuntime/selection/cellSelectionKeymap';
 import { triggerOpenCellRequestEffect } from '../tableRuntime/openCellRequest';
 
@@ -562,6 +565,31 @@ describe('cellSelectionKeymap', () => {
             anchor: { section: 'body', row: 0, col: 0 },
             focus: { section: 'body', row: 0, col: 1 },
         });
+    });
+
+    it('gives the main editor focus when a cell selection starts', () => {
+        // Every gesture that starts a selection suppresses the browser's own focusing, so
+        // without this focus stays parked on the body and the selection renders as unfocused.
+        const view = mountSelectionView(['| H1 | H2 |', '| --- | --- |', '| a1 | a2 |'].join('\n'));
+        view.dispatch({
+            effects: setActiveCellEffect.of({ tableFrom: 0, section: 'body', row: 0, col: 0 }),
+        });
+        const focusSpy = vi.spyOn(view, 'focus');
+
+        expect(startCellSelectionFromActiveCell(view, 'right')).toBe(true);
+        expect(focusSpy).toHaveBeenCalled();
+    });
+
+    it('leaves focus with the anchor cell while a drag is still running', () => {
+        // The drag keeps that cell's editor open for the length of the gesture and hands focus
+        // over on release; taking it here would tear the editor down mid-gesture.
+        const view = mountSelectionView(['| H1 | H2 |', '| --- | --- |', '| a1 | a2 |'].join('\n'));
+        const focusSpy = vi.spyOn(view, 'focus');
+
+        expect(
+            setCellDragSelection(view, 0, { section: 'body', row: 0, col: 0 }, { section: 'body', row: 0, col: 1 })
+        ).toBe(true);
+        expect(focusSpy).not.toHaveBeenCalled();
     });
 
     it('does not start cell selection from a stale active cell', () => {

--- a/src/contentScript/__tests__/cellSelectionKeymap.test.ts
+++ b/src/contentScript/__tests__/cellSelectionKeymap.test.ts
@@ -15,6 +15,7 @@ import { activeCellField, getActiveCell, setActiveCellEffect } from '../tableSta
 import { setCellSelectionEffect, getCellSelection, cellSelectionField } from '../tableState/cellSelectionState';
 import { cellDragField, endCellDragEffect, startCellDragEffect } from '../tableState/cellDragState';
 import {
+    cellSelectionFocusPlugin,
     setCellDragSelection,
     startCellSelectionFromActiveCell,
 } from '../tableRuntime/selection/cellSelectionController';
@@ -30,6 +31,13 @@ const GRID_DOC = ['| H1 | H2 | H3 |', '| --- | --- | --- |', '| a1 | a2 | a3 |',
 
 const mountedViews: EditorView[] = [];
 
+/** Waits for CodeMirror's measure cycle, which it schedules on an animation frame. */
+function flushMeasure(): Promise<void> {
+    return new Promise((resolve) => {
+        requestAnimationFrame(() => resolve());
+    });
+}
+
 function mountSelectionView(doc: string): EditorView {
     const parent = document.createElement('div');
     document.body.appendChild(parent);
@@ -43,6 +51,7 @@ function mountSelectionView(doc: string): EditorView {
             cellSelectionField,
             cellDragField,
             cellSelectionKeyCapturePlugin,
+            cellSelectionFocusPlugin,
         ],
         doc,
     });
@@ -580,9 +589,9 @@ describe('cellSelectionKeymap', () => {
         expect(focusSpy).toHaveBeenCalled();
     });
 
-    it('leaves focus with the anchor cell while a drag is still running', () => {
-        // The drag keeps that cell's editor open for the length of the gesture and hands focus
-        // over on release; taking it here would tear the editor down mid-gesture.
+    it('leaves focus alone while a drag is still running', () => {
+        // A drag does not disturb whatever had focus until the rectangle is final, and hands
+        // focus over itself on release.
         const view = mountSelectionView(['| H1 | H2 |', '| --- | --- |', '| a1 | a2 |'].join('\n'));
         const focusSpy = vi.spyOn(view, 'focus');
 
@@ -590,6 +599,25 @@ describe('cellSelectionKeymap', () => {
             setCellDragSelection(view, 0, { section: 'body', row: 0, col: 0 }, { section: 'body', row: 0, col: 1 })
         ).toBe(true);
         expect(focusSpy).not.toHaveBeenCalled();
+    });
+
+    it('takes focus for a cell selection created outside the controller', async () => {
+        // A paste inside a cell editor becomes a multi-cell paste in a transaction filter, which
+        // has no view to focus with, so the selection arrives with focus on the document body.
+        const view = mountSelectionView(['| H1 | H2 |', '| --- | --- |', '| a1 | a2 |'].join('\n'));
+        const focusSpy = vi.spyOn(view, 'focus');
+
+        view.dispatch({
+            effects: setCellSelectionEffect.of({
+                tableFrom: 0,
+                anchor: { section: 'body', row: 0, col: 0 },
+                focus: { section: 'body', row: 0, col: 1 },
+            }),
+        });
+        expect(focusSpy).not.toHaveBeenCalled();
+
+        await flushMeasure();
+        expect(focusSpy).toHaveBeenCalled();
     });
 
     it('does not start cell selection from a stale active cell', () => {

--- a/src/contentScript/__tests__/cellSelectionVisuals.test.ts
+++ b/src/contentScript/__tests__/cellSelectionVisuals.test.ts
@@ -7,7 +7,8 @@ import { EditorView } from '@codemirror/view';
 import { GFM } from '@lezer/markdown';
 import { afterEach, describe, expect, it } from 'vitest';
 import { cellSelectionField, clearCellSelectionEffect, setCellSelectionEffect } from '../tableState/cellSelectionState';
-import { cellSelectionCaretSuppression } from '../tableWidget/cellSelectionVisuals';
+import { cellDragField, endCellDragEffect, startCellDragEffect } from '../tableState/cellDragState';
+import { cellSelectionCaretSuppression, cellSelectionVisuals } from '../tableWidget/cellSelectionVisuals';
 
 const TABLE = ['| H1 | H2 |', '| --- | --- |', '| a1 | a2 |'].join('\n');
 const DOC = `above\n${TABLE}\nbelow`;
@@ -22,7 +23,13 @@ function mountView(): EditorView {
     const view = new EditorView({
         parent,
         doc: DOC,
-        extensions: [markdown({ extensions: [GFM] }), cellSelectionField, cellSelectionCaretSuppression],
+        extensions: [
+            markdown({ extensions: [GFM] }),
+            cellSelectionField,
+            cellDragField,
+            cellSelectionCaretSuppression,
+            cellSelectionVisuals,
+        ],
     });
     mountedViews.push(view);
 
@@ -52,5 +59,29 @@ describe('cellSelectionCaretSuppression', () => {
 
         view.dispatch({ effects: clearCellSelectionEffect.of(undefined) });
         expect(view.dom.hasAttribute('data-rt-cell-selection')).toBe(false);
+    });
+});
+
+describe('cell drag focus override', () => {
+    it('marks the editor while a drag sweeps out a rectangle and unmarks it afterwards', () => {
+        // The fill follows the editor's focus, but a drag leaves focus wherever it was until the
+        // rectangle is final — so the gesture in progress has to assert focus for itself.
+        const view = mountView();
+        // A drag cannot outlive the selection it is sweeping out, so it only reads as in progress
+        // alongside one.
+        view.dispatch({
+            effects: setCellSelectionEffect.of({
+                tableFrom: TABLE_FROM,
+                anchor: { section: 'body', row: 0, col: 0 },
+                focus: { section: 'body', row: 0, col: 1 },
+            }),
+        });
+        expect(view.dom.hasAttribute('data-rt-cell-drag')).toBe(false);
+
+        view.dispatch({ effects: startCellDragEffect.of(undefined) });
+        expect(view.dom.hasAttribute('data-rt-cell-drag')).toBe(true);
+
+        view.dispatch({ effects: endCellDragEffect.of(undefined) });
+        expect(view.dom.hasAttribute('data-rt-cell-drag')).toBe(false);
     });
 });

--- a/src/contentScript/__tests__/selectionClassSync.test.ts
+++ b/src/contentScript/__tests__/selectionClassSync.test.ts
@@ -14,7 +14,7 @@ import {
 import { cellSelectionVisuals } from '../tableWidget/cellSelectionVisuals';
 import { CLASS_CELL_SELECTED, CLASS_TABLE_WIDGET_SELECTED, getWidgetSelector } from '../tableWidget/domHelpers';
 import { tableDecorationField } from '../tableWidget/tableDecorationField';
-import { tableSelectionHighlight } from '../tableWidget/tableSelectionHighlight';
+import { wholeTableSelectionVisuals } from '../tableWidget/wholeTableSelectionVisuals';
 import { createMarkdownState } from './testMarkdownState';
 
 class ResizeObserverMock {
@@ -54,7 +54,7 @@ function mountView(): EditorView {
             cellDragField,
             tableDecorationField,
             cellSelectionVisuals,
-            tableSelectionHighlight,
+            wholeTableSelectionVisuals,
         ]),
     });
     mountedViews.push(view);

--- a/src/contentScript/__tests__/selectionClassSync.test.ts
+++ b/src/contentScript/__tests__/selectionClassSync.test.ts
@@ -1,0 +1,141 @@
+/** @vitest-environment jsdom */
+
+import { EditorSelection } from '@codemirror/state';
+import { EditorView } from '@codemirror/view';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { markdownRenderServiceFacet } from '../services/markdownRenderer';
+import { cellDragField } from '../tableState/cellDragState';
+import {
+    cellSelectionField,
+    clearCellSelectionEffect,
+    setCellSelectionEffect,
+    type CellSelection,
+} from '../tableState/cellSelectionState';
+import { cellSelectionVisuals } from '../tableWidget/cellSelectionVisuals';
+import { CLASS_CELL_SELECTED, CLASS_TABLE_WIDGET_SELECTED, getWidgetSelector } from '../tableWidget/domHelpers';
+import { tableDecorationField } from '../tableWidget/tableDecorationField';
+import { tableSelectionHighlight } from '../tableWidget/tableSelectionHighlight';
+import { createMarkdownState } from './testMarkdownState';
+
+class ResizeObserverMock {
+    observe = vi.fn();
+    disconnect = vi.fn();
+}
+
+const TABLE = ['| H1 | H2 |', '| --- | --- |', '| a1 | a2 |'].join('\n');
+const PREFIX = 'above\n\n';
+const DOC = `${PREFIX}${TABLE}\n\nbelow`;
+const TABLE_FROM = PREFIX.length;
+const TABLE_TO = TABLE_FROM + TABLE.length;
+const EDIT_FROM = DOC.indexOf('a1');
+const EDIT_INSERT = 'changed';
+
+const BODY_ROW_SELECTION: CellSelection = {
+    tableFrom: TABLE_FROM,
+    anchor: { section: 'body', row: 0, col: 0 },
+    focus: { section: 'body', row: 0, col: 1 },
+};
+
+const mountedViews: EditorView[] = [];
+
+function mountView(): EditorView {
+    const parent = document.createElement('div');
+    document.body.appendChild(parent);
+
+    const view = new EditorView({
+        parent,
+        state: createMarkdownState(DOC, [
+            markdownRenderServiceFacet.of({
+                getCached: vi.fn(() => undefined),
+                render: vi.fn(async () => ''),
+                clear: vi.fn(),
+            }),
+            cellSelectionField,
+            cellDragField,
+            tableDecorationField,
+            cellSelectionVisuals,
+            tableSelectionHighlight,
+        ]),
+    });
+    mountedViews.push(view);
+    return view;
+}
+
+/** Resolves after every measure already queued on the view has written its DOM changes. */
+function flushMeasure(view: EditorView): Promise<void> {
+    return new Promise((resolve) => {
+        view.requestMeasure({
+            read: () => undefined,
+            write: () => resolve(),
+        });
+    });
+}
+
+function getWidget(view: EditorView): HTMLElement {
+    const widget = view.contentDOM.querySelector<HTMLElement>(getWidgetSelector());
+    if (!widget) {
+        throw new Error('Expected a rendered table widget');
+    }
+    return widget;
+}
+
+beforeEach(() => {
+    vi.stubGlobal('ResizeObserver', ResizeObserverMock as unknown as typeof ResizeObserver);
+});
+
+afterEach(() => {
+    while (mountedViews.length > 0) {
+        mountedViews.pop()?.destroy();
+    }
+    document.body.replaceChildren();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+});
+
+describe('selection class synchronization', () => {
+    it('marks selected cells, removes the marks, and reapplies them to replacement widget DOM', async () => {
+        const view = mountView();
+
+        view.dispatch({ effects: setCellSelectionEffect.of(BODY_ROW_SELECTION) });
+        await flushMeasure(view);
+
+        const originalWidget = getWidget(view);
+        expect(originalWidget.querySelectorAll(`.${CLASS_CELL_SELECTED}`)).toHaveLength(2);
+
+        view.dispatch({ effects: clearCellSelectionEffect.of(undefined) });
+        await flushMeasure(view);
+        expect(originalWidget.querySelectorAll(`.${CLASS_CELL_SELECTED}`)).toHaveLength(0);
+
+        view.dispatch({
+            changes: { from: EDIT_FROM, to: EDIT_FROM + 2, insert: EDIT_INSERT },
+            effects: setCellSelectionEffect.of(BODY_ROW_SELECTION),
+        });
+        await flushMeasure(view);
+
+        const replacementWidget = getWidget(view);
+        expect(replacementWidget).not.toBe(originalWidget);
+        expect(replacementWidget.querySelectorAll(`.${CLASS_CELL_SELECTED}`)).toHaveLength(2);
+    });
+
+    it('marks a wholly selected table, removes the mark, and reapplies it after widget replacement', async () => {
+        const view = mountView();
+
+        view.dispatch({ selection: EditorSelection.single(TABLE_FROM, TABLE_TO) });
+        await flushMeasure(view);
+
+        const originalWidget = getWidget(view);
+        expect(originalWidget.classList.contains(CLASS_TABLE_WIDGET_SELECTED)).toBe(true);
+
+        view.dispatch({ selection: EditorSelection.single(0) });
+        await flushMeasure(view);
+        expect(originalWidget.classList.contains(CLASS_TABLE_WIDGET_SELECTED)).toBe(false);
+
+        view.dispatch({ selection: EditorSelection.single(TABLE_FROM, TABLE_TO) });
+        view.dispatch({ changes: { from: EDIT_FROM, to: EDIT_FROM + 2, insert: EDIT_INSERT } });
+        await flushMeasure(view);
+
+        const replacementWidget = getWidget(view);
+        expect(replacementWidget).not.toBe(originalWidget);
+        expect(replacementWidget.classList.contains(CLASS_TABLE_WIDGET_SELECTED)).toBe(true);
+    });
+});

--- a/src/contentScript/__tests__/selectionOverlayColor.test.ts
+++ b/src/contentScript/__tests__/selectionOverlayColor.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { alphaEquivalentLayer, parseHexColor, toCssColor, type Rgb } from '../tableWidget/selectionOverlayColor';
+import {
+    alphaEquivalentLayer,
+    parseHexColor,
+    toPercentageCss,
+    toRgbCss,
+    type Rgb,
+} from '../tableWidget/selectionOverlayColor';
 
 const WHITE: Rgb = { r: 255, g: 255, b: 255 };
 
@@ -58,7 +64,9 @@ describe('alphaEquivalentLayer', () => {
         expect(alphaEquivalentLayer(WHITE, WHITE)).toEqual({ color: WHITE, alpha: 0 });
     });
 
-    it('renders as a CSS rgba colour', () => {
-        expect(toCssColor({ color: { r: 18, g: 0, b: 166 }, alpha: 0.1686 })).toBe('rgba(18, 0, 166, 0.1686)');
+    it('renders the colour and its alpha as separate CSS values', () => {
+        expect(toRgbCss({ r: 18, g: 0, b: 166 })).toBe('rgb(18, 0, 166)');
+        expect(toPercentageCss(0.1687)).toBe('16.87%');
+        expect(toPercentageCss(0.15)).toBe('15%');
     });
 });

--- a/src/contentScript/__tests__/selectionOverlayColor.test.ts
+++ b/src/contentScript/__tests__/selectionOverlayColor.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { alphaEquivalentLayer, parseHexColor, toCssColor, type Rgb } from '../tableWidget/selectionOverlayColor';
+
+const WHITE: Rgb = { r: 255, g: 255, b: 255 };
+
+/** Composites a layer over a ground, the way a browser paints it. */
+function composite(target: Rgb, ground: Rgb): Rgb {
+    const { color, alpha } = alphaEquivalentLayer(target, ground);
+    const blend = (layerChannel: number, groundChannel: number): number =>
+        Math.round(alpha * layerChannel + (1 - alpha) * groundChannel);
+
+    return {
+        r: blend(color.r, ground.r),
+        g: blend(color.g, ground.g),
+        b: blend(color.b, ground.b),
+    };
+}
+
+describe('parseHexColor', () => {
+    it('unpacks a #rrggbb colour', () => {
+        expect(parseHexColor('#d7d4f0')).toEqual({ r: 215, g: 212, b: 240 });
+    });
+
+    it('rejects anything that is not a six-digit hex colour', () => {
+        expect(() => parseHexColor('#fff')).toThrow(RangeError);
+        expect(() => parseHexColor('rgb(1 2 3)')).toThrow(RangeError);
+    });
+});
+
+describe('alphaEquivalentLayer', () => {
+    it('reproduces the target when composited back over the ground', () => {
+        const cases: [Rgb, Rgb][] = [
+            [parseHexColor('#d7d4f0'), WHITE],
+            [parseHexColor('#d9d9d9'), WHITE],
+            [parseHexColor('#6b6b6b'), parseHexColor('#1d2024')],
+            [parseHexColor('#444444'), parseHexColor('#1d2024')],
+        ];
+
+        for (const [target, ground] of cases) {
+            expect(composite(target, ground)).toEqual(target);
+        }
+    });
+
+    it('stays faint enough to leave text of the opposite tone legible', () => {
+        // Lightening a white ground to Joplin's light selection colour needs 17%; every channel
+        // has to travel at most 40/255, so a heavier layer would only dim the text further.
+        expect(alphaEquivalentLayer(parseHexColor('#d7d4f0'), WHITE).alpha).toBeCloseTo(0.169, 3);
+    });
+
+    it('comes out dark to darken a ground and light to lighten one', () => {
+        expect(alphaEquivalentLayer(parseHexColor('#d7d4f0'), WHITE).color).toMatchObject({ r: 18, g: 0 });
+        expect(alphaEquivalentLayer(parseHexColor('#6b6b6b'), parseHexColor('#1d2024')).color).toMatchObject({
+            r: 255,
+        });
+    });
+
+    it('describes a ground that already is the target as a fully transparent layer', () => {
+        expect(alphaEquivalentLayer(WHITE, WHITE)).toEqual({ color: WHITE, alpha: 0 });
+    });
+
+    it('renders as a CSS rgba colour', () => {
+        expect(toCssColor({ color: { r: 18, g: 0, b: 166 }, alpha: 0.1686 })).toBe('rgba(18, 0, 166, 0.1686)');
+    });
+});

--- a/src/contentScript/__tests__/tableSelectionHighlight.test.ts
+++ b/src/contentScript/__tests__/tableSelectionHighlight.test.ts
@@ -1,0 +1,111 @@
+import { EditorSelection, EditorState } from '@codemirror/state';
+import { describe, expect, it } from 'vitest';
+import { sourceModeField, toggleSourceModeEffect } from '../tableState/sourceMode';
+import {
+    findRenderedTablesTouching,
+    findRenderedTablesWithin,
+    tableDecorationField,
+} from '../tableWidget/tableDecorationField';
+import { findSelectedTableSpans } from '../tableWidget/tableSelectionHighlight';
+import { createMarkdownState } from './testMarkdownState';
+
+const FIRST_TABLE = ['| H1 | H2 |', '| --- | --- |', '| a1 | a2 |'].join('\n');
+const SECOND_TABLE = ['| H3 | H4 |', '| --- | --- |', '| b1 | b2 |'].join('\n');
+const ABOVE = 'above';
+const BETWEEN = 'between';
+const DOC = `${ABOVE}\n\n${FIRST_TABLE}\n\n${BETWEEN}\n\n${SECOND_TABLE}\n\nbelow`;
+
+const FIRST_FROM = ABOVE.length + 2;
+const FIRST_TO = FIRST_FROM + FIRST_TABLE.length;
+const SECOND_FROM = FIRST_TO + BETWEEN.length + 4;
+const SECOND_TO = SECOND_FROM + SECOND_TABLE.length;
+
+function createState(selection?: EditorSelection) {
+    const state = createMarkdownState(DOC, [
+        tableDecorationField,
+        sourceModeField,
+        EditorState.allowMultipleSelections.of(true),
+    ]);
+    return selection ? state.update({ selection }).state : state;
+}
+
+describe('rendered table lookups', () => {
+    it('reports the document ranges of the rendered tables', () => {
+        expect(findRenderedTablesWithin(createState(), 0, DOC.length)).toEqual([
+            { from: FIRST_FROM, to: FIRST_TO },
+            { from: SECOND_FROM, to: SECOND_TO },
+        ]);
+    });
+
+    it('excludes a table the range only partly covers', () => {
+        expect(findRenderedTablesWithin(createState(), 0, FIRST_TO - 1)).toEqual([]);
+    });
+
+    it('reports a table a range only reaches into', () => {
+        expect(findRenderedTablesTouching(createState(), 0, FIRST_FROM + 3)).toEqual([
+            { from: FIRST_FROM, to: FIRST_TO },
+        ]);
+    });
+
+    it('counts a range stopping on either table edge as touching it', () => {
+        expect(findRenderedTablesTouching(createState(), 0, FIRST_FROM)).toEqual([{ from: FIRST_FROM, to: FIRST_TO }]);
+        expect(findRenderedTablesTouching(createState(), FIRST_TO, DOC.length)).toEqual([
+            { from: FIRST_FROM, to: FIRST_TO },
+            { from: SECOND_FROM, to: SECOND_TO },
+        ]);
+    });
+
+    it('reports no table for a range that stops short of one', () => {
+        expect(findRenderedTablesTouching(createState(), 0, FIRST_FROM - 1)).toEqual([]);
+    });
+
+    it('finds nothing in raw mode, where no table is rendered as a widget', () => {
+        const rawMode = createState().update({ effects: toggleSourceModeEffect.of(true) }).state;
+
+        expect(findRenderedTablesWithin(rawMode, 0, DOC.length)).toEqual([]);
+        expect(findRenderedTablesTouching(rawMode, 0, DOC.length)).toEqual([]);
+    });
+});
+
+describe('findSelectedTableSpans', () => {
+    it('reports a table the selection covers end to end', () => {
+        const state = createState(EditorSelection.single(0, FIRST_TO));
+
+        expect(findSelectedTableSpans(state)).toEqual([{ from: FIRST_FROM, to: FIRST_TO }]);
+    });
+
+    it('reports every covered table when the selection spans several', () => {
+        const state = createState(EditorSelection.single(0, DOC.length));
+
+        expect(findSelectedTableSpans(state)).toEqual([
+            { from: FIRST_FROM, to: FIRST_TO },
+            { from: SECOND_FROM, to: SECOND_TO },
+        ]);
+    });
+
+    it('reports nothing for a selection that stops short of a table end', () => {
+        const state = createState(EditorSelection.single(0, FIRST_TO - 1));
+
+        expect(findSelectedTableSpans(state)).toEqual([]);
+    });
+
+    it('reports nothing for a caret', () => {
+        const state = createState(EditorSelection.single(FIRST_FROM));
+
+        expect(findSelectedTableSpans(state)).toEqual([]);
+    });
+
+    it('collects tables covered by separate ranges of a multi-range selection', () => {
+        const state = createState(
+            EditorSelection.create([
+                EditorSelection.range(FIRST_FROM, FIRST_TO),
+                EditorSelection.range(SECOND_FROM, SECOND_TO),
+            ])
+        );
+
+        expect(findSelectedTableSpans(state)).toEqual([
+            { from: FIRST_FROM, to: FIRST_TO },
+            { from: SECOND_FROM, to: SECOND_TO },
+        ]);
+    });
+});

--- a/src/contentScript/__tests__/tableSelectionSnap.test.ts
+++ b/src/contentScript/__tests__/tableSelectionSnap.test.ts
@@ -1,0 +1,157 @@
+import { EditorSelection, EditorState } from '@codemirror/state';
+import { describe, expect, it } from 'vitest';
+import { sourceModeField, toggleSourceModeEffect } from '../tableState/sourceMode';
+import { activeCellField, setActiveCellEffect } from '../tableState/activeCellState';
+import { tableDecorationField, type TableSpan } from '../tableWidget/tableDecorationField';
+import { snapSelectionAroundTables, tableSelectionSnapFilter } from '../tableRuntime/selection/tableSelectionSnap';
+import { createMarkdownState } from './testMarkdownState';
+
+const TABLE = ['| H1 | H2 |', '| --- | --- |', '| a1 | a2 |'].join('\n');
+const ABOVE = 'above';
+const DOC = `${ABOVE}\n\n${TABLE}\n\nbelow`;
+const TABLE_FROM = ABOVE.length + 2;
+const TABLE_TO = TABLE_FROM + TABLE.length;
+const INSIDE_TABLE = TABLE_FROM + 4;
+
+function createState(): EditorState {
+    return createMarkdownState(DOC, [tableDecorationField, sourceModeField, activeCellField, tableSelectionSnapFilter]);
+}
+
+function select(state: EditorState, selection: EditorSelection): EditorState {
+    return state.update({ selection, userEvent: 'select' }).state;
+}
+
+describe('snapSelectionAroundTables', () => {
+    const table: TableSpan = { from: 10, to: 20 };
+    const findTablesTouching = (from: number, to: number): TableSpan[] =>
+        from <= table.to && to >= table.from ? [table] : [];
+
+    it('grows a forward selection ending inside a table to the table end', () => {
+        const snapped = snapSelectionAroundTables(EditorSelection.single(5, 15), findTablesTouching);
+
+        expect(snapped?.main).toMatchObject({ anchor: 5, head: 20 });
+    });
+
+    it('grows a backward selection ending inside a table to the table start', () => {
+        const snapped = snapSelectionAroundTables(EditorSelection.single(25, 15), findTablesTouching);
+
+        expect(snapped?.main).toMatchObject({ anchor: 25, head: 10 });
+    });
+
+    it('grows a selection that starts inside a table to the table start', () => {
+        const snapped = snapSelectionAroundTables(EditorSelection.single(15, 25), findTablesTouching);
+
+        expect(snapped?.main).toMatchObject({ anchor: 10, head: 25 });
+    });
+
+    it('expands a selection contained entirely within a table to the whole table', () => {
+        const snapped = snapSelectionAroundTables(EditorSelection.single(12, 16), findTablesTouching);
+
+        expect(snapped?.main).toMatchObject({ anchor: 10, head: 20 });
+    });
+
+    it('swallows the table as soon as a selection reaches its near edge', () => {
+        expect(snapSelectionAroundTables(EditorSelection.single(5, 10), findTablesTouching)?.main).toMatchObject({
+            anchor: 5,
+            head: 20,
+        });
+        expect(snapSelectionAroundTables(EditorSelection.single(25, 20), findTablesTouching)?.main).toMatchObject({
+            anchor: 25,
+            head: 10,
+        });
+    });
+
+    it('leaves a selection that already spans the whole table alone', () => {
+        expect(snapSelectionAroundTables(EditorSelection.single(5, 25), findTablesTouching)).toBeNull();
+        expect(snapSelectionAroundTables(EditorSelection.single(10, 20), findTablesTouching)).toBeNull();
+    });
+
+    it('leaves a selection that never reaches the table alone', () => {
+        expect(snapSelectionAroundTables(EditorSelection.single(2, 8), findTablesTouching)).toBeNull();
+    });
+
+    it('leaves a caret inside a table alone', () => {
+        expect(snapSelectionAroundTables(EditorSelection.single(15), findTablesTouching)).toBeNull();
+    });
+
+    it('snaps every range of a multi-range selection', () => {
+        const snapped = snapSelectionAroundTables(
+            EditorSelection.create([EditorSelection.range(0, 2), EditorSelection.range(5, 15)], 1),
+            findTablesTouching
+        );
+
+        expect(snapped?.ranges.map((range) => [range.from, range.to])).toEqual([
+            [0, 2],
+            [5, 20],
+        ]);
+        expect(snapped?.mainIndex).toBe(1);
+    });
+});
+
+describe('tableSelectionSnapFilter', () => {
+    it('grows a selection that stops inside a rendered table', () => {
+        const state = select(createState(), EditorSelection.single(0, INSIDE_TABLE));
+
+        expect(state.selection.main).toMatchObject({ anchor: 0, head: TABLE_TO });
+    });
+
+    it('grows a selection that only reaches the table start', () => {
+        const state = select(createState(), EditorSelection.single(0, TABLE_FROM));
+
+        expect(state.selection.main).toMatchObject({ anchor: 0, head: TABLE_TO });
+    });
+
+    it('keeps the user event so other policies still classify the transaction', () => {
+        const transaction = createState().update({
+            selection: EditorSelection.single(0, INSIDE_TABLE),
+            userEvent: 'select.pointer',
+        });
+
+        expect(transaction.isUserEvent('select.pointer')).toBe(true);
+    });
+
+    it('snaps a selection change that carries no user event', () => {
+        const state = createState().update({ selection: EditorSelection.single(0, INSIDE_TABLE) }).state;
+
+        expect(state.selection.main.head).toBe(TABLE_TO);
+    });
+
+    it('leaves a selection covering the whole table unchanged', () => {
+        const state = select(createState(), EditorSelection.single(0, TABLE_TO));
+
+        expect(state.selection.main).toMatchObject({ anchor: 0, head: TABLE_TO });
+    });
+
+    it('ignores selections while a cell editor owns the table', () => {
+        const withActiveCell = createState().update({
+            effects: setActiveCellEffect.of({
+                tableFrom: TABLE_FROM,
+                section: 'header',
+                row: 0,
+                col: 0,
+            }),
+        }).state;
+
+        const state = select(withActiveCell, EditorSelection.single(INSIDE_TABLE, INSIDE_TABLE + 1));
+
+        expect(state.selection.main).toMatchObject({ anchor: INSIDE_TABLE, head: INSIDE_TABLE + 1 });
+    });
+
+    it('ignores selections in raw mode, where the Markdown is the visible text', () => {
+        const rawMode = createState().update({ effects: toggleSourceModeEffect.of(true) }).state;
+
+        const state = select(rawMode, EditorSelection.single(0, INSIDE_TABLE));
+
+        expect(state.selection.main.head).toBe(INSIDE_TABLE);
+    });
+
+    it('leaves document changes to the editing policies', () => {
+        const state = createState().update({
+            changes: { from: 0, to: 0, insert: 'x' },
+            selection: EditorSelection.single(0, INSIDE_TABLE + 1),
+            userEvent: 'select',
+        }).state;
+
+        expect(state.selection.main.head).toBe(INSIDE_TABLE + 1);
+    });
+});

--- a/src/contentScript/__tests__/tableSelectionSnap.test.ts
+++ b/src/contentScript/__tests__/tableSelectionSnap.test.ts
@@ -1,4 +1,4 @@
-import { EditorSelection, EditorState } from '@codemirror/state';
+import { Annotation, EditorSelection, EditorState } from '@codemirror/state';
 import { describe, expect, it } from 'vitest';
 import { sourceModeField, toggleSourceModeEffect } from '../tableState/sourceMode';
 import { activeCellField, setActiveCellEffect } from '../tableState/activeCellState';
@@ -108,6 +108,17 @@ describe('tableSelectionSnapFilter', () => {
         });
 
         expect(transaction.isUserEvent('select.pointer')).toBe(true);
+    });
+
+    it('preserves arbitrary transaction annotations while snapping', () => {
+        const marker = Annotation.define<string>();
+        const transaction = createState().update({
+            selection: EditorSelection.single(0, INSIDE_TABLE),
+            annotations: marker.of('preserved'),
+        });
+
+        expect(transaction.annotation(marker)).toBe('preserved');
+        expect(transaction.newSelection.main.head).toBe(TABLE_TO);
     });
 
     it('snaps a selection change that carries no user event', () => {

--- a/src/contentScript/__tests__/wholeTableSelectionVisuals.test.ts
+++ b/src/contentScript/__tests__/wholeTableSelectionVisuals.test.ts
@@ -6,7 +6,7 @@ import {
     findRenderedTablesWithin,
     tableDecorationField,
 } from '../tableWidget/tableDecorationField';
-import { findSelectedTableSpans } from '../tableWidget/tableSelectionHighlight';
+import { findSelectedTableSpans } from '../tableWidget/wholeTableSelectionVisuals';
 import { createMarkdownState } from './testMarkdownState';
 
 const FIRST_TABLE = ['| H1 | H2 |', '| --- | --- |', '| a1 | a2 |'].join('\n');

--- a/src/contentScript/nestedEditor/nestedEditorTheme.ts
+++ b/src/contentScript/nestedEditor/nestedEditorTheme.ts
@@ -26,10 +26,10 @@ export function createNestedEditorTheme(isDarkTheme: boolean): Extension {
             // rootEditorSelectionTheme.ts, which has higher specificity than Joplin's
             // cascading `&.cm-focused ::selection` rule.
             '& .cm-selectionLayer .cm-selectionBackground': {
-                backgroundColor: 'var(--rt-nested-selection-blurred-bg) !important',
+                backgroundColor: 'var(--rt-selection-blurred-bg) !important',
             },
             '&.cm-focused > .cm-scroller > .cm-selectionLayer .cm-selectionBackground': {
-                backgroundColor: 'var(--rt-nested-selection-bg) !important',
+                backgroundColor: 'var(--rt-selection-focused-bg) !important',
             },
 
             // --- Joplin/CM environment resets ---

--- a/src/contentScript/tableRuntime/selection/cellSelectionController.ts
+++ b/src/contentScript/tableRuntime/selection/cellSelectionController.ts
@@ -1,5 +1,5 @@
 import { EditorSelection, type StateEffect } from '@codemirror/state';
-import type { EditorView } from '@codemirror/view';
+import { ViewPlugin, type EditorView, type ViewUpdate } from '@codemirror/view';
 import { clearActiveCellEffect } from '../../tableState/activeCellState';
 import {
     cellSelectionTransitionAnnotation,
@@ -44,6 +44,54 @@ function clampSelectionFocus(view: EditorView, tableFrom: number, focus: CellCoo
     return clampSelectionFocusWithinContext(ctx, focus);
 }
 
+/**
+ * Hands focus to the main editor for a cell selection it does not already hold.
+ *
+ * The main editor owns a cell selection's keyboard and clipboard commands, but none of the
+ * gestures that create one leave focus there: shift-click preventDefaults its mousedown, and a
+ * keyboard selection tears down the nested editor that had focus. Focus would otherwise sit on
+ * the document body — workable, since `cellSelectionShortcutScope` treats that as soft focus, but
+ * it reads as an unfocused selection.
+ *
+ * A running drag is the exception: it does not disturb whatever had focus until the rectangle is
+ * final, and hands focus over itself on release. `cellSelectionVisuals.ts` keeps the selection
+ * looking focused meanwhile, so nothing is gained by taking it early.
+ */
+function focusMainEditorForCellSelection(view: EditorView): void {
+    if (getCellSelection(view.state) && !isCellDragInProgress(view.state) && !view.hasFocus) {
+        view.focus();
+    }
+}
+
+/**
+ * Catches cell selections created outside this module.
+ *
+ * A paste inside a cell editor is rewritten into a multi-cell one by
+ * `editorBridge/mainEditorGuard.ts`, and a transaction filter has neither a view to focus nor any
+ * business running a side effect — so the selection arrives with focus still on the torn-down
+ * nested editor's former home.
+ *
+ * The work waits for the measure phase because view plugins update before CodeMirror redraws, and
+ * focusing writes the DOM selection, which has to happen against the new DOM. Selections this
+ * module dispatched have taken focus synchronously by then, so this finds nothing left to do and
+ * they never render unfocused for a frame.
+ */
+export const cellSelectionFocusPlugin = ViewPlugin.fromClass(
+    class {
+        update(update: ViewUpdate): void {
+            const appeared = !getCellSelection(update.startState) && getCellSelection(update.state);
+            if (!appeared) {
+                return;
+            }
+
+            update.view.requestMeasure({
+                read: () => undefined,
+                write: (_measured, view) => focusMainEditorForCellSelection(view),
+            });
+        }
+    }
+);
+
 interface SelectionDispatchOptions {
     clearActiveCell: boolean;
     scrollFocusIntoView?: boolean;
@@ -80,15 +128,7 @@ function dispatchSelectionWithContext(
         scrollIntoView: false,
     });
 
-    // The main editor owns a cell selection's keyboard and clipboard commands, so it takes focus
-    // for one. The gestures that create a selection all suppress the browser's own focusing —
-    // shift-click preventDefaults its mousedown, and a keyboard selection tears down the nested
-    // editor that had focus — which would otherwise leave focus parked on the document body.
-    // A running drag is the exception: it keeps its anchor cell's editor open for the length of
-    // the gesture, and hands focus over itself on release.
-    if (!isCellDragInProgress(view.state) && !view.hasFocus) {
-        view.focus();
-    }
+    focusMainEditorForCellSelection(view);
 
     const cellElement =
         (options.scrollFocusIntoView ?? true) ? findCellElement(view, makeTableId(ctx.from), selection.focus) : null;

--- a/src/contentScript/tableRuntime/selection/cellSelectionController.ts
+++ b/src/contentScript/tableRuntime/selection/cellSelectionController.ts
@@ -19,7 +19,7 @@ import { resolveCellDocRange, resolveTableContextAtPos } from '../tableResolutio
 import { isSameCellCoords, makeTableId, type CellCoords } from '../../tableModel/types';
 import { findCellElement } from '../../tableWidget/domHelpers';
 import { createResolvedActiveCell, getResolvedActiveCell } from '../activeCell/resolvedActiveCell';
-import { endCellDragEffect, startCellDragEffect } from '../../tableState/cellDragState';
+import { endCellDragEffect, isCellDragInProgress, startCellDragEffect } from '../../tableState/cellDragState';
 import { exitTableToAdjacentLine, type TableExitSide } from '../navigation/tableExit';
 import { requestOpenCell } from '../openCellRequest';
 
@@ -79,6 +79,16 @@ function dispatchSelectionWithContext(
         annotations: cellSelectionTransitionAnnotation.of(true),
         scrollIntoView: false,
     });
+
+    // The main editor owns a cell selection's keyboard and clipboard commands, so it takes focus
+    // for one. The gestures that create a selection all suppress the browser's own focusing —
+    // shift-click preventDefaults its mousedown, and a keyboard selection tears down the nested
+    // editor that had focus — which would otherwise leave focus parked on the document body.
+    // A running drag is the exception: it keeps its anchor cell's editor open for the length of
+    // the gesture, and hands focus over itself on release.
+    if (!isCellDragInProgress(view.state) && !view.hasFocus) {
+        view.focus();
+    }
 
     const cellElement =
         (options.scrollFocusIntoView ?? true) ? findCellElement(view, makeTableId(ctx.from), selection.focus) : null;

--- a/src/contentScript/tableRuntime/selection/tableSelectionSnap.ts
+++ b/src/contentScript/tableRuntime/selection/tableSelectionSnap.ts
@@ -1,4 +1,4 @@
-import { EditorSelection, EditorState, Transaction, type Extension, type SelectionRange } from '@codemirror/state';
+import { EditorSelection, EditorState, type Extension, type SelectionRange } from '@codemirror/state';
 import { findRenderedTablesTouching, type TableSpan } from '../../tableWidget/tableDecorationField';
 import { hasPlainRenderedTableCaret } from '../renderedTableCaret';
 
@@ -66,8 +66,8 @@ export function snapSelectionAroundTables(
  * Document changes are left alone too. This exists for selection gestures, which never carry
  * one, and an edit that rewrites a table has its own policies deciding where the caret lands.
  *
- * Replacing the transaction drops its annotations, so the user event is put back; other runtime
- * policies classify transactions by it.
+ * The original transaction stays first in the returned specs so every annotation and effect it
+ * carries survives. The second, sequential spec only replaces its selection with the snapped one.
  */
 export const tableSelectionSnapFilter: Extension = EditorState.transactionFilter.of((tr) => {
     if (tr.docChanged || !tr.selection || !hasPlainRenderedTableCaret(tr.startState)) {
@@ -81,12 +81,5 @@ export const tableSelectionSnapFilter: Extension = EditorState.transactionFilter
         return tr;
     }
 
-    const userEvent = tr.annotation(Transaction.userEvent);
-
-    return {
-        selection: snapped,
-        effects: tr.effects,
-        scrollIntoView: tr.scrollIntoView,
-        annotations: userEvent ? Transaction.userEvent.of(userEvent) : [],
-    };
+    return [tr, { selection: snapped, sequential: true }];
 });

--- a/src/contentScript/tableRuntime/selection/tableSelectionSnap.ts
+++ b/src/contentScript/tableRuntime/selection/tableSelectionSnap.ts
@@ -87,6 +87,6 @@ export const tableSelectionSnapFilter: Extension = EditorState.transactionFilter
         selection: snapped,
         effects: tr.effects,
         scrollIntoView: tr.scrollIntoView,
-        ...(userEvent ? { annotations: Transaction.userEvent.of(userEvent) } : {}),
+        annotations: userEvent ? Transaction.userEvent.of(userEvent) : [],
     };
 });

--- a/src/contentScript/tableRuntime/selection/tableSelectionSnap.ts
+++ b/src/contentScript/tableRuntime/selection/tableSelectionSnap.ts
@@ -1,0 +1,92 @@
+import { EditorSelection, EditorState, Transaction, type Extension, type SelectionRange } from '@codemirror/state';
+import { findRenderedTablesTouching, type TableSpan } from '../../tableWidget/tableDecorationField';
+import { hasPlainRenderedTableCaret } from '../renderedTableCaret';
+
+/** Looks up every rendered table a document range reaches. */
+export type TablesTouching = (from: number, to: number) => readonly TableSpan[];
+
+/** Grows one range until it contains every table it touches, keeping its direction. */
+function snapRange(range: SelectionRange, findTablesTouching: TablesTouching): SelectionRange {
+    // An empty range is a caret, not a partial selection: it has no inside to speak of, and
+    // caret placement around tables is owned by the navigation and entry policies.
+    if (range.empty) {
+        return range;
+    }
+
+    let from = range.from;
+    let to = range.to;
+
+    for (const table of findTablesTouching(range.from, range.to)) {
+        from = Math.min(from, table.from);
+        to = Math.max(to, table.to);
+    }
+
+    if (from === range.from && to === range.to) {
+        return range;
+    }
+
+    return range.anchor <= range.head ? EditorSelection.range(from, to) : EditorSelection.range(to, from);
+}
+
+/**
+ * Grows a selection so that no range holds part of a rendered table.
+ *
+ * A table is drawn as one block widget, so a selection reaching into it selects nothing the
+ * user can see or act on: the hidden Markdown behind the widget is not what they pointed at,
+ * and picking out rows or columns is what the plugin's own cell selection is for. Any contact
+ * with a table therefore swallows the whole table, so it is either wholly selected or wholly
+ * untouched — never a sliver of source hanging off the end of a drag.
+ *
+ * @returns The grown selection, or null when nothing needed moving.
+ */
+export function snapSelectionAroundTables(
+    selection: EditorSelection,
+    findTablesTouching: TablesTouching
+): EditorSelection | null {
+    let changed = false;
+
+    const ranges = selection.ranges.map((range) => {
+        const snapped = snapRange(range, findTablesTouching);
+        changed ||= snapped !== range;
+        return snapped;
+    });
+
+    // `create` merges any ranges the growth pushed into each other.
+    return changed ? EditorSelection.create(ranges, selection.mainIndex) : null;
+}
+
+/**
+ * Keeps a selection from holding part of a rendered table.
+ *
+ * Applies to any selection-only transaction on a document the main editor still owns: a nested
+ * cell editor, a cell selection and an in-flight entry request each park the main selection
+ * inside a table on purpose, and raw mode has no widgets to snap around. Everything the plugin
+ * itself dispatches under those conditions moves a bare caret, which this leaves alone.
+ *
+ * Document changes are left alone too. This exists for selection gestures, which never carry
+ * one, and an edit that rewrites a table has its own policies deciding where the caret lands.
+ *
+ * Replacing the transaction drops its annotations, so the user event is put back; other runtime
+ * policies classify transactions by it.
+ */
+export const tableSelectionSnapFilter: Extension = EditorState.transactionFilter.of((tr) => {
+    if (tr.docChanged || !tr.selection || !hasPlainRenderedTableCaret(tr.startState)) {
+        return tr;
+    }
+
+    const snapped = snapSelectionAroundTables(tr.selection, (from, to) =>
+        findRenderedTablesTouching(tr.startState, from, to)
+    );
+    if (!snapped) {
+        return tr;
+    }
+
+    const userEvent = tr.annotation(Transaction.userEvent);
+
+    return {
+        selection: snapped,
+        effects: tr.effects,
+        scrollIntoView: tr.scrollIntoView,
+        ...(userEvent ? { annotations: Transaction.userEvent.of(userEvent) } : {}),
+    };
+});

--- a/src/contentScript/tableWidget/cellSelectionVisuals.ts
+++ b/src/contentScript/tableWidget/cellSelectionVisuals.ts
@@ -51,7 +51,7 @@ const selectedCells = (pseudo = ''): string =>
  * Deliberately the same fill the main editor's selection puts on a whole table: both are a
  * selection over rendered cells, and telling them apart by colour would say nothing useful. What
  * distinguishes them on screen is their extent — a cell selection stops at the rectangle, while a
- * whole-table selection also floods the widget's own block (`tableSelectionHighlight.ts`).
+ * whole-table selection also floods the widget's own block (`wholeTableSelectionVisuals.ts`).
  */
 const cellSelectionFillTheme = EditorView.baseTheme(selectedCellRules(selectedCells));
 

--- a/src/contentScript/tableWidget/cellSelectionVisuals.ts
+++ b/src/contentScript/tableWidget/cellSelectionVisuals.ts
@@ -1,6 +1,7 @@
 import type { Extension } from '@codemirror/state';
 import { EditorView } from '@codemirror/view';
 import { cellSelectionField, getCellSelection, isCellInRect, toSelectionRect } from '../tableState/cellSelectionState';
+import { cellDragField, isCellDragInProgress } from '../tableState/cellDragState';
 import {
     CELL_TAGS,
     CLASS_CELL_SELECTED,
@@ -54,10 +55,35 @@ const selectedCells = (pseudo = ''): string =>
  */
 const cellSelectionFillTheme = EditorView.baseTheme(selectedCellRules(selectedCells));
 
+/** Marks the editor root while a cell drag is sweeping out a rectangle. */
+const ATTR_CELL_DRAG = 'data-rt-cell-drag';
+
+/**
+ * Keeps a rectangle being dragged out looking focused.
+ *
+ * The fill follows the editor's focus (`richTableThemeVars.ts`), and a drag deliberately leaves
+ * whatever had focus alone until the rectangle is final — an editor in another table, or
+ * something outside the editor entirely — so the selection the user is actively dragging would
+ * otherwise render unfocused, and snap to focused on release. A gesture in progress is as focused
+ * as a selection gets, whatever the DOM says.
+ */
+const cellDragFocusOverride: Extension = [
+    EditorView.editorAttributes.compute([cellDragField], (state): Record<string, string> =>
+        isCellDragInProgress(state) ? { [ATTR_CELL_DRAG]: '' } : {}
+    ),
+    EditorView.baseTheme({
+        [`&[${ATTR_CELL_DRAG}]`]: {
+            '--rt-tint': 'var(--rt-tint-focused)',
+            '--rt-tint-alpha': 'var(--rt-tint-focused-alpha)',
+        } as Record<string, string>,
+    }),
+];
+
 /** Multi-cell selection visuals: the class on each selected cell, and the fill it carries. */
 export const cellSelectionVisuals: Extension = [
     measuredClassSyncPlugin(CLASS_CELL_SELECTED, collectSelectedCells),
     cellSelectionFillTheme,
+    cellDragFocusOverride,
 ];
 
 /**

--- a/src/contentScript/tableWidget/cellSelectionVisuals.ts
+++ b/src/contentScript/tableWidget/cellSelectionVisuals.ts
@@ -1,8 +1,9 @@
 import type { Extension } from '@codemirror/state';
-import { EditorView, ViewPlugin, type ViewUpdate } from '@codemirror/view';
+import { EditorView } from '@codemirror/view';
 import { cellSelectionField, getCellSelection, isCellInRect, toSelectionRect } from '../tableState/cellSelectionState';
 import { CLASS_CELL_SELECTED, SELECTOR_CELL, findTableWidgetElement, readCellCoords } from './domHelpers';
 import { makeTableId } from '../tableModel/types';
+import { measuredClassSyncPlugin } from './measuredClassSync';
 
 function collectSelectedCells(view: EditorView): HTMLElement[] {
     const selection = getCellSelection(view.state);
@@ -31,54 +32,7 @@ function collectSelectedCells(view: EditorView): HTMLElement[] {
     return selectedCells;
 }
 
-class CellSelectionVisualsController {
-    private selectedCells = new Set<HTMLElement>();
-    private destroyed = false;
-
-    constructor(private readonly view: EditorView) {
-        this.scheduleSync();
-    }
-
-    update(_update: ViewUpdate): void {
-        this.scheduleSync();
-    }
-
-    destroy(): void {
-        this.destroyed = true;
-        this.clear();
-    }
-
-    private clear(): void {
-        for (const cell of this.selectedCells) {
-            cell.classList.remove(CLASS_CELL_SELECTED);
-        }
-        this.selectedCells.clear();
-    }
-
-    private scheduleSync(): void {
-        this.view.requestMeasure({
-            key: this,
-            // Selection rewrites can rebuild the table widget, and ViewPlugin.update()
-            // may run before the replacement DOM is mounted. Defer the DOM query/write
-            // to the measure phase so the highlight is applied against the current widget.
-            read: () => collectSelectedCells(this.view),
-            write: (selectedCells: HTMLElement[]) => {
-                if (this.destroyed) {
-                    return;
-                }
-
-                this.clear();
-
-                for (const element of selectedCells) {
-                    element.classList.add(CLASS_CELL_SELECTED);
-                    this.selectedCells.add(element);
-                }
-            },
-        });
-    }
-}
-
-export const cellSelectionVisualsPlugin = ViewPlugin.fromClass(CellSelectionVisualsController);
+export const cellSelectionVisualsPlugin = measuredClassSyncPlugin(CLASS_CELL_SELECTED, collectSelectedCells);
 
 /**
  * Hides the main editor's caret while a cell selection is active.

--- a/src/contentScript/tableWidget/cellSelectionVisuals.ts
+++ b/src/contentScript/tableWidget/cellSelectionVisuals.ts
@@ -1,9 +1,17 @@
 import type { Extension } from '@codemirror/state';
 import { EditorView } from '@codemirror/view';
 import { cellSelectionField, getCellSelection, isCellInRect, toSelectionRect } from '../tableState/cellSelectionState';
-import { CLASS_CELL_SELECTED, SELECTOR_CELL, findTableWidgetElement, readCellCoords } from './domHelpers';
+import {
+    CELL_TAGS,
+    CLASS_CELL_SELECTED,
+    CLASS_TABLE_WIDGET_TABLE,
+    SELECTOR_CELL,
+    findTableWidgetElement,
+    readCellCoords,
+} from './domHelpers';
 import { makeTableId } from '../tableModel/types';
 import { measuredClassSyncPlugin } from './measuredClassSync';
+import { selectedCellRules } from './selectionTint';
 
 function collectSelectedCells(view: EditorView): HTMLElement[] {
     const selection = getCellSelection(view.state);
@@ -32,7 +40,25 @@ function collectSelectedCells(view: EditorView): HTMLElement[] {
     return selectedCells;
 }
 
-export const cellSelectionVisualsPlugin = measuredClassSyncPlugin(CLASS_CELL_SELECTED, collectSelectedCells);
+/** The cells of the current multi-cell selection, optionally suffixed with a pseudo-element. */
+const selectedCells = (pseudo = ''): string =>
+    CELL_TAGS.map((tag) => `.${CLASS_TABLE_WIDGET_TABLE} ${tag}.${CLASS_CELL_SELECTED}${pseudo}`).join(', ');
+
+/**
+ * Paints the selected rectangle in Joplin's selection colour.
+ *
+ * Deliberately the same fill the main editor's selection puts on a whole table: both are a
+ * selection over rendered cells, and telling them apart by colour would say nothing useful. What
+ * distinguishes them on screen is their extent — a cell selection stops at the rectangle, while a
+ * whole-table selection also floods the widget's own block (`tableSelectionHighlight.ts`).
+ */
+const cellSelectionFillTheme = EditorView.baseTheme(selectedCellRules(selectedCells));
+
+/** Multi-cell selection visuals: the class on each selected cell, and the fill it carries. */
+export const cellSelectionVisuals: Extension = [
+    measuredClassSyncPlugin(CLASS_CELL_SELECTED, collectSelectedCells),
+    cellSelectionFillTheme,
+];
 
 /**
  * Hides the main editor's caret while a cell selection is active.

--- a/src/contentScript/tableWidget/domHelpers.ts
+++ b/src/contentScript/tableWidget/domHelpers.ts
@@ -40,13 +40,16 @@ export function getWidgetSelector(): string {
 /** Matches the coordinate attributes `TableWidget` writes on every cell it renders. */
 export const CELL_COORDS_ATTRIBUTES = `[data-${DATA_SECTION}][data-${DATA_ROW}][data-${DATA_COL}]`;
 
+/** The element types `TableWidget` renders cells as. */
+export const CELL_TAGS = ['td', 'th'] as const;
+
 /**
  * Matches a table widget's own cells, and only those.
  *
  * The attributes are required so `closest()` walks past `td`/`th` belonging to a raw HTML
  * table inside a cell's rendered Markdown, which carry no coordinates of their own.
  */
-export const SELECTOR_CELL = `td${CELL_COORDS_ATTRIBUTES}, th${CELL_COORDS_ATTRIBUTES}`;
+export const SELECTOR_CELL = CELL_TAGS.map((tag) => `${tag}${CELL_COORDS_ATTRIBUTES}`).join(', ');
 
 /**
  * Returns the CSS selector for a specific cell within a table widget.

--- a/src/contentScript/tableWidget/domHelpers.ts
+++ b/src/contentScript/tableWidget/domHelpers.ts
@@ -5,6 +5,8 @@ import type { EditorView } from '@codemirror/view';
 export const CLASS_TABLE_WIDGET = 'cm-table-widget';
 export const CLASS_TABLE_WIDGET_TABLE = 'cm-table-widget-table';
 export const CLASS_CELL_SELECTED = 'cm-table-cell-selected';
+/** Set on a widget root while the main editor's selection covers its whole table. */
+export const CLASS_TABLE_WIDGET_SELECTED = 'cm-table-widget-selected';
 
 // Floating toolbar container (positioned relative to the active table widget)
 export const CLASS_FLOATING_TOOLBAR = 'cm-table-floating-toolbar';
@@ -36,7 +38,7 @@ export function getWidgetSelector(): string {
 }
 
 /** Matches the coordinate attributes `TableWidget` writes on every cell it renders. */
-const CELL_COORDS_ATTRIBUTES = `[data-${DATA_SECTION}][data-${DATA_ROW}][data-${DATA_COL}]`;
+export const CELL_COORDS_ATTRIBUTES = `[data-${DATA_SECTION}][data-${DATA_ROW}][data-${DATA_COL}]`;
 
 /**
  * Matches a table widget's own cells, and only those.

--- a/src/contentScript/tableWidget/measuredClassSync.ts
+++ b/src/contentScript/tableWidget/measuredClassSync.ts
@@ -1,0 +1,70 @@
+import type { Extension } from '@codemirror/state';
+import { EditorView, ViewPlugin, type PluginValue } from '@codemirror/view';
+
+/** Picks the elements that should currently carry the class. */
+export type ClassSyncCollector = (view: EditorView) => HTMLElement[];
+
+/**
+ * Keeps a class in sync with editor state on elements a state field cannot address.
+ *
+ * Widget DOM lives outside the decoration model, so a class on a widget root or one of its
+ * cells has to be written by hand. The write is deferred to CodeMirror's measure phase
+ * because the transactions that change the selection can also rebuild the table widget, and
+ * `PluginValue.update()` may run before the replacement DOM is mounted — reading the DOM
+ * there would find the outgoing elements.
+ */
+class MeasuredClassSync implements PluginValue {
+    private applied = new Set<HTMLElement>();
+    private destroyed = false;
+
+    constructor(
+        private readonly view: EditorView,
+        private readonly className: string,
+        private readonly collect: ClassSyncCollector
+    ) {
+        this.scheduleSync();
+    }
+
+    update(): void {
+        this.scheduleSync();
+    }
+
+    destroy(): void {
+        this.destroyed = true;
+        this.clear();
+    }
+
+    private clear(): void {
+        for (const element of this.applied) {
+            element.classList.remove(this.className);
+        }
+        this.applied.clear();
+    }
+
+    private scheduleSync(): void {
+        this.view.requestMeasure({
+            key: this,
+            read: () => this.collect(this.view),
+            write: (elements: HTMLElement[]) => {
+                if (this.destroyed) {
+                    return;
+                }
+
+                this.clear();
+
+                for (const element of elements) {
+                    element.classList.add(this.className);
+                    this.applied.add(element);
+                }
+            },
+        });
+    }
+}
+
+/**
+ * A view plugin that applies `className` to exactly the elements `collect` returns, refreshing
+ * on every view update and removing the class from everything else it previously marked.
+ */
+export function measuredClassSyncPlugin(className: string, collect: ClassSyncCollector): Extension {
+    return ViewPlugin.define((view) => new MeasuredClassSync(view, className, collect));
+}

--- a/src/contentScript/tableWidget/richTableThemeVars.ts
+++ b/src/contentScript/tableWidget/richTableThemeVars.ts
@@ -42,7 +42,7 @@ const SELECTION_GROUNDS = {
  * fill.
  *
  * The colour and its alpha are published separately so consumers can lay the same tint over
- * whatever base they have; see `tableWidget/tableSelectionHighlight.ts`.
+ * whatever base they have; see `tableWidget/wholeTableSelectionVisuals.ts`.
  */
 function tintProperties(mode: keyof typeof JOPLIN_SELECTION_COLORS): Record<string, string> {
     const ground = parseHexColor(SELECTION_GROUNDS[mode]);

--- a/src/contentScript/tableWidget/richTableThemeVars.ts
+++ b/src/contentScript/tableWidget/richTableThemeVars.ts
@@ -24,15 +24,10 @@ const JOPLIN_SELECTION_COLORS = {
  * self-consistent whatever a theme does: the ground is fully covered by the overlay, which is
  * derived from it, so the two always composite to the selection colour.
  */
-const TABLE_SELECTION_GROUNDS = {
+const SELECTION_GROUNDS = {
     light: '#ffffff',
     dark: '#1d2024',
 } as const;
-
-/**
- * Alpha applied to the multi-cell selection fill.
- */
-const CELL_SELECTION_ALPHA = '60%';
 
 /**
  * The tint that turns a selected table's painted ground into Joplin's selection colour.
@@ -50,7 +45,7 @@ const CELL_SELECTION_ALPHA = '60%';
  * whatever base they have; see `tableWidget/tableSelectionHighlight.ts`.
  */
 function tintProperties(mode: keyof typeof JOPLIN_SELECTION_COLORS): Record<string, string> {
-    const ground = parseHexColor(TABLE_SELECTION_GROUNDS[mode]);
+    const ground = parseHexColor(SELECTION_GROUNDS[mode]);
     const tintFor = (target: string) => alphaEquivalentLayer(parseHexColor(target), ground);
     const focused = tintFor(JOPLIN_SELECTION_COLORS[mode].focused);
     const blurred = tintFor(JOPLIN_SELECTION_COLORS[mode].blurred);
@@ -64,11 +59,6 @@ function tintProperties(mode: keyof typeof JOPLIN_SELECTION_COLORS): Record<stri
 }
 
 /**
- * Fades a color toward transparent.
- */
-const withAlpha = (color: string, alpha: string): string => `color-mix(in srgb, ${color} ${alpha}, transparent)`;
-
-/**
  * Maps Joplin theme variables to plugin-owned --rt-* custom properties.
  *
  * Defined on the main editor root so all plugin DOM (widget, nested editor, toolbar)
@@ -76,13 +66,16 @@ const withAlpha = (color: string, alpha: string): string => `color-mix(in srgb, 
  * one line here rather than hunting across multiple style files.
  *
  * --rt-border-color        borders, outlines, dividers
- * --rt-cell-selection-bg   multi-cell selection background (painted on the cell, behind its text)
+ * --rt-selection-bg        the selection fill below, resolved for the editor's current focus state
+ * --rt-tint, --rt-tint-alpha  the tint pair below, likewise resolved.  Resolving focus once here
+ *                          keeps the fill and the tint from ever disagreeing about it, and spares
+ *                          every rule that reads them a focused copy of itself.
  * --rt-selection-focused-bg  Joplin's selection background while the editor owning it has focus.
  *                          Painted by the nested editor's drawSelection layer, and as the fill
  *                          behind a rendered table the main editor's selection covers.
  * --rt-selection-blurred-bg  the same fill while that editor is unfocused
- * --rt-table-selection-ground-bg  opaque ground painted on a selected table's cells
- * --rt-tint-focused        colour of the layer laid over a selected table, which composites with
+ * --rt-selection-ground-bg  opaque ground painted on a selected cell, beneath the tint
+ * --rt-tint-focused        colour of the layer laid over a selected cell, which composites with
  *                          that ground to --rt-selection-focused-bg
  * --rt-tint-focused-alpha  the alpha that layer is laid on at, as a percentage
  * --rt-tint-blurred, --rt-tint-blurred-alpha  the same pair for --rt-selection-blurred-bg
@@ -119,19 +112,29 @@ export const richTableThemeVars = EditorView.baseTheme({
         '--rt-toolbar-color': 'var(--joplin-color)',
         '--rt-toolbar-shadow': 'rgba(0, 0, 0, 0.2)',
         '--rt-toolbar-hover-bg': 'var(--joplin-selected-color)',
+        '--rt-selection-bg': 'var(--rt-selection-blurred-bg)',
+        '--rt-tint': 'var(--rt-tint-blurred)',
+        '--rt-tint-alpha': 'var(--rt-tint-blurred-alpha)',
+    } as Record<string, string>,
+    // `:focus-within` rather than `.cm-focused`, which tracks only this editor's own content:
+    // a nested cell editor holds focus on the plugin's behalf, most visibly through a cell drag,
+    // which keeps its anchor cell open for the length of the gesture.  Two components to the
+    // block above's one, so focus wins wherever this sits in source order.
+    '&:focus-within': {
+        '--rt-selection-bg': 'var(--rt-selection-focused-bg)',
+        '--rt-tint': 'var(--rt-tint-focused)',
+        '--rt-tint-alpha': 'var(--rt-tint-focused-alpha)',
     } as Record<string, string>,
     '&light': {
-        '--rt-cell-selection-bg': withAlpha(JOPLIN_SELECTION_COLORS.light.focused, CELL_SELECTION_ALPHA),
         '--rt-selection-focused-bg': JOPLIN_SELECTION_COLORS.light.focused,
         '--rt-selection-blurred-bg': JOPLIN_SELECTION_COLORS.light.blurred,
-        '--rt-table-selection-ground-bg': TABLE_SELECTION_GROUNDS.light,
+        '--rt-selection-ground-bg': SELECTION_GROUNDS.light,
         ...tintProperties('light'),
     } as Record<string, string>,
     '&dark': {
-        '--rt-cell-selection-bg': withAlpha(JOPLIN_SELECTION_COLORS.dark.focused, CELL_SELECTION_ALPHA),
         '--rt-selection-focused-bg': JOPLIN_SELECTION_COLORS.dark.focused,
         '--rt-selection-blurred-bg': JOPLIN_SELECTION_COLORS.dark.blurred,
-        '--rt-table-selection-ground-bg': TABLE_SELECTION_GROUNDS.dark,
+        '--rt-selection-ground-bg': SELECTION_GROUNDS.dark,
         ...tintProperties('dark'),
     } as Record<string, string>,
 });

--- a/src/contentScript/tableWidget/richTableThemeVars.ts
+++ b/src/contentScript/tableWidget/richTableThemeVars.ts
@@ -1,5 +1,5 @@
 import { EditorView } from '@codemirror/view';
-import { alphaEquivalentLayer, parseHexColor, toCssColor } from './selectionOverlayColor';
+import { alphaEquivalentLayer, parseHexColor, toPercentageCss, toRgbCss } from './selectionOverlayColor';
 
 /**
  * Joplin's editor text-selection colors, which no Joplin CSS variable exposes.
@@ -35,18 +35,33 @@ const TABLE_SELECTION_GROUNDS = {
 const CELL_SELECTION_ALPHA = '60%';
 
 /**
- * The overlay that turns a selected table's painted ground into Joplin's selection colour.
+ * The tint that turns a selected table's painted ground into Joplin's selection colour.
  *
  * CodeMirror puts its selection background *behind* editor text; a rendered table has surfaces
- * it can never reach — the header's background, inline code, `==highlight==`, images — so the
- * plugin lays its own layer *over* the table instead.  Solving for the faintest layer that
- * reproduces the selection colour on the ground keeps that honest: everything at the ground's
- * tone lands exactly on the selection colour, while text of the opposite tone passes through
- * nearly untouched.  Painting the selection colour itself at some chosen alpha does neither —
- * it washes the text out and still leaves every opaque surface standing proud of the fill.
+ * it can never reach — the header's background, inline code, `==highlight==`, images, the cell
+ * borders — so the plugin lays its own layer *over* the table instead.  Solving for the faintest
+ * layer that reproduces the selection colour on the ground keeps that honest: everything at the
+ * ground's tone lands exactly on the selection colour, while text of the opposite tone passes
+ * through nearly untouched.  Painting the selection colour itself at some chosen alpha does
+ * neither — it washes the text out and still leaves every opaque surface standing proud of the
+ * fill.
+ *
+ * The colour and its alpha are published separately so consumers can lay the same tint over
+ * whatever base they have; see `tableWidget/tableSelectionHighlight.ts`.
  */
-const selectionOverlay = (target: string, ground: string): string =>
-    toCssColor(alphaEquivalentLayer(parseHexColor(target), parseHexColor(ground)));
+function tintProperties(mode: keyof typeof JOPLIN_SELECTION_COLORS): Record<string, string> {
+    const ground = parseHexColor(TABLE_SELECTION_GROUNDS[mode]);
+    const tintFor = (target: string) => alphaEquivalentLayer(parseHexColor(target), ground);
+    const focused = tintFor(JOPLIN_SELECTION_COLORS[mode].focused);
+    const blurred = tintFor(JOPLIN_SELECTION_COLORS[mode].blurred);
+
+    return {
+        '--rt-tint-focused': toRgbCss(focused.color),
+        '--rt-tint-focused-alpha': toPercentageCss(focused.alpha),
+        '--rt-tint-blurred': toRgbCss(blurred.color),
+        '--rt-tint-blurred-alpha': toPercentageCss(blurred.alpha),
+    };
+}
 
 /**
  * Fades a color toward transparent.
@@ -67,9 +82,10 @@ const withAlpha = (color: string, alpha: string): string => `color-mix(in srgb, 
  *                          behind a rendered table the main editor's selection covers.
  * --rt-selection-blurred-bg  the same fill while that editor is unfocused
  * --rt-table-selection-ground-bg  opaque ground painted on a selected table's cells
- * --rt-table-selection-overlay  layer painted over a selected table, which composites with that
- *                          ground to --rt-selection-focused-bg
- * --rt-table-selection-overlay-blurred  the same layer for --rt-selection-blurred-bg
+ * --rt-tint-focused        colour of the layer laid over a selected table, which composites with
+ *                          that ground to --rt-selection-focused-bg
+ * --rt-tint-focused-alpha  the alpha that layer is laid on at, as a percentage
+ * --rt-tint-blurred, --rt-tint-blurred-alpha  the same pair for --rt-selection-blurred-bg
  * --rt-code-bg             inline code background
  * --rt-code-color          inline code text
  * --rt-mark-bg             ==highlight== background
@@ -109,27 +125,13 @@ export const richTableThemeVars = EditorView.baseTheme({
         '--rt-selection-focused-bg': JOPLIN_SELECTION_COLORS.light.focused,
         '--rt-selection-blurred-bg': JOPLIN_SELECTION_COLORS.light.blurred,
         '--rt-table-selection-ground-bg': TABLE_SELECTION_GROUNDS.light,
-        '--rt-table-selection-overlay': selectionOverlay(
-            JOPLIN_SELECTION_COLORS.light.focused,
-            TABLE_SELECTION_GROUNDS.light
-        ),
-        '--rt-table-selection-overlay-blurred': selectionOverlay(
-            JOPLIN_SELECTION_COLORS.light.blurred,
-            TABLE_SELECTION_GROUNDS.light
-        ),
+        ...tintProperties('light'),
     } as Record<string, string>,
     '&dark': {
         '--rt-cell-selection-bg': withAlpha(JOPLIN_SELECTION_COLORS.dark.focused, CELL_SELECTION_ALPHA),
         '--rt-selection-focused-bg': JOPLIN_SELECTION_COLORS.dark.focused,
         '--rt-selection-blurred-bg': JOPLIN_SELECTION_COLORS.dark.blurred,
         '--rt-table-selection-ground-bg': TABLE_SELECTION_GROUNDS.dark,
-        '--rt-table-selection-overlay': selectionOverlay(
-            JOPLIN_SELECTION_COLORS.dark.focused,
-            TABLE_SELECTION_GROUNDS.dark
-        ),
-        '--rt-table-selection-overlay-blurred': selectionOverlay(
-            JOPLIN_SELECTION_COLORS.dark.blurred,
-            TABLE_SELECTION_GROUNDS.dark
-        ),
+        ...tintProperties('dark'),
     } as Record<string, string>,
 });

--- a/src/contentScript/tableWidget/richTableThemeVars.ts
+++ b/src/contentScript/tableWidget/richTableThemeVars.ts
@@ -1,4 +1,5 @@
 import { EditorView } from '@codemirror/view';
+import { alphaEquivalentLayer, parseHexColor, toCssColor } from './selectionOverlayColor';
 
 /**
  * Joplin's editor text-selection colors, which no Joplin CSS variable exposes.
@@ -15,9 +16,37 @@ const JOPLIN_SELECTION_COLORS = {
 } as const;
 
 /**
+ * The ground a selected table's cells are painted with, beneath the selection overlay.
+ *
+ * Joplin's editor background is a runtime variable, and the overlay below can only be solved
+ * against a background known ahead of time — so the plugin paints one rather than guessing.
+ * These match Joplin's default light and dark editor backgrounds, but the pair is
+ * self-consistent whatever a theme does: the ground is fully covered by the overlay, which is
+ * derived from it, so the two always composite to the selection colour.
+ */
+const TABLE_SELECTION_GROUNDS = {
+    light: '#ffffff',
+    dark: '#1d2024',
+} as const;
+
+/**
  * Alpha applied to the multi-cell selection fill.
  */
 const CELL_SELECTION_ALPHA = '60%';
+
+/**
+ * The overlay that turns a selected table's painted ground into Joplin's selection colour.
+ *
+ * CodeMirror puts its selection background *behind* editor text; a rendered table has surfaces
+ * it can never reach — the header's background, inline code, `==highlight==`, images — so the
+ * plugin lays its own layer *over* the table instead.  Solving for the faintest layer that
+ * reproduces the selection colour on the ground keeps that honest: everything at the ground's
+ * tone lands exactly on the selection colour, while text of the opposite tone passes through
+ * nearly untouched.  Painting the selection colour itself at some chosen alpha does neither —
+ * it washes the text out and still leaves every opaque surface standing proud of the fill.
+ */
+const selectionOverlay = (target: string, ground: string): string =>
+    toCssColor(alphaEquivalentLayer(parseHexColor(target), parseHexColor(ground)));
 
 /**
  * Fades a color toward transparent.
@@ -32,9 +61,15 @@ const withAlpha = (color: string, alpha: string): string => `color-mix(in srgb, 
  * one line here rather than hunting across multiple style files.
  *
  * --rt-border-color        borders, outlines, dividers
- * --rt-selection-bg        multi-cell selection background (painted on the cell, behind its text)
- * --rt-nested-selection-bg CodeMirror drawSelection layer inside a focused nested editor
- * --rt-nested-selection-blurred-bg  the same layer while the nested editor is unfocused
+ * --rt-cell-selection-bg   multi-cell selection background (painted on the cell, behind its text)
+ * --rt-selection-focused-bg  Joplin's selection background while the editor owning it has focus.
+ *                          Painted by the nested editor's drawSelection layer, and as the fill
+ *                          behind a rendered table the main editor's selection covers.
+ * --rt-selection-blurred-bg  the same fill while that editor is unfocused
+ * --rt-table-selection-ground-bg  opaque ground painted on a selected table's cells
+ * --rt-table-selection-overlay  layer painted over a selected table, which composites with that
+ *                          ground to --rt-selection-focused-bg
+ * --rt-table-selection-overlay-blurred  the same layer for --rt-selection-blurred-bg
  * --rt-code-bg             inline code background
  * --rt-code-color          inline code text
  * --rt-mark-bg             ==highlight== background
@@ -70,13 +105,31 @@ export const richTableThemeVars = EditorView.baseTheme({
         '--rt-toolbar-hover-bg': 'var(--joplin-selected-color)',
     } as Record<string, string>,
     '&light': {
-        '--rt-selection-bg': withAlpha(JOPLIN_SELECTION_COLORS.light.focused, CELL_SELECTION_ALPHA),
-        '--rt-nested-selection-bg': JOPLIN_SELECTION_COLORS.light.focused,
-        '--rt-nested-selection-blurred-bg': JOPLIN_SELECTION_COLORS.light.blurred,
+        '--rt-cell-selection-bg': withAlpha(JOPLIN_SELECTION_COLORS.light.focused, CELL_SELECTION_ALPHA),
+        '--rt-selection-focused-bg': JOPLIN_SELECTION_COLORS.light.focused,
+        '--rt-selection-blurred-bg': JOPLIN_SELECTION_COLORS.light.blurred,
+        '--rt-table-selection-ground-bg': TABLE_SELECTION_GROUNDS.light,
+        '--rt-table-selection-overlay': selectionOverlay(
+            JOPLIN_SELECTION_COLORS.light.focused,
+            TABLE_SELECTION_GROUNDS.light
+        ),
+        '--rt-table-selection-overlay-blurred': selectionOverlay(
+            JOPLIN_SELECTION_COLORS.light.blurred,
+            TABLE_SELECTION_GROUNDS.light
+        ),
     } as Record<string, string>,
     '&dark': {
-        '--rt-selection-bg': withAlpha(JOPLIN_SELECTION_COLORS.dark.focused, CELL_SELECTION_ALPHA),
-        '--rt-nested-selection-bg': JOPLIN_SELECTION_COLORS.dark.focused,
-        '--rt-nested-selection-blurred-bg': JOPLIN_SELECTION_COLORS.dark.blurred,
+        '--rt-cell-selection-bg': withAlpha(JOPLIN_SELECTION_COLORS.dark.focused, CELL_SELECTION_ALPHA),
+        '--rt-selection-focused-bg': JOPLIN_SELECTION_COLORS.dark.focused,
+        '--rt-selection-blurred-bg': JOPLIN_SELECTION_COLORS.dark.blurred,
+        '--rt-table-selection-ground-bg': TABLE_SELECTION_GROUNDS.dark,
+        '--rt-table-selection-overlay': selectionOverlay(
+            JOPLIN_SELECTION_COLORS.dark.focused,
+            TABLE_SELECTION_GROUNDS.dark
+        ),
+        '--rt-table-selection-overlay-blurred': selectionOverlay(
+            JOPLIN_SELECTION_COLORS.dark.blurred,
+            TABLE_SELECTION_GROUNDS.dark
+        ),
     } as Record<string, string>,
 });

--- a/src/contentScript/tableWidget/selectionOverlayColor.ts
+++ b/src/contentScript/tableWidget/selectionOverlayColor.ts
@@ -1,0 +1,98 @@
+/** An opaque sRGB colour. */
+export interface Rgb {
+    r: number;
+    g: number;
+    b: number;
+}
+
+/** A translucent layer: an opaque colour and the alpha it is painted at. */
+export interface AlphaLayer {
+    color: Rgb;
+    alpha: number;
+}
+
+const CHANNEL_MAX = 255;
+const HEX_COLOR_PATTERN = /^#([0-9a-f]{6})$/i;
+/** Alpha is rounded up at this precision so no channel is pushed back out of range. */
+const ALPHA_PRECISION = 10_000;
+
+/**
+ * Parses a `#rrggbb` colour.
+ *
+ * @throws RangeError when the string is not a six-digit hex colour.
+ */
+export function parseHexColor(hex: string): Rgb {
+    const match = HEX_COLOR_PATTERN.exec(hex.trim());
+    if (!match) {
+        throw new RangeError(`Expected a #rrggbb colour, received "${hex}"`);
+    }
+
+    const value = Number.parseInt(match[1], 16);
+
+    // Unpack the packed 24-bit colour.
+    return { r: (value >> 16) & 0xff, g: (value >> 8) & 0xff, b: value & 0xff };
+}
+
+const channelsOf = (color: Rgb): readonly number[] => [color.r, color.g, color.b];
+
+/**
+ * The smallest alpha at which some opaque colour, painted over `ground`, can produce `target`.
+ *
+ * Painting a layer of colour `c` at alpha `a` yields `a·c + (1 - a)·ground`, so reaching a
+ * target channel needs `c = (target - (1 - a)·ground) / a`.  That has a solution only while `c`
+ * stays inside `[0, 255]`: darkening a channel needs at least `(ground - target) / ground`, and
+ * lightening one at least `(target - ground) / (255 - ground)`.  The channel demanding the most
+ * decides the layer, and every smaller alpha is unreachable.
+ */
+function minimumAlpha(target: Rgb, ground: Rgb): number {
+    let alpha = 0;
+
+    channelsOf(target).forEach((targetChannel, index) => {
+        const groundChannel = channelsOf(ground)[index];
+        const darkening = targetChannel <= groundChannel;
+        const headroom = darkening ? groundChannel : CHANNEL_MAX - groundChannel;
+        if (headroom === 0) {
+            return;
+        }
+
+        alpha = Math.max(alpha, Math.abs(targetChannel - groundChannel) / headroom);
+    });
+
+    return Math.ceil(alpha * ALPHA_PRECISION) / ALPHA_PRECISION;
+}
+
+const clampChannel = (value: number): number => Math.min(CHANNEL_MAX, Math.max(0, Math.round(value)));
+
+/**
+ * The translucent layer that turns `ground` into `target` when painted over it.
+ *
+ * A layer picked this way is the faintest one that still reproduces the target exactly, which is
+ * what makes it usable on top of content: to lighten a ground it comes out near-white, to darken
+ * one near-black, so it barely disturbs text of the opposite tone while every surface at the
+ * ground's own tone lands squarely on the target colour.
+ */
+export function alphaEquivalentLayer(target: Rgb, ground: Rgb): AlphaLayer {
+    const alpha = minimumAlpha(target, ground);
+    if (alpha === 0) {
+        // The ground already is the target, so any colour at zero alpha describes it.
+        return { color: target, alpha: 0 };
+    }
+
+    const solveChannel = (targetChannel: number, groundChannel: number): number =>
+        clampChannel((targetChannel - (1 - alpha) * groundChannel) / alpha);
+
+    return {
+        color: {
+            r: solveChannel(target.r, ground.r),
+            g: solveChannel(target.g, ground.g),
+            b: solveChannel(target.b, ground.b),
+        },
+        alpha,
+    };
+}
+
+/** Renders a layer as a CSS `rgba()` colour. */
+export function toCssColor(layer: AlphaLayer): string {
+    const { color, alpha } = layer;
+    return `rgba(${color.r}, ${color.g}, ${color.b}, ${alpha})`;
+}

--- a/src/contentScript/tableWidget/selectionOverlayColor.ts
+++ b/src/contentScript/tableWidget/selectionOverlayColor.ts
@@ -5,7 +5,14 @@ export interface Rgb {
     b: number;
 }
 
-/** A translucent layer: an opaque colour and the alpha it is painted at. */
+/**
+ * A translucent layer: an opaque colour and the alpha it is painted at.
+ *
+ * The two halves stay apart rather than combining into one `rgba()` so the pair can be laid over
+ * more than one base.  `color-mix()` takes a colour at an alpha expressed as a percentage, which
+ * composites it over transparency to give the layer itself, or over an opaque colour to give what
+ * that colour looks like beneath the layer.
+ */
 export interface AlphaLayer {
     color: Rgb;
     alpha: number;
@@ -35,7 +42,7 @@ export function parseHexColor(hex: string): Rgb {
     return { r: (value >> 16) & 0xff, g: (value >> 8) & 0xff, b: value & 0xff };
 }
 
-const channelsOf = (color: Rgb): readonly number[] => [color.r, color.g, color.b];
+const CHANNELS = ['r', 'g', 'b'] as const;
 
 /**
  * The smallest alpha at which some opaque colour, painted over `ground`, can produce `target`.
@@ -47,20 +54,13 @@ const channelsOf = (color: Rgb): readonly number[] => [color.r, color.g, color.b
  * decides the layer, and every smaller alpha is unreachable.
  */
 function minimumAlpha(target: Rgb, ground: Rgb): number {
-    let alpha = 0;
-
-    channelsOf(target).forEach((targetChannel, index) => {
-        const groundChannel = channelsOf(ground)[index];
-        const darkening = targetChannel <= groundChannel;
-        const headroom = darkening ? groundChannel : CHANNEL_MAX - groundChannel;
-        if (headroom === 0) {
-            return;
-        }
-
-        alpha = Math.max(alpha, Math.abs(targetChannel - groundChannel) / headroom);
+    const demands = CHANNELS.map((channel) => {
+        const headroom = target[channel] <= ground[channel] ? ground[channel] : CHANNEL_MAX - ground[channel];
+        // A channel with no headroom is already at the end it would have to travel toward.
+        return headroom === 0 ? 0 : Math.abs(target[channel] - ground[channel]) / headroom;
     });
 
-    return Math.ceil(alpha * ALPHA_PRECISION) / ALPHA_PRECISION;
+    return Math.ceil(Math.max(...demands) * ALPHA_PRECISION) / ALPHA_PRECISION;
 }
 
 const clampChannel = (value: number): number => Math.min(CHANNEL_MAX, Math.max(0, Math.round(value)));
@@ -93,14 +93,7 @@ export function alphaEquivalentLayer(target: Rgb, ground: Rgb): AlphaLayer {
     };
 }
 
-/**
- * Renders a layer's opaque colour and its alpha separately, as CSS.
- *
- * Kept apart rather than combined into one `rgba()` so the pair can be laid over more than one
- * base: `color-mix()` takes the colour at the alpha as a percentage, which composites it over
- * transparency to give the layer itself, or over an opaque colour to give what that colour looks
- * like beneath the layer.
- */
+/** Renders an opaque colour as a CSS `rgb()`, for the first half of a `color-mix()`. */
 export function toRgbCss(color: Rgb): string {
     return `rgb(${color.r}, ${color.g}, ${color.b})`;
 }

--- a/src/contentScript/tableWidget/selectionOverlayColor.ts
+++ b/src/contentScript/tableWidget/selectionOverlayColor.ts
@@ -15,6 +15,8 @@ const CHANNEL_MAX = 255;
 const HEX_COLOR_PATTERN = /^#([0-9a-f]{6})$/i;
 /** Alpha is rounded up at this precision so no channel is pushed back out of range. */
 const ALPHA_PRECISION = 10_000;
+/** Decimal places kept when an alpha is written as a percentage. */
+const PERCENTAGE_DECIMALS = 2;
 
 /**
  * Parses a `#rrggbb` colour.
@@ -91,8 +93,19 @@ export function alphaEquivalentLayer(target: Rgb, ground: Rgb): AlphaLayer {
     };
 }
 
-/** Renders a layer as a CSS `rgba()` colour. */
-export function toCssColor(layer: AlphaLayer): string {
-    const { color, alpha } = layer;
-    return `rgba(${color.r}, ${color.g}, ${color.b}, ${alpha})`;
+/**
+ * Renders a layer's opaque colour and its alpha separately, as CSS.
+ *
+ * Kept apart rather than combined into one `rgba()` so the pair can be laid over more than one
+ * base: `color-mix()` takes the colour at the alpha as a percentage, which composites it over
+ * transparency to give the layer itself, or over an opaque colour to give what that colour looks
+ * like beneath the layer.
+ */
+export function toRgbCss(color: Rgb): string {
+    return `rgb(${color.r}, ${color.g}, ${color.b})`;
+}
+
+/** Renders an alpha as a CSS percentage, for the second half of a `color-mix()`. */
+export function toPercentageCss(alpha: number): string {
+    return `${Number((alpha * 100).toFixed(PERCENTAGE_DECIMALS))}%`;
 }

--- a/src/contentScript/tableWidget/selectionTint.ts
+++ b/src/contentScript/tableWidget/selectionTint.ts
@@ -1,3 +1,5 @@
+import { CELL_BORDER_WIDTH } from './tableStyles';
+
 /** Builds the selector for a set of selected cells, optionally suffixed with a pseudo-element. */
 export type SelectedCellSelector = (pseudo?: string) => string;
 
@@ -30,6 +32,14 @@ const tinted = (base: string): string => `color-mix(in srgb, var(--rt-tint) var(
  * reach them would darken those twice. Left untinted they all but vanish — the divider colour is
  * a light grey chosen to read on the editor background, and the selection ground is darker than
  * it, dropping a gridline's contrast against its own cell from about 1.36 to 1.06.
+ *
+ * A shared gridline can only take one colour, and where a selection ends mid-table the two cells
+ * meeting across it disagree. CSS settles that in favour of the cell further up and left, so a
+ * selection's top and left edges are drawn by their *unselected* neighbours, in the untinted
+ * colour — the two sides of a rectangle that come out faint while the other two look right. The
+ * overlay redraws those two sides itself, from inside the cell where no conflict can arise. It
+ * paints the same opaque tinted colour the border already carries, so on the edges the border
+ * won there is nothing to see.
  */
 export function selectedCellRules(cells: SelectedCellSelector): Record<string, Record<string, string>> {
     return {
@@ -44,6 +54,8 @@ export function selectedCellRules(cells: SelectedCellSelector): Record<string, R
             // Above content the cell positions for itself, which would otherwise paint over the fill.
             zIndex: '1',
             backgroundColor: tinted('transparent'),
+            // One shadow offset diagonally, so the corner between the two sides is covered too.
+            boxShadow: `-${CELL_BORDER_WIDTH} -${CELL_BORDER_WIDTH} 0 ${tinted('var(--rt-border-color)')}`,
             pointerEvents: 'none',
         },
     };

--- a/src/contentScript/tableWidget/selectionTint.ts
+++ b/src/contentScript/tableWidget/selectionTint.ts
@@ -1,0 +1,50 @@
+/** Builds the selector for a set of selected cells, optionally suffixed with a pseudo-element. */
+export type SelectedCellSelector = (pseudo?: string) => string;
+
+/**
+ * Lays the selection tint over `base`.
+ *
+ * `--rt-tint`/`--rt-tint-alpha` describe one layer, already resolved for the editor's focus state
+ * (see `richTableThemeVars.ts`), and `color-mix` composites it over whatever it is given: over
+ * transparency it is the layer itself, over an opaque colour it is what that colour looks like
+ * beneath the layer. That second form is how surfaces the overlay cannot physically cover still
+ * get tinted with it.
+ */
+const tinted = (base: string): string => `color-mix(in srgb, var(--rt-tint) var(--rt-tint-alpha), ${base})`;
+
+/**
+ * Theme rules painting cells as selected, in Joplin's selection colour.
+ *
+ * Shared by the two selections a rendered table can be under — the main editor's, covering the
+ * whole table, and the widget's own multi-cell rectangle — so the two read as one idea.
+ *
+ * A cell takes the ground the tint is solved against, replacing whatever background it had, and
+ * an overlay composites that ground up to the selection colour, taking everything the cell
+ * renders with it. CodeMirror's own selection background could not: it sits behind editor text,
+ * where a table carries opaque backgrounds of its own on the header, inline code, `==highlight==`
+ * and images. Painting the ground rather than inheriting the theme's is what lets the tint be
+ * exact (see `selectionOverlayColor.ts`).
+ *
+ * Cell borders are tinted through their colour instead, because they sit outside the padding box
+ * the overlay covers and `border-collapse` has made each inner one shared, so an overlay grown to
+ * reach them would darken those twice. Left untinted they all but vanish — the divider colour is
+ * a light grey chosen to read on the editor background, and the selection ground is darker than
+ * it, dropping a gridline's contrast against its own cell from about 1.36 to 1.06.
+ */
+export function selectedCellRules(cells: SelectedCellSelector): Record<string, Record<string, string>> {
+    return {
+        [cells()]: {
+            backgroundColor: 'var(--rt-selection-ground-bg)',
+            borderColor: tinted('var(--rt-border-color)'),
+        },
+        [cells('::after')]: {
+            content: '""',
+            position: 'absolute',
+            inset: '0',
+            // Above content the cell positions for itself, which would otherwise paint over the fill.
+            zIndex: '1',
+            backgroundColor: tinted('transparent'),
+            pointerEvents: 'none',
+        },
+    };
+}

--- a/src/contentScript/tableWidget/tableDecorationField.ts
+++ b/src/contentScript/tableWidget/tableDecorationField.ts
@@ -1,6 +1,6 @@
 import { EditorState, RangeSetBuilder, StateField } from '@codemirror/state';
 import { syntaxTreeAvailable } from '@codemirror/language';
-import { Decoration, DecorationSet, EditorView } from '@codemirror/view';
+import { Decoration, type DecorationSet, EditorView } from '@codemirror/view';
 import { logger } from '../../logger';
 import { buildTableContext } from '../tableModel/tableContext';
 import { findTableRanges } from '../tableRuntime/tableResolution';
@@ -81,3 +81,50 @@ export const tableDecorationField = StateField.define<TableDecorationState>({
     },
     provide: (field) => EditorView.decorations.from(field, (value) => value.decorations),
 });
+
+/** A rendered table's document range. */
+export interface TableSpan {
+    from: number;
+    to: number;
+}
+
+/**
+ * The widget decorations currently in effect, or an empty set.
+ *
+ * Falls back to `Decoration.none` rather than throwing so callers work in states that never
+ * registered the field, and so raw mode (where the field holds no decorations) reads as
+ * "no rendered tables" without a separate mode check.
+ */
+function getTableDecorations(state: EditorState): DecorationSet {
+    return state.field(tableDecorationField, false)?.decorations ?? Decoration.none;
+}
+
+/**
+ * Every rendered table whose range overlaps or abuts `[from, to]`, in document order.
+ *
+ * Abutting counts as touching: a selection endpoint that stops exactly on a table edge has
+ * been dragged onto the widget, since the document positions either side of a table belong to
+ * the blank lines that separate it from its neighbours.
+ */
+export function findRenderedTablesTouching(state: EditorState, from: number, to: number): TableSpan[] {
+    const spans: TableSpan[] = [];
+
+    getTableDecorations(state).between(from, to, (tableFrom, tableTo) => {
+        spans.push({ from: tableFrom, to: tableTo });
+    });
+
+    return spans;
+}
+
+/** Every rendered table whose range lies entirely inside `[from, to]`, in document order. */
+export function findRenderedTablesWithin(state: EditorState, from: number, to: number): TableSpan[] {
+    const spans: TableSpan[] = [];
+
+    getTableDecorations(state).between(from, to, (tableFrom, tableTo) => {
+        if (tableFrom >= from && tableTo <= to) {
+            spans.push({ from: tableFrom, to: tableTo });
+        }
+    });
+
+    return spans;
+}

--- a/src/contentScript/tableWidget/tableSelectionHighlight.ts
+++ b/src/contentScript/tableWidget/tableSelectionHighlight.ts
@@ -2,12 +2,14 @@ import type { EditorState, Extension } from '@codemirror/state';
 import { EditorView } from '@codemirror/view';
 import {
     CELL_COORDS_ATTRIBUTES,
+    CELL_TAGS,
     CLASS_TABLE_WIDGET_SELECTED,
     CLASS_TABLE_WIDGET_TABLE,
     getWidgetSelector,
 } from './domHelpers';
 import { findRenderedTablesWithin, type TableSpan } from './tableDecorationField';
 import { measuredClassSyncPlugin } from './measuredClassSync';
+import { selectedCellRules } from './selectionTint';
 
 /**
  * Rendered tables the main editor's selection covers end to end.
@@ -54,8 +56,6 @@ function collectSelectedTableWidgets(view: EditorView): HTMLElement[] {
 }
 
 const SELECTED_WIDGET = `${getWidgetSelector()}.${CLASS_TABLE_WIDGET_SELECTED}`;
-const CELL_TAGS = ['td', 'th'] as const;
-
 /**
  * Selector for the widget's own cells inside a selected table.
  *
@@ -86,38 +86,12 @@ const NATIVE_SELECTION_RESET = {
 };
 
 /**
- * Lays the selection tint over `base`.
- *
- * `--rt-tint`/`--rt-tint-alpha` describe one layer (see `selectionOverlayColor.ts`), and
- * `color-mix` composites it over whatever it is given: over transparency it is the layer itself,
- * over an opaque colour it is what that colour looks like beneath the layer. That second form is
- * how surfaces the overlay cannot physically cover still get tinted with it.
- */
-const tinted = (base: string): string => `color-mix(in srgb, var(--rt-tint) var(--rt-tint-alpha), ${base})`;
-
-/**
  * Paints a table the main editor's selection covers as one selected block.
  *
- * Three layers, because a rendered table has surfaces CodeMirror's own selection background can
- * never reach — it sits behind editor text, while a table carries opaque backgrounds of its own
- * on the header, inline code, `==highlight==` and images.
- *
- * 1. The widget root takes the selection colour outright. It is the block box, so this covers
- *    the widget's padding and the strip beside a narrow table, and being a background rather
- *    than a positioned layer it stays put when a wide table scrolls horizontally.
- * 2. Every cell takes the ground the tint is solved against, replacing the header's own
- *    background. Painting the ground rather than inheriting the theme's is what lets the tint
- *    be exact (see `selectionOverlayColor.ts`).
- * 3. A cell-sized overlay composites that ground up to the selection colour, and takes
- *    everything the cell renders with it. It hangs off the cells because they are already
- *    positioned (`tableStyles.ts`) and scroll with the table; an overlay on the widget root
- *    would be pinned to the scroll origin and slide off a wide table.
- *
- * Cell borders are tinted through their colour rather than by the overlay: they sit outside the
- * padding box it covers, and growing it to reach them would darken every inner border twice,
- * `border-collapse` having made each one shared. Left untinted they all but vanish — the divider
- * colour is a light grey chosen to read on the editor background, and the selection ground is
- * darker than it, dropping a gridline's contrast against its own cell from about 1.36 to 1.06.
+ * `selectionTint.ts` paints the cells; the widget root takes the selection colour outright on top
+ * of that. The root is the block box, so this covers the widget's padding and the strip beside a
+ * narrow table, and being a background rather than a positioned layer it stays put when a wide
+ * table scrolls horizontally.
  *
  * Painting the block ourselves also frees the highlight from `drawSelection`, whose rects around
  * a rendered table are unreliable: it measures through `coordsAtPos`, which `TableWidget.coordsAt`
@@ -129,32 +103,11 @@ const tableSelectionHighlightTheme = EditorView.baseTheme({
     [`&.cm-focused ${getWidgetSelector()}::selection`]: NATIVE_SELECTION_RESET,
     [`&.cm-focused ${getWidgetSelector()} ::selection`]: NATIVE_SELECTION_RESET,
 
-    // Focus is resolved once, into the tint the rules below read, so nothing else needs a
-    // `.cm-focused` copy of itself.
     [SELECTED_WIDGET]: {
-        '--rt-tint': 'var(--rt-tint-blurred)',
-        '--rt-tint-alpha': 'var(--rt-tint-blurred-alpha)',
-        backgroundColor: 'var(--rt-selection-blurred-bg)',
-    } as Record<string, string>,
-    [`&.cm-focused ${SELECTED_WIDGET}`]: {
-        '--rt-tint': 'var(--rt-tint-focused)',
-        '--rt-tint-alpha': 'var(--rt-tint-focused-alpha)',
-        backgroundColor: 'var(--rt-selection-focused-bg)',
-    } as Record<string, string>,
+        backgroundColor: 'var(--rt-selection-bg)',
+    },
 
-    [selectedCells()]: {
-        backgroundColor: 'var(--rt-table-selection-ground-bg)',
-        borderColor: tinted('var(--rt-border-color)'),
-    },
-    [selectedCells('::after')]: {
-        content: '""',
-        position: 'absolute',
-        inset: '0',
-        // Above content the cell positions for itself, which would otherwise paint over the fill.
-        zIndex: '1',
-        backgroundColor: tinted('transparent'),
-        pointerEvents: 'none',
-    },
+    ...selectedCellRules(selectedCells),
 });
 
 /** Whole-table selection highlight for tables the main editor's selection covers. */

--- a/src/contentScript/tableWidget/tableSelectionHighlight.ts
+++ b/src/contentScript/tableWidget/tableSelectionHighlight.ts
@@ -75,11 +75,11 @@ const CELL_TAGS = ['td', 'th'] as const;
  * The coordinate attributes keep it off `td`/`th` belonging to a raw HTML table inside a cell's
  * rendered Markdown, which is content the highlight passes over rather than chrome it owns.
  */
-function selectedCells(options: { scope?: string; pseudo?: string } = {}): string {
-    const { scope = '', pseudo = '' } = options;
+function selectedCells(options: { pseudo?: string } = {}): string {
+    const { pseudo = '' } = options;
 
     return CELL_TAGS.map(
-        (tag) => `${scope}${SELECTED_WIDGET} .${CLASS_TABLE_WIDGET_TABLE} ${tag}${CELL_COORDS_ATTRIBUTES}${pseudo}`
+        (tag) => `${SELECTED_WIDGET} .${CLASS_TABLE_WIDGET_TABLE} ${tag}${CELL_COORDS_ATTRIBUTES}${pseudo}`
     ).join(', ');
 }
 
@@ -101,6 +101,16 @@ const NATIVE_SELECTION_RESET = {
 };
 
 /**
+ * Lays the selection tint over `base`.
+ *
+ * `--rt-tint`/`--rt-tint-alpha` describe one layer (see `selectionOverlayColor.ts`), and
+ * `color-mix` composites it over whatever it is given: over transparency it is the layer itself,
+ * over an opaque colour it is what that colour looks like beneath the layer. That second form is
+ * how surfaces the overlay cannot physically cover still get tinted with it.
+ */
+const tinted = (base: string): string => `color-mix(in srgb, var(--rt-tint) var(--rt-tint-alpha), ${base})`;
+
+/**
  * Paints a table the main editor's selection covers as one selected block.
  *
  * Three layers, because a rendered table has surfaces CodeMirror's own selection background can
@@ -110,22 +120,24 @@ const NATIVE_SELECTION_RESET = {
  * 1. The widget root takes the selection colour outright. It is the block box, so this covers
  *    the widget's padding and the strip beside a narrow table, and being a background rather
  *    than a positioned layer it stays put when a wide table scrolls horizontally.
- * 2. Every cell takes the ground the overlay is solved against, replacing the header's own
- *    background. Painting the ground rather than inheriting the theme's is what lets the
- *    overlay be exact (see `selectionOverlayColor.ts`).
+ * 2. Every cell takes the ground the tint is solved against, replacing the header's own
+ *    background. Painting the ground rather than inheriting the theme's is what lets the tint
+ *    be exact (see `selectionOverlayColor.ts`).
  * 3. A cell-sized overlay composites that ground up to the selection colour, and takes
  *    everything the cell renders with it. It hangs off the cells because they are already
  *    positioned (`tableStyles.ts`) and scroll with the table; an overlay on the widget root
  *    would be pinned to the scroll origin and slide off a wide table.
  *
+ * Cell borders sit outside the padding box an overlay can cover, and `border-collapse` makes each
+ * inner one shared, so an overlay grown to reach them would darken those twice over. They are
+ * tinted through their colour instead. Left alone they all but vanish: the divider colour is a
+ * light grey chosen to read on the editor background, and the selection ground is darker than it,
+ * which drops a gridline's contrast against its own cell from about 1.36 to 1.06.
+ *
  * Painting the block ourselves also makes the highlight independent of `drawSelection`, which
  * measures ranges through `coordsAtPos` — answered for a rendered table by
  * `TableWidget.coordsAt` with cell rectangles, so the rects it paints around a selected table
  * are unreliable: sometimes the full block, sometimes a sliver at the table's edge.
- *
- * Cell borders sit outside the padding box the overlay covers, so they keep their own colour and
- * read as grid lines across the fill. Tinting them from both sides would darken them twice,
- * since `border-collapse` makes each one shared.
  */
 const tableSelectionHighlightTheme = EditorView.baseTheme({
     [`${getWidgetSelector()}::selection`]: NATIVE_SELECTION_RESET,
@@ -133,14 +145,22 @@ const tableSelectionHighlightTheme = EditorView.baseTheme({
     [`&.cm-focused ${getWidgetSelector()}::selection`]: NATIVE_SELECTION_RESET,
     [`&.cm-focused ${getWidgetSelector()} ::selection`]: NATIVE_SELECTION_RESET,
 
+    // Focus is resolved once, into the tint the rules below read, so nothing else needs a
+    // `.cm-focused` copy of itself.
     [SELECTED_WIDGET]: {
+        '--rt-tint': 'var(--rt-tint-blurred)',
+        '--rt-tint-alpha': 'var(--rt-tint-blurred-alpha)',
         backgroundColor: 'var(--rt-selection-blurred-bg)',
-    },
+    } as Record<string, string>,
     [`&.cm-focused ${SELECTED_WIDGET}`]: {
+        '--rt-tint': 'var(--rt-tint-focused)',
+        '--rt-tint-alpha': 'var(--rt-tint-focused-alpha)',
         backgroundColor: 'var(--rt-selection-focused-bg)',
-    },
+    } as Record<string, string>,
+
     [selectedCells()]: {
         backgroundColor: 'var(--rt-table-selection-ground-bg)',
+        borderColor: tinted('var(--rt-border-color)'),
     },
     [selectedCells({ pseudo: '::after' })]: {
         content: '""',
@@ -152,11 +172,8 @@ const tableSelectionHighlightTheme = EditorView.baseTheme({
         left: '0',
         // Above content the cell positions for itself, which would otherwise paint over the fill.
         zIndex: '1',
-        backgroundColor: 'var(--rt-table-selection-overlay-blurred)',
+        backgroundColor: tinted('transparent'),
         pointerEvents: 'none',
-    },
-    [selectedCells({ scope: '&.cm-focused ', pseudo: '::after' })]: {
-        backgroundColor: 'var(--rt-table-selection-overlay)',
     },
 });
 

--- a/src/contentScript/tableWidget/tableSelectionHighlight.ts
+++ b/src/contentScript/tableWidget/tableSelectionHighlight.ts
@@ -1,0 +1,167 @@
+import type { EditorState, Extension } from '@codemirror/state';
+import { EditorView } from '@codemirror/view';
+import {
+    CELL_COORDS_ATTRIBUTES,
+    CLASS_TABLE_WIDGET_SELECTED,
+    CLASS_TABLE_WIDGET_TABLE,
+    getWidgetSelector,
+} from './domHelpers';
+import { findRenderedTablesWithin, type TableSpan } from './tableDecorationField';
+import { measuredClassSyncPlugin } from './measuredClassSync';
+
+/**
+ * Rendered tables the main editor's selection covers end to end.
+ *
+ * Coverage is all-or-nothing by design: a block widget has no meaningful partial selection, and
+ * `tableRuntime/selection/tableSelectionSnap.ts` grows any selection that touches a table until
+ * it contains the whole thing, so a partially covered table is only ever a transient state.
+ */
+export function findSelectedTableSpans(state: EditorState): TableSpan[] {
+    const spans: TableSpan[] = [];
+    const seen = new Set<number>();
+
+    for (const range of state.selection.ranges) {
+        if (range.empty) {
+            continue;
+        }
+
+        for (const span of findRenderedTablesWithin(state, range.from, range.to)) {
+            // Ranges in a selection never overlap, so a repeat only happens when two ranges
+            // touch the same table edge; de-duplicating keeps the result a set of tables.
+            if (!seen.has(span.from)) {
+                seen.add(span.from);
+                spans.push(span);
+            }
+        }
+    }
+
+    return spans;
+}
+
+/**
+ * Widget roots for the selected tables.
+ *
+ * One pass over the mounted widgets rather than a lookup per table: `posAtDOM` is the only
+ * trustworthy widget identity (see `findTableWidgetElement`), so scanning once keeps a
+ * select-all over a table-heavy note linear in the number of visible widgets.
+ */
+function collectSelectedTableWidgets(view: EditorView): HTMLElement[] {
+    const selectedTableStarts = new Set(findSelectedTableSpans(view.state).map((span) => span.from));
+    if (selectedTableStarts.size === 0) {
+        return [];
+    }
+
+    const selectedWidgets: HTMLElement[] = [];
+
+    for (const widget of view.contentDOM.querySelectorAll<HTMLElement>(getWidgetSelector())) {
+        try {
+            if (selectedTableStarts.has(view.posAtDOM(widget))) {
+                selectedWidgets.push(widget);
+            }
+        } catch {
+            // posAtDOM can fail for widget DOM that is on its way out; skip it.
+        }
+    }
+
+    return selectedWidgets;
+}
+
+const SELECTED_WIDGET = `${getWidgetSelector()}.${CLASS_TABLE_WIDGET_SELECTED}`;
+const CELL_TAGS = ['td', 'th'] as const;
+
+/**
+ * Selector for the widget's own cells inside a selected table.
+ *
+ * The coordinate attributes keep it off `td`/`th` belonging to a raw HTML table inside a cell's
+ * rendered Markdown, which is content the highlight passes over rather than chrome it owns.
+ */
+function selectedCells(options: { scope?: string; pseudo?: string } = {}): string {
+    const { scope = '', pseudo = '' } = options;
+
+    return CELL_TAGS.map(
+        (tag) => `${scope}${SELECTED_WIDGET} .${CLASS_TABLE_WIDGET_TABLE} ${tag}${CELL_COORDS_ATTRIBUTES}${pseudo}`
+    ).join(', ');
+}
+
+/**
+ * Removes the browser's own selection highlight from everything a table widget renders.
+ *
+ * CodeMirror's `drawSelection` only neutralizes native `::selection` inside `.cm-line`, and a
+ * block replace widget is a direct child of `.cm-content`, so the browser paints its own
+ * highlight over every run of text in the rendered table — ragged per-word boxes in whatever
+ * colour the platform picked.
+ *
+ * The `&.cm-focused` copies exist for specificity: Joplin's own `&.cm-focused ::selection` rule
+ * is two classes with `!important`, so the unfocused rules alone would tie with it and be
+ * settled by stylesheet order. Same approach as `nestedEditor/rootEditorSelectionTheme.ts`.
+ */
+const NATIVE_SELECTION_RESET = {
+    'background-color': 'transparent !important',
+    color: 'inherit !important',
+};
+
+/**
+ * Paints a table the main editor's selection covers as one selected block.
+ *
+ * Three layers, because a rendered table has surfaces CodeMirror's own selection background can
+ * never reach — it sits behind editor text, while a table carries opaque backgrounds of its own
+ * on the header, inline code, `==highlight==` and images.
+ *
+ * 1. The widget root takes the selection colour outright. It is the block box, so this covers
+ *    the widget's padding and the strip beside a narrow table, and being a background rather
+ *    than a positioned layer it stays put when a wide table scrolls horizontally.
+ * 2. Every cell takes the ground the overlay is solved against, replacing the header's own
+ *    background. Painting the ground rather than inheriting the theme's is what lets the
+ *    overlay be exact (see `selectionOverlayColor.ts`).
+ * 3. A cell-sized overlay composites that ground up to the selection colour, and takes
+ *    everything the cell renders with it. It hangs off the cells because they are already
+ *    positioned (`tableStyles.ts`) and scroll with the table; an overlay on the widget root
+ *    would be pinned to the scroll origin and slide off a wide table.
+ *
+ * Painting the block ourselves also makes the highlight independent of `drawSelection`, which
+ * measures ranges through `coordsAtPos` — answered for a rendered table by
+ * `TableWidget.coordsAt` with cell rectangles, so the rects it paints around a selected table
+ * are unreliable: sometimes the full block, sometimes a sliver at the table's edge.
+ *
+ * Cell borders sit outside the padding box the overlay covers, so they keep their own colour and
+ * read as grid lines across the fill. Tinting them from both sides would darken them twice,
+ * since `border-collapse` makes each one shared.
+ */
+const tableSelectionHighlightTheme = EditorView.baseTheme({
+    [`${getWidgetSelector()}::selection`]: NATIVE_SELECTION_RESET,
+    [`${getWidgetSelector()} ::selection`]: NATIVE_SELECTION_RESET,
+    [`&.cm-focused ${getWidgetSelector()}::selection`]: NATIVE_SELECTION_RESET,
+    [`&.cm-focused ${getWidgetSelector()} ::selection`]: NATIVE_SELECTION_RESET,
+
+    [SELECTED_WIDGET]: {
+        backgroundColor: 'var(--rt-selection-blurred-bg)',
+    },
+    [`&.cm-focused ${SELECTED_WIDGET}`]: {
+        backgroundColor: 'var(--rt-selection-focused-bg)',
+    },
+    [selectedCells()]: {
+        backgroundColor: 'var(--rt-table-selection-ground-bg)',
+    },
+    [selectedCells({ pseudo: '::after' })]: {
+        content: '""',
+        position: 'absolute',
+        // Longhand rather than `inset`, which older mobile WebViews do not support.
+        top: '0',
+        right: '0',
+        bottom: '0',
+        left: '0',
+        // Above content the cell positions for itself, which would otherwise paint over the fill.
+        zIndex: '1',
+        backgroundColor: 'var(--rt-table-selection-overlay-blurred)',
+        pointerEvents: 'none',
+    },
+    [selectedCells({ scope: '&.cm-focused ', pseudo: '::after' })]: {
+        backgroundColor: 'var(--rt-table-selection-overlay)',
+    },
+});
+
+/** Whole-table selection highlight for tables the main editor's selection covers. */
+export const tableSelectionHighlight: Extension = [
+    measuredClassSyncPlugin(CLASS_TABLE_WIDGET_SELECTED, collectSelectedTableWidgets),
+    tableSelectionHighlightTheme,
+];

--- a/src/contentScript/tableWidget/tableSelectionHighlight.ts
+++ b/src/contentScript/tableWidget/tableSelectionHighlight.ts
@@ -15,27 +15,14 @@ import { measuredClassSyncPlugin } from './measuredClassSync';
  * Coverage is all-or-nothing by design: a block widget has no meaningful partial selection, and
  * `tableRuntime/selection/tableSelectionSnap.ts` grows any selection that touches a table until
  * it contains the whole thing, so a partially covered table is only ever a transient state.
+ *
+ * No table can appear twice: selection ranges never overlap, so containing the same table whole
+ * would take a range of zero length.
  */
 export function findSelectedTableSpans(state: EditorState): TableSpan[] {
-    const spans: TableSpan[] = [];
-    const seen = new Set<number>();
-
-    for (const range of state.selection.ranges) {
-        if (range.empty) {
-            continue;
-        }
-
-        for (const span of findRenderedTablesWithin(state, range.from, range.to)) {
-            // Ranges in a selection never overlap, so a repeat only happens when two ranges
-            // touch the same table edge; de-duplicating keeps the result a set of tables.
-            if (!seen.has(span.from)) {
-                seen.add(span.from);
-                spans.push(span);
-            }
-        }
-    }
-
-    return spans;
+    return state.selection.ranges.flatMap((range) =>
+        range.empty ? [] : findRenderedTablesWithin(state, range.from, range.to)
+    );
 }
 
 /**
@@ -75,9 +62,7 @@ const CELL_TAGS = ['td', 'th'] as const;
  * The coordinate attributes keep it off `td`/`th` belonging to a raw HTML table inside a cell's
  * rendered Markdown, which is content the highlight passes over rather than chrome it owns.
  */
-function selectedCells(options: { pseudo?: string } = {}): string {
-    const { pseudo = '' } = options;
-
+function selectedCells(pseudo = ''): string {
     return CELL_TAGS.map(
         (tag) => `${SELECTED_WIDGET} .${CLASS_TABLE_WIDGET_TABLE} ${tag}${CELL_COORDS_ATTRIBUTES}${pseudo}`
     ).join(', ');
@@ -128,16 +113,15 @@ const tinted = (base: string): string => `color-mix(in srgb, var(--rt-tint) var(
  *    positioned (`tableStyles.ts`) and scroll with the table; an overlay on the widget root
  *    would be pinned to the scroll origin and slide off a wide table.
  *
- * Cell borders sit outside the padding box an overlay can cover, and `border-collapse` makes each
- * inner one shared, so an overlay grown to reach them would darken those twice over. They are
- * tinted through their colour instead. Left alone they all but vanish: the divider colour is a
- * light grey chosen to read on the editor background, and the selection ground is darker than it,
- * which drops a gridline's contrast against its own cell from about 1.36 to 1.06.
+ * Cell borders are tinted through their colour rather than by the overlay: they sit outside the
+ * padding box it covers, and growing it to reach them would darken every inner border twice,
+ * `border-collapse` having made each one shared. Left untinted they all but vanish — the divider
+ * colour is a light grey chosen to read on the editor background, and the selection ground is
+ * darker than it, dropping a gridline's contrast against its own cell from about 1.36 to 1.06.
  *
- * Painting the block ourselves also makes the highlight independent of `drawSelection`, which
- * measures ranges through `coordsAtPos` — answered for a rendered table by
- * `TableWidget.coordsAt` with cell rectangles, so the rects it paints around a selected table
- * are unreliable: sometimes the full block, sometimes a sliver at the table's edge.
+ * Painting the block ourselves also frees the highlight from `drawSelection`, whose rects around
+ * a rendered table are unreliable: it measures through `coordsAtPos`, which `TableWidget.coordsAt`
+ * answers with cell rectangles.
  */
 const tableSelectionHighlightTheme = EditorView.baseTheme({
     [`${getWidgetSelector()}::selection`]: NATIVE_SELECTION_RESET,
@@ -162,14 +146,10 @@ const tableSelectionHighlightTheme = EditorView.baseTheme({
         backgroundColor: 'var(--rt-table-selection-ground-bg)',
         borderColor: tinted('var(--rt-border-color)'),
     },
-    [selectedCells({ pseudo: '::after' })]: {
+    [selectedCells('::after')]: {
         content: '""',
         position: 'absolute',
-        // Longhand rather than `inset`, which older mobile WebViews do not support.
-        top: '0',
-        right: '0',
-        bottom: '0',
-        left: '0',
+        inset: '0',
         // Above content the cell positions for itself, which would otherwise paint over the fill.
         zIndex: '1',
         backgroundColor: tinted('transparent'),

--- a/src/contentScript/tableWidget/tableStyles.ts
+++ b/src/contentScript/tableWidget/tableStyles.ts
@@ -85,7 +85,7 @@ export const tableStyles = EditorView.baseTheme({
     },
     [`.${CLASS_TABLE_WIDGET_TABLE} td.${CLASS_CELL_SELECTED}, .${CLASS_TABLE_WIDGET_TABLE} th.${CLASS_CELL_SELECTED}`]:
         {
-            backgroundColor: 'var(--rt-selection-bg)',
+            backgroundColor: 'var(--rt-cell-selection-bg)',
         },
 
     // -------------------------------------------------------------------------

--- a/src/contentScript/tableWidget/tableStyles.ts
+++ b/src/contentScript/tableWidget/tableStyles.ts
@@ -8,6 +8,14 @@ import {
 import { CLASS_TABLE_WIDGET_TABLE, getWidgetSelector } from './domHelpers';
 
 /**
+ * Width of the gridline between cells.
+ *
+ * `border-collapse` makes each one shared, so this is the whole line, not a half of one --
+ * `selectionTint.ts` redraws a gridline at exactly this width.
+ */
+export const CELL_BORDER_WIDTH = '1px';
+
+/**
  * Base styles for the table widget, split by responsibility:
  *
  *   1. Widget container and table layout
@@ -42,7 +50,7 @@ export const tableStyles = EditorView.baseTheme({
     // -------------------------------------------------------------------------
 
     [`.${CLASS_TABLE_WIDGET_TABLE} th, .${CLASS_TABLE_WIDGET_TABLE} td`]: {
-        border: '1px solid var(--rt-border-color)',
+        border: `${CELL_BORDER_WIDTH} solid var(--rt-border-color)`,
         padding: '8px 12px',
         minWidth: '75px',
         // Joplin/CodeMirror editor styles can apply aggressive breaking (e.g. `overflow-wrap: anywhere`)

--- a/src/contentScript/tableWidget/tableStyles.ts
+++ b/src/contentScript/tableWidget/tableStyles.ts
@@ -5,7 +5,7 @@ import {
     CLASS_CELL_EDITOR,
     CLASS_CELL_EDITOR_HIDDEN,
 } from '../shared/tableDomClasses';
-import { CLASS_CELL_SELECTED, CLASS_TABLE_WIDGET_TABLE, getWidgetSelector } from './domHelpers';
+import { CLASS_TABLE_WIDGET_TABLE, getWidgetSelector } from './domHelpers';
 
 /**
  * Base styles for the table widget, split by responsibility:
@@ -83,11 +83,6 @@ export const tableStyles = EditorView.baseTheme({
         overflowWrap: 'normal',
         boxSizing: 'border-box',
     },
-    [`.${CLASS_TABLE_WIDGET_TABLE} td.${CLASS_CELL_SELECTED}, .${CLASS_TABLE_WIDGET_TABLE} th.${CLASS_CELL_SELECTED}`]:
-        {
-            backgroundColor: 'var(--rt-cell-selection-bg)',
-        },
-
     // -------------------------------------------------------------------------
     // 3. Nested editor DOM resets
     //

--- a/src/contentScript/tableWidget/tableWidgetExtension.ts
+++ b/src/contentScript/tableWidget/tableWidgetExtension.ts
@@ -19,6 +19,7 @@ import { sourceModeField } from '../tableState/sourceMode';
 import { insertedTableActivationField } from '../tableState/insertedTableActivation';
 import { cellSelectionClipboardPlugin } from '../tableRuntime/selection/cellSelectionClipboard';
 import { cellSelectionKeyCapturePlugin } from '../tableRuntime/selection/cellSelectionKeymap';
+import { cellSelectionFocusPlugin } from '../tableRuntime/selection/cellSelectionController';
 import { cellSelectionScopeGuard } from '../tableRuntime/selection/cellSelectionScopeGuard';
 import { cellSelectionCaretSuppression, cellSelectionVisuals } from './cellSelectionVisuals';
 import { tableSelectionHighlight } from './tableSelectionHighlight';
@@ -144,6 +145,7 @@ async function registerTableWidgetExtension(
         cellSelectionKeyCapturePlugin,
         cellSelectionScopeGuard,
         cellSelectionClipboardPlugin,
+        cellSelectionFocusPlugin,
         cellSelectionVisuals,
         cellSelectionCaretSuppression,
         tableSelectionHighlight,

--- a/src/contentScript/tableWidget/tableWidgetExtension.ts
+++ b/src/contentScript/tableWidget/tableWidgetExtension.ts
@@ -20,7 +20,7 @@ import { insertedTableActivationField } from '../tableState/insertedTableActivat
 import { cellSelectionClipboardPlugin } from '../tableRuntime/selection/cellSelectionClipboard';
 import { cellSelectionKeyCapturePlugin } from '../tableRuntime/selection/cellSelectionKeymap';
 import { cellSelectionScopeGuard } from '../tableRuntime/selection/cellSelectionScopeGuard';
-import { cellSelectionCaretSuppression, cellSelectionVisualsPlugin } from './cellSelectionVisuals';
+import { cellSelectionCaretSuppression, cellSelectionVisuals } from './cellSelectionVisuals';
 import { tableSelectionHighlight } from './tableSelectionHighlight';
 import { tableSelectionSnapFilter } from '../tableRuntime/selection/tableSelectionSnap';
 import { isNestedEditorOpen, nestedEditorPlugin } from '../nestedEditor/nestedEditorController';
@@ -144,7 +144,7 @@ async function registerTableWidgetExtension(
         cellSelectionKeyCapturePlugin,
         cellSelectionScopeGuard,
         cellSelectionClipboardPlugin,
-        cellSelectionVisualsPlugin,
+        cellSelectionVisuals,
         cellSelectionCaretSuppression,
         tableSelectionHighlight,
         nestedEditorFocusGuard,

--- a/src/contentScript/tableWidget/tableWidgetExtension.ts
+++ b/src/contentScript/tableWidget/tableWidgetExtension.ts
@@ -21,6 +21,8 @@ import { cellSelectionClipboardPlugin } from '../tableRuntime/selection/cellSele
 import { cellSelectionKeyCapturePlugin } from '../tableRuntime/selection/cellSelectionKeymap';
 import { cellSelectionScopeGuard } from '../tableRuntime/selection/cellSelectionScopeGuard';
 import { cellSelectionCaretSuppression, cellSelectionVisualsPlugin } from './cellSelectionVisuals';
+import { tableSelectionHighlight } from './tableSelectionHighlight';
+import { tableSelectionSnapFilter } from '../tableRuntime/selection/tableSelectionSnap';
 import { isNestedEditorOpen, nestedEditorPlugin } from '../nestedEditor/nestedEditorController';
 import { nestedEditorFocusGuard } from '../nestedEditor/nestedEditorFocusGuard';
 import { createMainEditorActiveCellGuard } from '../editorBridge/mainEditorGuard';
@@ -127,6 +129,7 @@ async function registerTableWidgetExtension(
         cellSelectionField,
         cellDragField,
         mainEditorTableEntryExtension,
+        tableSelectionSnapFilter,
         // Registered ahead of the guard so its paste rewrites are already spaced when
         // boundary maintenance inspects the result.
         tableBoundaryMaintenanceExtension,
@@ -143,6 +146,7 @@ async function registerTableWidgetExtension(
         cellSelectionClipboardPlugin,
         cellSelectionVisualsPlugin,
         cellSelectionCaretSuppression,
+        tableSelectionHighlight,
         nestedEditorFocusGuard,
         nestedEditorLifecyclePlugin,
         tableDecorationField,

--- a/src/contentScript/tableWidget/tableWidgetExtension.ts
+++ b/src/contentScript/tableWidget/tableWidgetExtension.ts
@@ -22,7 +22,7 @@ import { cellSelectionKeyCapturePlugin } from '../tableRuntime/selection/cellSel
 import { cellSelectionFocusPlugin } from '../tableRuntime/selection/cellSelectionController';
 import { cellSelectionScopeGuard } from '../tableRuntime/selection/cellSelectionScopeGuard';
 import { cellSelectionCaretSuppression, cellSelectionVisuals } from './cellSelectionVisuals';
-import { tableSelectionHighlight } from './tableSelectionHighlight';
+import { wholeTableSelectionVisuals } from './wholeTableSelectionVisuals';
 import { tableSelectionSnapFilter } from '../tableRuntime/selection/tableSelectionSnap';
 import { isNestedEditorOpen, nestedEditorPlugin } from '../nestedEditor/nestedEditorController';
 import { nestedEditorFocusGuard } from '../nestedEditor/nestedEditorFocusGuard';
@@ -148,7 +148,7 @@ async function registerTableWidgetExtension(
         cellSelectionFocusPlugin,
         cellSelectionVisuals,
         cellSelectionCaretSuppression,
-        tableSelectionHighlight,
+        wholeTableSelectionVisuals,
         nestedEditorFocusGuard,
         nestedEditorLifecyclePlugin,
         tableDecorationField,

--- a/src/contentScript/tableWidget/wholeTableSelectionVisuals.ts
+++ b/src/contentScript/tableWidget/wholeTableSelectionVisuals.ts
@@ -60,7 +60,7 @@ const SELECTED_WIDGET = `${getWidgetSelector()}.${CLASS_TABLE_WIDGET_SELECTED}`;
  * Selector for the widget's own cells inside a selected table.
  *
  * The coordinate attributes keep it off `td`/`th` belonging to a raw HTML table inside a cell's
- * rendered Markdown, which is content the highlight passes over rather than chrome it owns.
+ * rendered Markdown, which is content the selection fill passes over rather than chrome the widget owns.
  */
 function selectedCells(pseudo = ''): string {
     return CELL_TAGS.map(
@@ -97,7 +97,7 @@ const NATIVE_SELECTION_RESET = {
  * a rendered table are unreliable: it measures through `coordsAtPos`, which `TableWidget.coordsAt`
  * answers with cell rectangles.
  */
-const tableSelectionHighlightTheme = EditorView.baseTheme({
+const wholeTableSelectionTheme = EditorView.baseTheme({
     [`${getWidgetSelector()}::selection`]: NATIVE_SELECTION_RESET,
     [`${getWidgetSelector()} ::selection`]: NATIVE_SELECTION_RESET,
     [`&.cm-focused ${getWidgetSelector()}::selection`]: NATIVE_SELECTION_RESET,
@@ -110,8 +110,8 @@ const tableSelectionHighlightTheme = EditorView.baseTheme({
     ...selectedCellRules(selectedCells),
 });
 
-/** Whole-table selection highlight for tables the main editor's selection covers. */
-export const tableSelectionHighlight: Extension = [
+/** Whole-table selection visuals for tables the main editor's selection covers end to end. */
+export const wholeTableSelectionVisuals: Extension = [
     measuredClassSyncPlugin(CLASS_TABLE_WIDGET_SELECTED, collectSelectedTableWidgets),
-    tableSelectionHighlightTheme,
+    wholeTableSelectionTheme,
 ];


### PR DESCRIPTION
Enhance the visual appearance of selections when a main editor selection covers a table, and ensure that main editor selections cover either none of the table or the entire table (partial selections that aren't visible under the block widget aren't useful)

Also refactor the multi-cell selection functionality to share the improved selection appearance.