### PR TITLE
feat: click-to-caret placement in cell editing

### DIFF
--- a/docs/Architecture/Interaction-and-Navigation.md
+++ b/docs/Architecture/Interaction-and-Navigation.md
@@ -89,11 +89,12 @@ block-level tokens with line numbers only, and a cell is one line. The mapping i
    text a reader sees, counting `<br>` as the newline it stands for and skipping MathML, whose text transcribes the
    formula rather than its source.
 2. `shared/textAlignment.ts` aligns that text against the cell's own text. Rendering only removes characters, so the
-   rendered text is a subsequence of its source for the inline constructs cells contain. Alignment uses `difflib`'s
-   recursive longest-matching-block scheme rather than a plain LCS, which is free to scatter its matches across a
-   URL or a repeated word. The runtime excludes raw-HTML tag, comment and processing-instruction ranges identified
-   by CodeMirror's Markdown syntax tree, preventing visible text from mapping into raw-HTML syntax without mistaking
-   inline code or autolinks for HTML.
+   rendered text is a subsequence of its source for the inline constructs cells contain. Alignment prefers `difflib`'s
+   recursive longest-matching-block scheme, which avoids scattering matches across a URL or repeated word. When that
+   heuristic leaves a partial match, a leftmost subsequence pass recovers complete mappings across repeated markup.
+   The runtime excludes raw-HTML tag, comment and processing-instruction ranges identified by CodeMirror's Markdown
+   syntax tree, preventing visible text from mapping into raw-HTML syntax without mistaking inline code or autolinks
+   for HTML.
 3. `tableRuntime/interaction/clickCursorPlacement.ts` converts the aligned offset into an `InitialCursorPos`.
 
 The press is read at pointerdown, before the open request replaces the rendered content, and carried on the gesture

--- a/docs/Architecture/Interaction-and-Navigation.md
+++ b/docs/Architecture/Interaction-and-Navigation.md
@@ -82,8 +82,8 @@ Moving the main-editor caret outside the selected table clears table-owned selec
 A click on a rendered cell opens it with the caret at the clicked point in the Markdown source, so clicking inside a
 bolded word lands between the same two letters once the syntax is visible.
 
-Joplin's `renderMarkup` cannot help with this: its source map (`MdToHtml/rules/source_map.ts`) annotates block-level
-tokens with line numbers only, and a cell is one line. The mapping is instead recovered by aligning text.
+Joplin's `renderMarkup` accepts `mapsToLine`, but the emitted map (`MdToHtml/rules/source_map.ts`) annotates
+block-level tokens with line numbers only, and a cell is one line. The mapping is instead recovered by aligning text.
 
 1. `tableWidget/cellCaretHit.ts` hit-tests the press against the rendered content and flattens that content into the
    text a reader sees, counting `<br>` as the newline it stands for and skipping MathML, whose text transcribes the
@@ -91,8 +91,9 @@ tokens with line numbers only, and a cell is one line. The mapping is instead re
 2. `shared/textAlignment.ts` aligns that text against the cell's own text. Rendering only removes characters, so the
    rendered text is a subsequence of its source for the inline constructs cells contain. Alignment uses `difflib`'s
    recursive longest-matching-block scheme rather than a plain LCS, which is free to scatter its matches across a
-   URL or a repeated word. Matches outside probable raw-HTML tokens win ties, preventing visible text from mapping
-   into a tag or attribute; unrestricted matching remains available for tag-shaped text rendered literally.
+   URL or a repeated word. The runtime excludes raw-HTML tag, comment and processing-instruction ranges identified
+   by CodeMirror's Markdown syntax tree, preventing visible text from mapping into raw-HTML syntax without mistaking
+   inline code or autolinks for HTML.
 3. `tableRuntime/interaction/clickCursorPlacement.ts` converts the aligned offset into an `InitialCursorPos`.
 
 The press is read at pointerdown, before the open request replaces the rendered content, and carried on the gesture

--- a/docs/Architecture/Interaction-and-Navigation.md
+++ b/docs/Architecture/Interaction-and-Navigation.md
@@ -77,9 +77,34 @@ the same cell-selection tint; their extent distinguishes them.
 
 Moving the main-editor caret outside the selected table clears table-owned selection state.
 
+## Click-to-Caret Placement
+
+A click on a rendered cell opens it with the caret at the clicked point in the Markdown source, so clicking inside a
+bolded word lands between the same two letters once the syntax is visible.
+
+Joplin's `renderMarkup` cannot help with this: its source map (`MdToHtml/rules/source_map.ts`) annotates block-level
+tokens with line numbers only, and a cell is one line. The mapping is instead recovered by aligning text.
+
+1. `tableWidget/cellCaretHit.ts` hit-tests the press against the rendered content and flattens that content into the
+   text a reader sees, counting `<br>` as the newline it stands for and skipping MathML, whose text transcribes the
+   formula rather than its source.
+2. `shared/textAlignment.ts` aligns that text against the cell's own text. Rendering only removes characters, so the
+   rendered text is a subsequence of its source for the inline constructs cells contain. Alignment uses `difflib`'s
+   recursive longest-matching-block scheme rather than a plain LCS, which is free to scatter its matches across a
+   URL or a repeated word.
+3. `tableRuntime/interaction/clickCursorPlacement.ts` converts the aligned offset into an `InitialCursorPos`.
+
+The press is read at pointerdown, before the open request replaces the rendered content, and carried on the gesture
+until the release proves it was a click rather than a drag.
+
+Substitutions that are not subsequences (`&amp;` to `&`, emoji shortcodes, KaTeX) leave a gap the alignment steps
+over; because each gap is bounded by the blocks around it, the damage stays local. A caret landing in one resolves to
+the nearest anchor, and a cell whose rendered text is mostly gaps abandons the placement and mirrors the main
+editor's selection, which is what every unplaced entry has always done.
+
 ## Pointer, Links, and Scrolling
 
-- Clicking activates a cell or updates the current cell selection.
+- Clicking activates a cell or updates the current cell selection, placing the caret where the click landed.
 - Mouse dragging selects a cell rectangle; touch and pen input retain native scrolling and tap behavior.
 - Drags near an edge auto-scroll the table or host scroll container. See
   [Table-Display.md](./Table-Display.md#host-scroll-modes).

--- a/docs/Architecture/Interaction-and-Navigation.md
+++ b/docs/Architecture/Interaction-and-Navigation.md
@@ -91,7 +91,8 @@ tokens with line numbers only, and a cell is one line. The mapping is instead re
 2. `shared/textAlignment.ts` aligns that text against the cell's own text. Rendering only removes characters, so the
    rendered text is a subsequence of its source for the inline constructs cells contain. Alignment uses `difflib`'s
    recursive longest-matching-block scheme rather than a plain LCS, which is free to scatter its matches across a
-   URL or a repeated word.
+   URL or a repeated word. Matches outside probable raw-HTML tokens win ties, preventing visible text from mapping
+   into a tag or attribute; unrestricted matching remains available for tag-shaped text rendered literally.
 3. `tableRuntime/interaction/clickCursorPlacement.ts` converts the aligned offset into an `InitialCursorPos`.
 
 The press is read at pointerdown, before the open request replaces the rendered content, and carried on the gesture

--- a/src/contentScript/__tests__/clickCursorPlacement.test.ts
+++ b/src/contentScript/__tests__/clickCursorPlacement.test.ts
@@ -158,6 +158,20 @@ describe('resolveClickCursorPos', () => {
         expect(placement(CANONICAL_DOC, boldCell, { renderedText: 'qqqqqqqq', renderedOffset: 4 })).toBe('<mirrored>');
     });
 
+    it('mirrors the main selection when non-empty source renders no indexable text', () => {
+        const doc = ['', '| H1 |', '| --- |', '| ![alt](resource) |', ''].join('\n');
+
+        expect(placement(doc, { section: 'body', row: 0, col: 0 }, { renderedText: '', renderedOffset: 0 })).toBe(
+            '<mirrored>'
+        );
+    });
+
+    it('places the only possible caret in a genuinely empty cell', () => {
+        const doc = ['', '| H1 |', '| --- |', '|  |', ''].join('\n');
+
+        expect(placement(doc, { section: 'body', row: 0, col: 0 }, { renderedText: '', renderedOffset: 0 })).toBe('|');
+    });
+
     it('clamps a caret past the end of the cell text', () => {
         expect(placement(CANONICAL_DOC, boldCell, { renderedText: 'markdown', renderedOffset: 99 })).toBe(
             '**markdown**|'

--- a/src/contentScript/__tests__/clickCursorPlacement.test.ts
+++ b/src/contentScript/__tests__/clickCursorPlacement.test.ts
@@ -149,6 +149,80 @@ describe('resolveClickCursorPos', () => {
         );
     });
 
+    it('excludes raw-HTML tags when aligning their visible text', () => {
+        const doc = ['', '| H1 |', '| --- |', '| <code>code</code> |', ''].join('\n');
+
+        expect(placement(doc, { section: 'body', row: 0, col: 0 }, { renderedText: 'code', renderedOffset: 2 })).toBe(
+            '<code>co|de</code>'
+        );
+    });
+
+    it('excludes raw-HTML attributes when aligning identical visible text', () => {
+        const doc = ['', '| H1 |', '| --- |', '| <span title="hello">hello</span> |', ''].join('\n');
+
+        expect(placement(doc, { section: 'body', row: 0, col: 0 }, { renderedText: 'hello', renderedOffset: 2 })).toBe(
+            '<span title="hello">he|llo</span>'
+        );
+    });
+
+    it('excludes HTML comments when aligning later visible text', () => {
+        const doc = ['', '| H1 |', '| --- |', '| <!--hello-->hello |', ''].join('\n');
+
+        expect(placement(doc, { section: 'body', row: 0, col: 0 }, { renderedText: 'hello', renderedOffset: 2 })).toBe(
+            '<!--hello-->he|llo'
+        );
+    });
+
+    it('excludes HTML processing instructions when aligning later visible text', () => {
+        const doc = ['', '| H1 |', '| --- |', '| <?pi hello?>hello |', ''].join('\n');
+
+        expect(placement(doc, { section: 'body', row: 0, col: 0 }, { renderedText: 'hello', renderedOffset: 2 })).toBe(
+            '<?pi hello?>he|llo'
+        );
+    });
+
+    it('keeps tag-shaped inline code and autolinks available to alignment', () => {
+        const inlineCodeDoc = ['', '| H1 |', '| --- |', '| `<code>code</code>` |', ''].join('\n');
+        const autolinkDoc = ['', '| H1 |', '| --- |', '| <https://example.com> |', ''].join('\n');
+
+        expect(
+            placement(
+                inlineCodeDoc,
+                { section: 'body', row: 0, col: 0 },
+                {
+                    renderedText: '<code>code</code>',
+                    renderedOffset: 8,
+                }
+            )
+        ).toBe('`<code>co|de</code>`');
+        expect(
+            placement(
+                autolinkDoc,
+                { section: 'body', row: 0, col: 0 },
+                {
+                    renderedText: 'https://example.com',
+                    renderedOffset: 8,
+                }
+            )
+        ).toBe('<https://|example.com>');
+    });
+
+    it('maps excluded HTML ranges through an earlier escaped pipe', () => {
+        const doc = ['', '| H1 |', '| --- |', '| a \\| <code>code</code> |', ''].join('\n');
+
+        expect(
+            placement(doc, { section: 'body', row: 0, col: 0 }, { renderedText: 'a | code', renderedOffset: 6 })
+        ).toBe('a | <code>co|de</code>');
+    });
+
+    it('maps excluded HTML ranges through an earlier line break', () => {
+        const doc = ['', '| H1 |', '| --- |', '| one<br><code>code</code> |', ''].join('\n');
+
+        expect(
+            placement(doc, { section: 'body', row: 0, col: 0 }, { renderedText: 'one\ncode', renderedOffset: 6 })
+        ).toBe('one\n<code>co|de</code>');
+    });
+
     it('mirrors the main selection when the press produced no caret', () => {
         expect(placement(CANONICAL_DOC, boldCell, null)).toBe('<mirrored>');
     });

--- a/src/contentScript/__tests__/clickCursorPlacement.test.ts
+++ b/src/contentScript/__tests__/clickCursorPlacement.test.ts
@@ -1,0 +1,166 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect } from 'vitest';
+import { CLASS_CELL_CONTENT } from '../shared/tableDomClasses';
+import { indexRenderedText, flatOffsetFromDomPosition, type RenderedCaretHit } from '../tableWidget/cellCaretHit';
+import { resolveClickCursorPos } from '../tableRuntime/interaction/clickCursorPlacement';
+import { createResolvedActiveCell, type ResolvedActiveCell } from '../tableRuntime/activeCell/resolvedActiveCell';
+import { resolveTableContextAtPos } from '../tableRuntime/tableResolution';
+import { isCellTextOffset } from '../shared/cursorPlacement';
+import type { CellCoords } from '../tableModel/types';
+import { unsanitizeRootText } from '../editorBridge/cellTextCodec';
+import { createMarkdownState } from './testMarkdownState';
+
+function contentElement(html: string): HTMLElement {
+    const content = document.createElement('div');
+    content.className = CLASS_CELL_CONTENT;
+    content.innerHTML = html;
+    return content;
+}
+
+/** Locates a text node by its content, so tests can name a caret without walking the tree. */
+function textNode(root: HTMLElement, data: string): Text {
+    const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+    let node = walker.nextNode();
+    while (node) {
+        if ((node as Text).data === data) {
+            return node as Text;
+        }
+        node = walker.nextNode();
+    }
+    throw new Error(`No text node with data ${JSON.stringify(data)}`);
+}
+
+describe('indexRenderedText', () => {
+    it('flattens nested inline markup into the text a reader sees', () => {
+        expect(indexRenderedText(contentElement('see <strong>the</strong> <code>docs</code>')).text).toBe(
+            'see the docs'
+        );
+    });
+
+    it('counts a line break as the single newline it stands for in the cell text', () => {
+        // A cell newline survives its GFM row as `<br>`, and the nested editor shows it as `\n`.
+        expect(indexRenderedText(contentElement('one<br>two')).text).toBe('one\ntwo');
+    });
+
+    it('skips MathML, whose text transcribes the formula rather than its source', () => {
+        const index = indexRenderedText(contentElement('a <math><mi>x</mi></math> b'));
+        expect(index.text).toBe('a  b');
+    });
+
+    it('contributes nothing for an image', () => {
+        expect(indexRenderedText(contentElement('a<img src="x.png" alt="pic">b')).text).toBe('ab');
+    });
+});
+
+describe('flatOffsetFromDomPosition', () => {
+    it('offsets into a text node from where its own text begins', () => {
+        const content = contentElement('see <strong>the</strong> docs');
+        const index = indexRenderedText(content);
+
+        expect(flatOffsetFromDomPosition(index, textNode(content, 'the'), 2)).toBe(6);
+    });
+
+    it('resolves a caret in an element to the start of the child it precedes', () => {
+        const content = contentElement('see <strong>the</strong> docs');
+        const index = indexRenderedText(content);
+
+        expect(flatOffsetFromDomPosition(index, content, 1)).toBe(4);
+    });
+
+    it('resolves a caret past an element’s last child to the end of its text', () => {
+        const content = contentElement('see <strong>the</strong> docs');
+        const index = indexRenderedText(content);
+
+        expect(flatOffsetFromDomPosition(index, content, content.childNodes.length)).toBe('see the docs'.length);
+    });
+
+    it('declines a node it never indexed', () => {
+        const index = indexRenderedText(contentElement('text'));
+
+        expect(flatOffsetFromDomPosition(index, document.createElement('div'), 0)).toBeNull();
+    });
+});
+
+const CANONICAL_DOC = ['', '| H1 | H2 |', '| --- | --- |', '| **markdown** | b |', ''].join('\n');
+
+function resolveCell(
+    doc: string,
+    coords: CellCoords
+): { state: ReturnType<typeof createMarkdownState>; resolvedCell: ResolvedActiveCell } {
+    const state = createMarkdownState(doc);
+    const ctx = resolveTableContextAtPos(state, doc.indexOf('|'));
+    if (!ctx) {
+        throw new Error('Expected a table context');
+    }
+    const resolvedCell = createResolvedActiveCell({ ctx, coords });
+    if (!resolvedCell) {
+        throw new Error('Expected a resolved cell');
+    }
+    return { state, resolvedCell };
+}
+
+/**
+ * The placement split into the cell's local text - the text the nested editor opens on,
+ * with `<br>` back as a newline and pipes unescaped - so failures read as text and the
+ * coordinate system the offset is expressed in stays visible.
+ */
+function placement(doc: string, coords: CellCoords, hit: RenderedCaretHit | null): string {
+    const { state, resolvedCell } = resolveCell(doc, coords);
+    const cellText = unsanitizeRootText(state.doc.sliceString(resolvedCell.editableFrom, resolvedCell.editableTo));
+    const pos = resolveClickCursorPos(state, resolvedCell, hit);
+    if (pos === undefined) {
+        return '<mirrored>';
+    }
+    if (!isCellTextOffset(pos)) {
+        throw new Error(`Expected an offset placement, got ${pos}`);
+    }
+    return `${cellText.slice(0, pos.localOffset)}|${cellText.slice(pos.localOffset)}`;
+}
+
+describe('resolveClickCursorPos', () => {
+    const boldCell: CellCoords = { section: 'body', row: 0, col: 0 };
+
+    it('places the caret at the clicked point inside the cell’s Markdown source', () => {
+        // The reported case: clicking between "w" and "n" of a bolded "markdown".
+        expect(placement(CANONICAL_DOC, boldCell, { renderedText: 'markdown', renderedOffset: 7 })).toBe(
+            '**markdow|n**'
+        );
+    });
+
+    it('places the caret in a plain cell one-to-one', () => {
+        expect(
+            placement(CANONICAL_DOC, { section: 'body', row: 0, col: 1 }, { renderedText: 'b', renderedOffset: 1 })
+        ).toBe('b|');
+    });
+
+    it('places a caret across a line break, which the source stores as <br>', () => {
+        const doc = ['', '| H1 |', '| --- |', '| one<br>two |', ''].join('\n');
+
+        expect(
+            placement(doc, { section: 'body', row: 0, col: 0 }, { renderedText: 'one\ntwo', renderedOffset: 5 })
+        ).toBe('one\nt|wo');
+    });
+
+    it('places a caret past a pipe, which the source stores escaped', () => {
+        const doc = ['', '| H1 |', '| --- |', '| a \\| b |', ''].join('\n');
+
+        expect(placement(doc, { section: 'body', row: 0, col: 0 }, { renderedText: 'a | b', renderedOffset: 4 })).toBe(
+            'a | |b'
+        );
+    });
+
+    it('mirrors the main selection when the press produced no caret', () => {
+        expect(placement(CANONICAL_DOC, boldCell, null)).toBe('<mirrored>');
+    });
+
+    it('mirrors the main selection when too little of the rendered text aligns', () => {
+        // A cell rendered as something unrecognisable has no anchors worth placing from.
+        expect(placement(CANONICAL_DOC, boldCell, { renderedText: 'qqqqqqqq', renderedOffset: 4 })).toBe('<mirrored>');
+    });
+
+    it('clamps a caret past the end of the cell text', () => {
+        expect(placement(CANONICAL_DOC, boldCell, { renderedText: 'markdown', renderedOffset: 99 })).toBe(
+            '**markdown**|'
+        );
+    });
+});

--- a/src/contentScript/__tests__/clickCursorPlacement.test.ts
+++ b/src/contentScript/__tests__/clickCursorPlacement.test.ts
@@ -133,6 +133,14 @@ describe('resolveClickCursorPos', () => {
         ).toBe('b|');
     });
 
+    it('places repeated text on the correct side of an emphasis boundary', () => {
+        const doc = ['', '| H1 |', '| --- |', '| a**aa** |', ''].join('\n');
+
+        expect(placement(doc, { section: 'body', row: 0, col: 0 }, { renderedText: 'aaa', renderedOffset: 1 })).toBe(
+            'a**|aa**'
+        );
+    });
+
     it('places a caret across a line break, which the source stores as <br>', () => {
         const doc = ['', '| H1 |', '| --- |', '| one<br>two |', ''].join('\n');
 

--- a/src/contentScript/__tests__/interactiveTableTestHarness.ts
+++ b/src/contentScript/__tests__/interactiveTableTestHarness.ts
@@ -13,6 +13,7 @@ export const NON_CANONICAL_DOC = ['|H1|H2|', '|---|---|', '|a|b|'].join('\n');
 interface CellStub {
     dataset: Record<string, string>;
     closest: (selector: string) => unknown;
+    querySelector: (selector: string) => unknown;
 }
 
 export interface MutableTestView {
@@ -84,6 +85,9 @@ export function createInteractiveTableHarness(params?: {
                 }
                 return null;
             },
+            // These cells carry no rendered content wrapper, so a press on one yields no
+            // caret to place from and entry falls back to mirroring the main selection.
+            querySelector: () => null,
         };
 
         return cell as unknown as HTMLElement;

--- a/src/contentScript/__tests__/nestedEditorSelection.test.ts
+++ b/src/contentScript/__tests__/nestedEditorSelection.test.ts
@@ -79,4 +79,18 @@ describe('resolveInitialLocalSelection', () => {
     it('places the caret after a trailing newline for lastLineStart', () => {
         expect(resolveInitialLocalSelection(mirrored, 'first\n', 'lastLineStart')).toEqual({ anchor: 6, head: 6 });
     });
+
+    it('collapses to a requested offset in the cell text', () => {
+        expect(resolveInitialLocalSelection(mirrored, 'hello world', { localOffset: 4 })).toEqual({
+            anchor: 4,
+            head: 4,
+        });
+    });
+
+    it('clamps a requested offset the cell text can no longer hold', () => {
+        // The offset is decided against the cell as it stood; an entry that repairs the table
+        // into canonical form can restripe that cell's padding in the same transaction.
+        expect(resolveInitialLocalSelection(mirrored, 'hi', { localOffset: 9 })).toEqual({ anchor: 2, head: 2 });
+        expect(resolveInitialLocalSelection(mirrored, 'hi', { localOffset: -1 })).toEqual({ anchor: 0, head: 0 });
+    });
 });

--- a/src/contentScript/__tests__/textAlignment.test.ts
+++ b/src/contentScript/__tests__/textAlignment.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest';
+import { alignRenderedToSource, mapCaretToSource } from '../shared/textAlignment';
+
+/**
+ * Maps a caret in rendered text back to its source offset, expressed as the source split
+ * at that point so failures read as text rather than as an integer mismatch.
+ */
+function place(rendered: string, source: string, caret: number): string {
+    const alignment = alignRenderedToSource(rendered, source);
+    if (!alignment) {
+        throw new Error('expected an alignment');
+    }
+    const offset = mapCaretToSource(alignment, caret, source.length);
+    return `${source.slice(0, offset)}|${source.slice(offset)}`;
+}
+
+function ratio(rendered: string, source: string): number {
+    const alignment = alignRenderedToSource(rendered, source);
+    if (!alignment) {
+        throw new Error('expected an alignment');
+    }
+    return alignment.matchedRatio;
+}
+
+describe('alignRenderedToSource', () => {
+    it('places a caret inside emphasised text at the matching source character', () => {
+        // The reported case: clicking between "w" and "n" of a bolded "markdown".
+        expect(place('markdown', '**markdown**', 7)).toBe('**markdow|n**');
+    });
+
+    it('maps identical text one-to-one', () => {
+        expect(place('plain text', 'plain text', 6)).toBe('plain |text');
+    });
+
+    it('places a caret in link text rather than in the URL', () => {
+        // "link" occurs twice in the source; only the label is the text that was rendered.
+        expect(place('link', '[link](http://link.com)', 2)).toBe('[li|nk](http://link.com)');
+    });
+
+    it('keeps the caret inside inline code', () => {
+        expect(place('code', '`code`', 2)).toBe('`co|de`');
+    });
+
+    it('binds a caret at a syntax boundary to the character that follows it', () => {
+        // Both sides of the closing `**` are defensible for a caret between "bold" and the
+        // space. Ties resolve towards the following character throughout, so the rule is the
+        // same at an opening boundary, where it puts the caret inside the emphasis instead.
+        expect(place('bold and more', '**bold** and more', 4)).toBe('**bold**| and more');
+        expect(place('abc', 'a**b**c', 1)).toBe('a**|b**c');
+    });
+
+    it('pins a caret past the last rendered character to the end of the source', () => {
+        // Clicking to the right of a short cell means "type here", including past trailing syntax.
+        expect(place('bold', '**bold**', 4)).toBe('**bold**|');
+    });
+
+    it('pins a caret before the first rendered character to the start of the source', () => {
+        expect(place('bold', '**bold**', 0)).toBe('|**bold**');
+    });
+
+    it('aligns across several inline constructs', () => {
+        const source = 'see **the** `docs` for [more](http://x.y)';
+        expect(place('see the docs for more', source, 9)).toBe('see **the** `d|ocs` for [more](http://x.y)');
+    });
+
+    it('recovers after a substitution instead of desynchronising', () => {
+        // "&" is rendered from "&amp;"; everything after it must still align exactly.
+        const source = 'a &amp; bcdef';
+        expect(place('a & bcdef', source, 6)).toBe('a &amp; bc|def');
+    });
+
+    it('treats a newline from a line break like any other character', () => {
+        expect(place('one\ntwo', 'one\ntwo', 5)).toBe('one\nt|wo');
+    });
+
+    it('resolves a caret beside an unmatched run to the nearest anchor', () => {
+        // The emoji is nowhere in the source, so the shortcode it came from is one gap the
+        // caret steps over rather than into. Its two UTF-16 units put "after" at caret 4.
+        expect(place('ab\u{1F600}cd', 'ab:smile:cd', 2)).toBe('ab|:smile:cd');
+        expect(place('ab\u{1F600}cd', 'ab:smile:cd', 4)).toBe('ab:smile:|cd');
+    });
+
+    it('reports full matching when the rendered text is a subsequence of the source', () => {
+        expect(ratio('bold', '**bold**')).toBe(1);
+    });
+
+    it('reports partial matching when the rendered text diverges from the source', () => {
+        expect(ratio('\u{1D465}²', '$x^2$')).toBeLessThan(0.5);
+    });
+
+    it('treats empty rendered text as fully matched', () => {
+        expect(ratio('', '$x^2$')).toBe(1);
+        expect(place('', '$x^2$', 0)).toBe('|$x^2$');
+    });
+
+    it('handles a source that shares nothing with the rendered text', () => {
+        expect(place('xyz', 'abc', 1)).toBe('|abc');
+        expect(ratio('xyz', 'abc')).toBe(0);
+    });
+
+    it('declines to align inputs longer than the supported cell size', () => {
+        expect(alignRenderedToSource('a'.repeat(1001), 'a'.repeat(1001))).toBeNull();
+        expect(alignRenderedToSource('a', 'a'.repeat(1001))).toBeNull();
+    });
+
+    it('aligns a long repeated-character cell within the supported size', () => {
+        // The worst case for block matching: every character is a candidate for every other.
+        expect(alignRenderedToSource('a'.repeat(1000), 'a'.repeat(1000))?.matchedRatio).toBe(1);
+    });
+});

--- a/src/contentScript/__tests__/textAlignment.test.ts
+++ b/src/contentScript/__tests__/textAlignment.test.ts
@@ -126,7 +126,27 @@ describe('alignRenderedToSource', () => {
     });
 
     it('aligns a long repeated-character cell within the supported size', () => {
-        // The worst case for block matching: every character is a candidate for every other.
+        // The worst case for a single scan: every character is a candidate for every other.
+        // It still costs about half the comparison budget, so this pins that headroom.
         expect(alignRenderedToSource('a'.repeat(1000), 'a'.repeat(1000))?.matchedRatio).toBe(1);
+    });
+
+    it('aligns a long prose cell carrying inline markup', () => {
+        const rendered = 'lorem ipsum dolor sit amet '.repeat(33);
+        const source = rendered.replace(/dolor/g, '**dolor**').slice(0, 1000);
+
+        expect(alignRenderedToSource(rendered, source)?.matchedRatio).toBeGreaterThan(0.9);
+    });
+
+    it('declines text whose shape would cost more than the comparison budget', () => {
+        // Nothing longer than one character is common to the two, so every character becomes
+        // its own block and the recursion rescans the rest of the cell for each of them.
+        expect(alignRenderedToSource('a'.repeat(500), 'ab'.repeat(500))).toBeNull();
+    });
+
+    it('declines a cell of short inline code spans rather than stalling the click', () => {
+        // Same shape from real Markdown: `a` `a` `a` ... shares no run longer than one
+        // character with the text it renders to.
+        expect(alignRenderedToSource('a '.repeat(200), '`a` '.repeat(200))).toBeNull();
     });
 });

--- a/src/contentScript/__tests__/textAlignment.test.ts
+++ b/src/contentScript/__tests__/textAlignment.test.ts
@@ -37,6 +37,11 @@ describe('alignRenderedToSource', () => {
         expect(place('plain text', 'plain text', 6)).toBe('plain |text');
     });
 
+    it('maps all repeated text when a later longest block would strand an earlier character', () => {
+        expect(place('aaa', 'a**aa**', 1)).toBe('a**|aa**');
+        expect(place('aaa', 'a**aa**', 2)).toBe('a**a|a**');
+    });
+
     it('places a caret in link text rather than in the URL', () => {
         // "link" occurs twice in the source; only the label is the text that was rendered.
         expect(place('link', '[link](http://link.com)', 2)).toBe('[li|nk](http://link.com)');

--- a/src/contentScript/__tests__/textAlignment.test.ts
+++ b/src/contentScript/__tests__/textAlignment.test.ts
@@ -1,12 +1,17 @@
 import { describe, it, expect } from 'vitest';
-import { alignRenderedToSource, mapCaretToSource } from '../shared/textAlignment';
+import { alignRenderedToSource, mapCaretToSource, type ExcludedSourceRange } from '../shared/textAlignment';
 
 /**
  * Maps a caret in rendered text back to its source offset, expressed as the source split
  * at that point so failures read as text rather than as an integer mismatch.
  */
-function place(rendered: string, source: string, caret: number): string {
-    const alignment = alignRenderedToSource(rendered, source);
+function place(
+    rendered: string,
+    source: string,
+    caret: number,
+    excludedRanges: readonly ExcludedSourceRange[] = []
+): string {
+    const alignment = alignRenderedToSource(rendered, source, excludedRanges);
     if (!alignment) {
         throw new Error('expected an alignment');
     }
@@ -41,16 +46,13 @@ describe('alignRenderedToSource', () => {
         expect(place('code', '`code`', 2)).toBe('`co|de`');
     });
 
-    it('does not align visible raw-HTML text to an identical opening tag', () => {
-        expect(place('code', '<code>code</code>', 2)).toBe('<code>co|de</code>');
-    });
-
-    it('does not align visible raw-HTML text to an identical attribute value', () => {
-        expect(place('hello', '<span title="hello">hello</span>', 2)).toBe('<span title="hello">he|llo</span>');
-    });
-
-    it('does not align visible text to an earlier HTML comment', () => {
-        expect(place('hello', '<!--hello-->hello', 2)).toBe('<!--hello-->he|llo');
+    it('does not use excluded source ranges as alignment anchors', () => {
+        expect(
+            place('code', '<code>code</code>', 2, [
+                { from: 0, to: 6 },
+                { from: 10, to: 17 },
+            ])
+        ).toBe('<code>co|de</code>');
     });
 
     it('still aligns tag-shaped text rendered literally by an inline code span', () => {

--- a/src/contentScript/__tests__/textAlignment.test.ts
+++ b/src/contentScript/__tests__/textAlignment.test.ts
@@ -41,6 +41,26 @@ describe('alignRenderedToSource', () => {
         expect(place('code', '`code`', 2)).toBe('`co|de`');
     });
 
+    it('does not align visible raw-HTML text to an identical opening tag', () => {
+        expect(place('code', '<code>code</code>', 2)).toBe('<code>co|de</code>');
+    });
+
+    it('does not align visible raw-HTML text to an identical attribute value', () => {
+        expect(place('hello', '<span title="hello">hello</span>', 2)).toBe('<span title="hello">he|llo</span>');
+    });
+
+    it('does not align visible text to an earlier HTML comment', () => {
+        expect(place('hello', '<!--hello-->hello', 2)).toBe('<!--hello-->he|llo');
+    });
+
+    it('still aligns tag-shaped text rendered literally by an inline code span', () => {
+        expect(place('<code>code</code>', '`<code>code</code>`', 8)).toBe('`<code>co|de</code>`');
+    });
+
+    it('does not mistake an autolink for an HTML tag', () => {
+        expect(place('https://example.com', '<https://example.com>', 8)).toBe('<https://|example.com>');
+    });
+
     it('binds a caret at a syntax boundary to the character that follows it', () => {
         // Both sides of the closing `**` are defensible for a caret between "bold" and the
         // space. Ties resolve towards the following character throughout, so the rule is the

--- a/src/contentScript/nestedEditor/nestedEditorSelection.ts
+++ b/src/contentScript/nestedEditor/nestedEditorSelection.ts
@@ -1,6 +1,6 @@
 import type { EditorSelection } from '@codemirror/state';
 import type { LocalSelection } from '../editorBridge/cellTextCodec';
-import type { InitialCursorPos } from '../shared/cursorPlacement';
+import { isCellTextOffset, type InitialCursorPos } from '../shared/cursorPlacement';
 import { clamp } from '../shared/numberUtils';
 
 /** Shifts a cell-relative selection into main-document coordinates. */
@@ -39,12 +39,22 @@ export function areSelectionsEqual(a: LocalSelection, b: LocalSelection): boolea
  *
  * `lastLineStart` splits on the last newline, so a single-line cell collapses to
  * the start and a trailing newline leaves the caret on the empty final line.
+ *
+ * An exact offset is clamped rather than trusted: it is measured against the cell
+ * text as it stood when the placement was decided, and an entry that repairs the
+ * table into canonical form can restripe that cell's padding in the same
+ * transaction.
  */
 export function resolveInitialLocalSelection(
     mirroredSelection: LocalSelection,
     localText: string,
     initialCursorPos?: InitialCursorPos
 ): LocalSelection {
+    if (initialCursorPos !== undefined && isCellTextOffset(initialCursorPos)) {
+        const pos = clamp(initialCursorPos.localOffset, 0, localText.length);
+        return { anchor: pos, head: pos };
+    }
+
     switch (initialCursorPos) {
         case 'start':
             return { anchor: 0, head: 0 };

--- a/src/contentScript/shared/cursorPlacement.ts
+++ b/src/contentScript/shared/cursorPlacement.ts
@@ -2,15 +2,33 @@
  * Where the caret should land when a cell is opened programmatically.
  *
  * The value travels from the code that decides the placement (keyboard
- * navigation, structural mutations) through an open-cell request to the nested
- * editor, which applies it in `resolveInitialLocalSelection`. Each hop is a
- * separate module, so the vocabulary is defined here once instead of being
- * re-declared at every boundary.
+ * navigation, structural mutations, click-to-caret placement) through an
+ * open-cell request to the nested editor, which applies it in
+ * `resolveInitialLocalSelection`. Each hop is a separate module, so the
+ * vocabulary is defined here once instead of being re-declared at every boundary.
  *
  * - `start` / `end`: collapse to the corresponding edge of the cell text.
  * - `lastLineStart`: collapse to the start of the final line, so moving up into
  *   a multi-line cell lands on the line nearest the cell the caret came from.
+ * - {@link CellTextOffset}: collapse to a specific offset in the cell text.
  *
  * Omitting the value mirrors the main editor's own selection into the cell.
  */
-export type InitialCursorPos = 'start' | 'end' | 'lastLineStart';
+export type InitialCursorPos = 'start' | 'end' | 'lastLineStart' | CellTextOffset;
+
+/**
+ * An exact caret offset in a cell's own text.
+ *
+ * Produced by placements derived from something outside the document - a click on rendered
+ * Markdown, whose offset comes from aligning what was drawn against the source. The offset
+ * is clamped when applied, because the entry that carries it may rewrite the cell's padding
+ * in the same transaction.
+ */
+export interface CellTextOffset {
+    localOffset: number;
+}
+
+/** Distinguishes an exact offset from the named edges. */
+export function isCellTextOffset(value: InitialCursorPos): value is CellTextOffset {
+    return typeof value === 'object';
+}

--- a/src/contentScript/shared/textAlignment.ts
+++ b/src/contentScript/shared/textAlignment.ts
@@ -24,11 +24,33 @@
 /**
  * Longest length either side may have before alignment is refused.
  *
- * Block matching is O(n*m) in the worst case (a cell of one repeated character), so the cap
- * bounds the cost of a hit test that runs on a click. Cells this long are far past the point
- * where a caret lands somewhere the reader was looking anyway.
+ * Cells this long are far past the point where a caret lands somewhere the reader was
+ * looking anyway. The cap bounds a single {@link findLongestMatch} scan; it does not bound
+ * the recursion around it, which is what {@link MAX_ALIGNMENT_CANDIDATES} is for.
  */
 const MAX_ALIGNMENT_LENGTH = 1000;
+
+/**
+ * Candidate comparisons alignment may spend before it gives up.
+ *
+ * The length cap alone does not bound the cost of a hit test that runs on a click. A cell
+ * whose longest common run is a single character - a row of short inline code spans, or
+ * emphasis around every character - recurses once per character and rescans the shrinking
+ * range each time, which is quadratic in the cell length rather than linear.
+ *
+ * Measured on the shapes this has to survive, a comparison costs roughly 30ns and the cells
+ * that read as prose stay near a million: a 1000-character cell with inline markup spends
+ * ~0.8M, a cell of 1000 identical characters ~1.0M. The degenerate shapes above spend 10M to
+ * 40M, or 0.3s to 1s. The budget sits above the first group and well below the second, which
+ * holds a click to ~60ms. What it gives up is the alignment of a cell that is both long and
+ * degenerate, which then falls back like any other cell that cannot be aligned.
+ */
+const MAX_ALIGNMENT_CANDIDATES = 2_000_000;
+
+/** Remaining comparison budget, shared by every scan in one alignment. */
+interface AlignmentBudget {
+    remaining: number;
+}
 
 /** A run of characters that is identical in both strings. */
 interface MatchingBlock {
@@ -93,7 +115,9 @@ function indexCharacterPositions(
  * rendered character, so extending a run is a single lookup. Ties keep the first run found,
  * which is the earliest position in both strings because the position lists ascend.
  *
- * Returns a zero-length block when the ranges share no characters.
+ * Returns a zero-length block when the ranges share no characters, and null when `budget`
+ * ran out before the scan finished, which makes a truncated scan impossible to mistake for
+ * a completed one.
  */
 function findLongestMatch(
     rendered: string,
@@ -101,12 +125,17 @@ function findLongestMatch(
     renderedFrom: number,
     renderedTo: number,
     sourceFrom: number,
-    sourceTo: number
-): MatchingBlock {
+    sourceTo: number,
+    budget: AlignmentBudget
+): MatchingBlock | null {
     let best: MatchingBlock = { renderedFrom, sourceFrom, length: 0 };
     let runLengths = new Map<number, number>();
 
     for (let i = renderedFrom; i < renderedTo; i++) {
+        if (budget.remaining <= 0) {
+            return null;
+        }
+
         const nextRunLengths = new Map<number, number>();
         for (const j of sourcePositions.get(rendered[i]) ?? []) {
             if (j < sourceFrom) {
@@ -116,6 +145,7 @@ function findLongestMatch(
                 break;
             }
 
+            budget.remaining--;
             const length = (runLengths.get(j - 1) ?? 0) + 1;
             nextRunLengths.set(j, length);
             if (length > best.length) {
@@ -135,13 +165,19 @@ function findLongestMatch(
  * The recursion is an explicit stack: a pathological input can nest as deeply as the strings
  * are long, and the cap alone is not a reason to spend that on the call stack. Blocks come
  * back unordered, which is all the caller needs to fill a lookup table.
+ *
+ * Returns null once the shared budget runs out. Partial blocks are discarded rather than
+ * returned, because the stack descends into one gap at a time: whatever it had found would
+ * cover one end of the cell and leave the other unanchored, which places a caret confidently
+ * in the wrong place. Declining hands the caller the fallback it already has.
  */
 function collectMatchingBlocks(
     rendered: string,
     sourcePositions: Map<string, number[]>,
     sourceLength: number
-): MatchingBlock[] {
+): MatchingBlock[] | null {
     const blocks: MatchingBlock[] = [];
+    const budget: AlignmentBudget = { remaining: MAX_ALIGNMENT_CANDIDATES };
     const pending: Array<[number, number, number, number]> = [[0, rendered.length, 0, sourceLength]];
 
     while (pending.length > 0) {
@@ -150,7 +186,18 @@ function collectMatchingBlocks(
             continue;
         }
 
-        const match = findLongestMatch(rendered, sourcePositions, renderedFrom, renderedTo, sourceFrom, sourceTo);
+        const match = findLongestMatch(
+            rendered,
+            sourcePositions,
+            renderedFrom,
+            renderedTo,
+            sourceFrom,
+            sourceTo,
+            budget
+        );
+        if (!match) {
+            return null;
+        }
         if (match.length === 0) {
             continue;
         }
@@ -169,8 +216,10 @@ function collectMatchingBlocks(
  * Characters inside `excludedRanges` cannot anchor a match. Callers use this for syntax that
  * may duplicate visible text, such as an HTML tag name or attribute value.
  *
- * Returns null when either side is longer than {@link MAX_ALIGNMENT_LENGTH}; callers treat
- * that as "no better placement is available" rather than as an error.
+ * Returns null when either side is longer than {@link MAX_ALIGNMENT_LENGTH}, or when the
+ * text is shaped such that aligning it would cost more than {@link MAX_ALIGNMENT_CANDIDATES}
+ * comparisons; callers treat that as "no better placement is available" rather than as an
+ * error.
  */
 export function alignRenderedToSource(
     rendered: string,
@@ -186,13 +235,14 @@ export function alignRenderedToSource(
         return { toSource: new Int32Array(), matchedRatio: 1 };
     }
 
+    const blocks = collectMatchingBlocks(rendered, indexCharacterPositions(source, excludedRanges), source.length);
+    if (!blocks) {
+        return null;
+    }
+
     const toSource = new Int32Array(rendered.length).fill(-1);
     let matched = 0;
-    for (const block of collectMatchingBlocks(
-        rendered,
-        indexCharacterPositions(source, excludedRanges),
-        source.length
-    )) {
+    for (const block of blocks) {
         for (let k = 0; k < block.length; k++) {
             toSource[block.renderedFrom + k] = block.sourceFrom + k;
         }

--- a/src/contentScript/shared/textAlignment.ts
+++ b/src/contentScript/shared/textAlignment.ts
@@ -1,0 +1,214 @@
+/**
+ * Character-level alignment between a rendered string and the source it was rendered from.
+ *
+ * Markdown rendering is lossy in one direction only: syntax characters disappear, but the
+ * text that survives normally appears in the source in the same order. That makes the
+ * rendered text a subsequence of its source for the inline constructs cells actually
+ * contain (`**bold**`, `[text](url)`, `` `code` ``, `~~strike~~`, raw HTML), so a diff
+ * recovers where each rendered character came from without the renderer emitting a source
+ * map.
+ *
+ * The algorithm is the recursive longest-matching-block scheme used by Python's `difflib`,
+ * not a plain LCS. Both maximise the number of matched characters, but LCS is free to
+ * scatter its matches: aligning `link` against `[link](http://link.com)` may legally pick
+ * characters out of the URL. Anchoring on the longest common block first and recursing into
+ * the gaps prefers long contiguous runs and, on ties, the earliest source position - which
+ * is what a caret placement needs.
+ *
+ * Substitutions that are not subsequences (`&amp;` to `&`, `:smile:` to an emoji, KaTeX to
+ * MathML) simply leave a gap. Because each gap is bounded by the blocks around it, the
+ * damage stays local instead of desynchronising everything that follows, and
+ * `matchedRatio` reports how much of the rendered text failed to find a home.
+ */
+
+/**
+ * Longest length either side may have before alignment is refused.
+ *
+ * Block matching is O(n*m) in the worst case (a cell of one repeated character), so the cap
+ * bounds the cost of a hit test that runs on a click. Cells this long are far past the point
+ * where a caret lands somewhere the reader was looking anyway.
+ */
+const MAX_ALIGNMENT_LENGTH = 1000;
+
+/** A run of characters that is identical in both strings. */
+interface MatchingBlock {
+    renderedFrom: number;
+    sourceFrom: number;
+    length: number;
+}
+
+export interface TextAlignment {
+    /** Source index each rendered index maps to, or -1 where the character did not align. */
+    readonly toSource: Int32Array;
+    /** Fraction of the rendered text that aligned, from 0 (nothing) to 1 (everything). */
+    readonly matchedRatio: number;
+}
+
+/** Character to ascending list of positions, so block matching can skip non-candidates. */
+function indexCharacterPositions(source: string): Map<string, number[]> {
+    const positions = new Map<string, number[]>();
+    for (let i = 0; i < source.length; i++) {
+        const existing = positions.get(source[i]);
+        if (existing) {
+            existing.push(i);
+        } else {
+            positions.set(source[i], [i]);
+        }
+    }
+    return positions;
+}
+
+/**
+ * Longest run common to `rendered[renderedFrom, renderedTo)` and `source[sourceFrom, sourceTo)`.
+ *
+ * `runLengths` holds, per source index, the length of the common run ending at the previous
+ * rendered character, so extending a run is a single lookup. Ties keep the first run found,
+ * which is the earliest position in both strings because the position lists ascend.
+ *
+ * Returns a zero-length block when the ranges share no characters.
+ */
+function findLongestMatch(
+    rendered: string,
+    sourcePositions: Map<string, number[]>,
+    renderedFrom: number,
+    renderedTo: number,
+    sourceFrom: number,
+    sourceTo: number
+): MatchingBlock {
+    let best: MatchingBlock = { renderedFrom, sourceFrom, length: 0 };
+    let runLengths = new Map<number, number>();
+
+    for (let i = renderedFrom; i < renderedTo; i++) {
+        const nextRunLengths = new Map<number, number>();
+        for (const j of sourcePositions.get(rendered[i]) ?? []) {
+            if (j < sourceFrom) {
+                continue;
+            }
+            if (j >= sourceTo) {
+                break;
+            }
+
+            const length = (runLengths.get(j - 1) ?? 0) + 1;
+            nextRunLengths.set(j, length);
+            if (length > best.length) {
+                best = { renderedFrom: i - length + 1, sourceFrom: j - length + 1, length };
+            }
+        }
+        runLengths = nextRunLengths;
+    }
+
+    return best;
+}
+
+/**
+ * Every matching block, found by anchoring on the longest one and recursing into the
+ * unmatched region on each side of it.
+ *
+ * The recursion is an explicit stack: a pathological input can nest as deeply as the strings
+ * are long, and the cap alone is not a reason to spend that on the call stack. Blocks come
+ * back unordered, which is all the caller needs to fill a lookup table.
+ */
+function collectMatchingBlocks(
+    rendered: string,
+    sourcePositions: Map<string, number[]>,
+    sourceLength: number
+): MatchingBlock[] {
+    const blocks: MatchingBlock[] = [];
+    const pending: Array<[number, number, number, number]> = [[0, rendered.length, 0, sourceLength]];
+
+    while (pending.length > 0) {
+        const [renderedFrom, renderedTo, sourceFrom, sourceTo] = pending.pop() as [number, number, number, number];
+        if (renderedFrom >= renderedTo || sourceFrom >= sourceTo) {
+            continue;
+        }
+
+        const match = findLongestMatch(rendered, sourcePositions, renderedFrom, renderedTo, sourceFrom, sourceTo);
+        if (match.length === 0) {
+            continue;
+        }
+
+        blocks.push(match);
+        pending.push([renderedFrom, match.renderedFrom, sourceFrom, match.sourceFrom]);
+        pending.push([match.renderedFrom + match.length, renderedTo, match.sourceFrom + match.length, sourceTo]);
+    }
+
+    return blocks;
+}
+
+/**
+ * Aligns rendered text back onto the source it came from.
+ *
+ * Returns null when either side is longer than {@link MAX_ALIGNMENT_LENGTH}; callers treat
+ * that as "no better placement is available" rather than as an error.
+ */
+export function alignRenderedToSource(rendered: string, source: string): TextAlignment | null {
+    if (rendered.length > MAX_ALIGNMENT_LENGTH || source.length > MAX_ALIGNMENT_LENGTH) {
+        return null;
+    }
+
+    const toSource = new Int32Array(rendered.length).fill(-1);
+    if (rendered.length === 0) {
+        // Nothing to place is vacuously well aligned: the only caret is at offset 0.
+        return { toSource, matchedRatio: 1 };
+    }
+
+    let matched = 0;
+    for (const block of collectMatchingBlocks(rendered, indexCharacterPositions(source), source.length)) {
+        for (let k = 0; k < block.length; k++) {
+            toSource[block.renderedFrom + k] = block.sourceFrom + k;
+        }
+        matched += block.length;
+    }
+
+    return { toSource, matchedRatio: matched / rendered.length };
+}
+
+/**
+ * Maps a caret offset in the rendered text to a caret offset in the source.
+ *
+ * A caret sits between characters, so it is resolved from the aligned character on either
+ * side of it, whichever is nearer; a tie prefers the character after the caret, which keeps
+ * a caret inside a matched run exactly where it was. Landing in a gap therefore yields the
+ * closest anchor rather than nothing, which is still far more useful than the start of
+ * the cell.
+ *
+ * Both ends are pinned: clicking past the last rendered character means the end of the
+ * source, including any trailing syntax, and the same in reverse at the start.
+ */
+export function mapCaretToSource(alignment: TextAlignment, caret: number, sourceLength: number): number {
+    const { toSource } = alignment;
+    if (caret <= 0) {
+        return 0;
+    }
+    if (caret >= toSource.length) {
+        return sourceLength;
+    }
+
+    let after = -1;
+    for (let i = caret; i < toSource.length; i++) {
+        if (toSource[i] >= 0) {
+            after = i;
+            break;
+        }
+    }
+
+    let before = -1;
+    for (let i = caret - 1; i >= 0; i--) {
+        if (toSource[i] >= 0) {
+            before = i;
+            break;
+        }
+    }
+
+    if (after < 0 && before < 0) {
+        return 0;
+    }
+    if (after < 0) {
+        return toSource[before] + 1;
+    }
+    if (before < 0) {
+        return toSource[after];
+    }
+
+    return after - caret <= caret - 1 - before ? toSource[after] : toSource[before] + 1;
+}

--- a/src/contentScript/shared/textAlignment.ts
+++ b/src/contentScript/shared/textAlignment.ts
@@ -44,9 +44,33 @@ export interface TextAlignment {
     readonly matchedRatio: number;
 }
 
+/** Half-open source range whose characters must not be used as alignment anchors. */
+export interface ExcludedSourceRange {
+    from: number;
+    to: number;
+}
+
+function excludedSourcePositions(sourceLength: number, ranges: readonly ExcludedSourceRange[]): Uint8Array | null {
+    if (ranges.length === 0) {
+        return null;
+    }
+
+    const excluded = new Uint8Array(sourceLength);
+    for (const range of ranges) {
+        const from = Math.max(0, Math.min(range.from, sourceLength));
+        const to = Math.max(from, Math.min(range.to, sourceLength));
+        excluded.fill(1, from, to);
+    }
+    return excluded;
+}
+
 /** Character to ascending list of positions, so block matching can skip non-candidates. */
-function indexCharacterPositions(source: string, excluded?: Uint8Array): Map<string, number[]> {
+function indexCharacterPositions(
+    source: string,
+    excludedRanges: readonly ExcludedSourceRange[]
+): Map<string, number[]> {
     const positions = new Map<string, number[]>();
+    const excluded = excludedSourcePositions(source.length, excludedRanges);
     for (let i = 0; i < source.length; i++) {
         if (excluded?.[i]) {
             continue;
@@ -60,113 +84,6 @@ function indexCharacterPositions(source: string, excluded?: Uint8Array): Map<str
         }
     }
     return positions;
-}
-
-/** Whether `character` can start an HTML tag name, e.g. the `s` in `<span>`. */
-function isAsciiLetter(character: string | undefined): boolean {
-    if (!character) {
-        return false;
-    }
-    const code = character.charCodeAt(0);
-    return (code >= 65 && code <= 90) || (code >= 97 && code <= 122);
-}
-
-/** Whether `character` can continue an HTML tag name, including custom elements such as `x-note`. */
-function isHtmlTagNameCharacter(character: string | undefined): boolean {
-    if (!character) {
-        return false;
-    }
-    const code = character.charCodeAt(0);
-    return isAsciiLetter(character) || (code >= 48 && code <= 57) || character === '-';
-}
-
-/** A tag name must be followed by whitespace, `/>`, or `>`; this excludes autolinks such as `<https://x>`. */
-function isHtmlTagNameBoundary(character: string | undefined): boolean {
-    return character !== undefined && (/\s/.test(character) || character === '/' || character === '>');
-}
-
-/** Finds a closing `>` without mistaking one inside a quoted attribute value for the end of the tag. */
-function findTagEnd(source: string, from: number): number {
-    let quote: '"' | "'" | null = null;
-    for (let i = from; i < source.length; i++) {
-        const character = source[i];
-        if (quote) {
-            if (character === quote) {
-                quote = null;
-            }
-        } else if (character === '"' || character === "'") {
-            quote = character;
-        } else if (character === '>') {
-            return i + 1;
-        }
-    }
-    return -1;
-}
-
-/** Returns the exclusive end of an HTML token at `from`, or -1 when `<` starts ordinary text such as an autolink. */
-function rawHtmlTokenEnd(source: string, from: number): number {
-    if (source.startsWith('<!--', from)) {
-        const close = source.indexOf('-->', from + 4);
-        return close < 0 ? -1 : close + 3;
-    }
-    if (source.startsWith('<![CDATA[', from)) {
-        const close = source.indexOf(']]>', from + 9);
-        return close < 0 ? -1 : close + 3;
-    }
-    if (source.startsWith('<?', from)) {
-        const close = source.indexOf('?>', from + 2);
-        return close < 0 ? -1 : close + 2;
-    }
-    if (source.startsWith('<!', from)) {
-        return findTagEnd(source, from + 2);
-    }
-
-    let cursor = from + 1;
-    if (source[cursor] === '/') {
-        cursor++;
-    }
-    if (!isAsciiLetter(source[cursor])) {
-        return -1;
-    }
-    cursor++;
-    while (isHtmlTagNameCharacter(source[cursor])) {
-        cursor++;
-    }
-    if (!isHtmlTagNameBoundary(source[cursor])) {
-        return -1;
-    }
-
-    return findTagEnd(source, cursor);
-}
-
-/**
- * Marks probable raw-HTML syntax so visible text prefers the occurrence between tags over an
- * identical tag name, attribute value, or comment that appears earlier in the source.
- *
- * The caller compares this preferred alignment with an unrestricted one. That preserves
- * literal tags rendered by code spans, where excluding the tag-shaped source would lose
- * matches, while fixing raw HTML such as `<code>code</code>`.
- */
-function rawHtmlSyntaxMask(source: string): Uint8Array | null {
-    let mask: Uint8Array | null = null;
-    let i = 0;
-    while (i < source.length) {
-        if (source[i] !== '<') {
-            i++;
-            continue;
-        }
-
-        const to = rawHtmlTokenEnd(source, i);
-        if (to < 0) {
-            i++;
-            continue;
-        }
-
-        mask ??= new Uint8Array(source.length);
-        mask.fill(1, i, to);
-        i = to;
-    }
-    return mask;
 }
 
 /**
@@ -249,10 +166,17 @@ function collectMatchingBlocks(
 /**
  * Aligns rendered text back onto the source it came from.
  *
+ * Characters inside `excludedRanges` cannot anchor a match. Callers use this for syntax that
+ * may duplicate visible text, such as an HTML tag name or attribute value.
+ *
  * Returns null when either side is longer than {@link MAX_ALIGNMENT_LENGTH}; callers treat
  * that as "no better placement is available" rather than as an error.
  */
-export function alignRenderedToSource(rendered: string, source: string): TextAlignment | null {
+export function alignRenderedToSource(
+    rendered: string,
+    source: string,
+    excludedRanges: readonly ExcludedSourceRange[] = []
+): TextAlignment | null {
     if (rendered.length > MAX_ALIGNMENT_LENGTH || source.length > MAX_ALIGNMENT_LENGTH) {
         return null;
     }
@@ -262,33 +186,20 @@ export function alignRenderedToSource(rendered: string, source: string): TextAli
         return { toSource: new Int32Array(), matchedRatio: 1 };
     }
 
-    const align = (excluded?: Uint8Array): TextAlignment => {
-        const toSource = new Int32Array(rendered.length).fill(-1);
-        let matched = 0;
-        for (const block of collectMatchingBlocks(rendered, indexCharacterPositions(source, excluded), source.length)) {
-            for (let k = 0; k < block.length; k++) {
-                toSource[block.renderedFrom + k] = block.sourceFrom + k;
-            }
-            matched += block.length;
+    const toSource = new Int32Array(rendered.length).fill(-1);
+    let matched = 0;
+    for (const block of collectMatchingBlocks(
+        rendered,
+        indexCharacterPositions(source, excludedRanges),
+        source.length
+    )) {
+        for (let k = 0; k < block.length; k++) {
+            toSource[block.renderedFrom + k] = block.sourceFrom + k;
         }
-
-        return { toSource, matchedRatio: matched / rendered.length };
-    };
-
-    const syntaxMask = rawHtmlSyntaxMask(source);
-    if (!syntaxMask) {
-        return align();
+        matched += block.length;
     }
 
-    // Prefer matches outside raw-HTML syntax when that does not sacrifice any rendered text.
-    // If the source contains tag-shaped literal code, the unrestricted alignment wins instead.
-    const preferred = align(syntaxMask);
-    if (preferred.matchedRatio === 1) {
-        return preferred;
-    }
-
-    const unrestricted = align();
-    return preferred.matchedRatio >= unrestricted.matchedRatio ? preferred : unrestricted;
+    return { toSource, matchedRatio: matched / rendered.length };
 }
 
 /**

--- a/src/contentScript/shared/textAlignment.ts
+++ b/src/contentScript/shared/textAlignment.ts
@@ -87,12 +87,8 @@ function excludedSourcePositions(sourceLength: number, ranges: readonly Excluded
 }
 
 /** Character to ascending list of positions, so block matching can skip non-candidates. */
-function indexCharacterPositions(
-    source: string,
-    excludedRanges: readonly ExcludedSourceRange[]
-): Map<string, number[]> {
+function indexCharacterPositions(source: string, excluded: Uint8Array | null): Map<string, number[]> {
     const positions = new Map<string, number[]>();
-    const excluded = excludedSourcePositions(source.length, excludedRanges);
     for (let i = 0; i < source.length; i++) {
         if (excluded?.[i]) {
             continue;
@@ -106,6 +102,37 @@ function indexCharacterPositions(
         }
     }
     return positions;
+}
+
+/**
+ * Maps every rendered character to its earliest available source occurrence in order.
+ *
+ * Choosing the earliest match cannot prevent a later match that another subsequence could
+ * make, so a single forward scan is enough to prove whether the rendered text is a complete
+ * subsequence. This repairs repeated-text cases where longest-block alignment commits to a
+ * later run and strands otherwise matchable characters on one side of it.
+ */
+function alignCompleteSubsequence(rendered: string, source: string, excluded: Uint8Array | null): TextAlignment | null {
+    const toSource = new Int32Array(rendered.length);
+    let sourceIndex = 0;
+
+    for (let renderedIndex = 0; renderedIndex < rendered.length; renderedIndex++) {
+        while (
+            sourceIndex < source.length &&
+            (Boolean(excluded?.[sourceIndex]) || source[sourceIndex] !== rendered[renderedIndex])
+        ) {
+            sourceIndex++;
+        }
+
+        if (sourceIndex >= source.length) {
+            return null;
+        }
+
+        toSource[renderedIndex] = sourceIndex;
+        sourceIndex++;
+    }
+
+    return { toSource, matchedRatio: 1 };
 }
 
 /**
@@ -235,7 +262,8 @@ export function alignRenderedToSource(
         return { toSource: new Int32Array(), matchedRatio: 1 };
     }
 
-    const blocks = collectMatchingBlocks(rendered, indexCharacterPositions(source, excludedRanges), source.length);
+    const excluded = excludedSourcePositions(source.length, excludedRanges);
+    const blocks = collectMatchingBlocks(rendered, indexCharacterPositions(source, excluded), source.length);
     if (!blocks) {
         return null;
     }
@@ -249,7 +277,12 @@ export function alignRenderedToSource(
         matched += block.length;
     }
 
-    return { toSource, matchedRatio: matched / rendered.length };
+    const blockAlignment = { toSource, matchedRatio: matched / rendered.length };
+    if (matched === rendered.length) {
+        return blockAlignment;
+    }
+
+    return alignCompleteSubsequence(rendered, source, excluded) ?? blockAlignment;
 }
 
 /**

--- a/src/contentScript/shared/textAlignment.ts
+++ b/src/contentScript/shared/textAlignment.ts
@@ -45,9 +45,13 @@ export interface TextAlignment {
 }
 
 /** Character to ascending list of positions, so block matching can skip non-candidates. */
-function indexCharacterPositions(source: string): Map<string, number[]> {
+function indexCharacterPositions(source: string, excluded?: Uint8Array): Map<string, number[]> {
     const positions = new Map<string, number[]>();
     for (let i = 0; i < source.length; i++) {
+        if (excluded?.[i]) {
+            continue;
+        }
+
         const existing = positions.get(source[i]);
         if (existing) {
             existing.push(i);
@@ -56,6 +60,113 @@ function indexCharacterPositions(source: string): Map<string, number[]> {
         }
     }
     return positions;
+}
+
+/** Whether `character` can start an HTML tag name, e.g. the `s` in `<span>`. */
+function isAsciiLetter(character: string | undefined): boolean {
+    if (!character) {
+        return false;
+    }
+    const code = character.charCodeAt(0);
+    return (code >= 65 && code <= 90) || (code >= 97 && code <= 122);
+}
+
+/** Whether `character` can continue an HTML tag name, including custom elements such as `x-note`. */
+function isHtmlTagNameCharacter(character: string | undefined): boolean {
+    if (!character) {
+        return false;
+    }
+    const code = character.charCodeAt(0);
+    return isAsciiLetter(character) || (code >= 48 && code <= 57) || character === '-';
+}
+
+/** A tag name must be followed by whitespace, `/>`, or `>`; this excludes autolinks such as `<https://x>`. */
+function isHtmlTagNameBoundary(character: string | undefined): boolean {
+    return character !== undefined && (/\s/.test(character) || character === '/' || character === '>');
+}
+
+/** Finds a closing `>` without mistaking one inside a quoted attribute value for the end of the tag. */
+function findTagEnd(source: string, from: number): number {
+    let quote: '"' | "'" | null = null;
+    for (let i = from; i < source.length; i++) {
+        const character = source[i];
+        if (quote) {
+            if (character === quote) {
+                quote = null;
+            }
+        } else if (character === '"' || character === "'") {
+            quote = character;
+        } else if (character === '>') {
+            return i + 1;
+        }
+    }
+    return -1;
+}
+
+/** Returns the exclusive end of an HTML token at `from`, or -1 when `<` starts ordinary text such as an autolink. */
+function rawHtmlTokenEnd(source: string, from: number): number {
+    if (source.startsWith('<!--', from)) {
+        const close = source.indexOf('-->', from + 4);
+        return close < 0 ? -1 : close + 3;
+    }
+    if (source.startsWith('<![CDATA[', from)) {
+        const close = source.indexOf(']]>', from + 9);
+        return close < 0 ? -1 : close + 3;
+    }
+    if (source.startsWith('<?', from)) {
+        const close = source.indexOf('?>', from + 2);
+        return close < 0 ? -1 : close + 2;
+    }
+    if (source.startsWith('<!', from)) {
+        return findTagEnd(source, from + 2);
+    }
+
+    let cursor = from + 1;
+    if (source[cursor] === '/') {
+        cursor++;
+    }
+    if (!isAsciiLetter(source[cursor])) {
+        return -1;
+    }
+    cursor++;
+    while (isHtmlTagNameCharacter(source[cursor])) {
+        cursor++;
+    }
+    if (!isHtmlTagNameBoundary(source[cursor])) {
+        return -1;
+    }
+
+    return findTagEnd(source, cursor);
+}
+
+/**
+ * Marks probable raw-HTML syntax so visible text prefers the occurrence between tags over an
+ * identical tag name, attribute value, or comment that appears earlier in the source.
+ *
+ * The caller compares this preferred alignment with an unrestricted one. That preserves
+ * literal tags rendered by code spans, where excluding the tag-shaped source would lose
+ * matches, while fixing raw HTML such as `<code>code</code>`.
+ */
+function rawHtmlSyntaxMask(source: string): Uint8Array | null {
+    let mask: Uint8Array | null = null;
+    let i = 0;
+    while (i < source.length) {
+        if (source[i] !== '<') {
+            i++;
+            continue;
+        }
+
+        const to = rawHtmlTokenEnd(source, i);
+        if (to < 0) {
+            i++;
+            continue;
+        }
+
+        mask ??= new Uint8Array(source.length);
+        mask.fill(1, i, to);
+        i = to;
+    }
+    return mask;
 }
 
 /**
@@ -146,21 +257,38 @@ export function alignRenderedToSource(rendered: string, source: string): TextAli
         return null;
     }
 
-    const toSource = new Int32Array(rendered.length).fill(-1);
     if (rendered.length === 0) {
         // Nothing to place is vacuously well aligned: the only caret is at offset 0.
-        return { toSource, matchedRatio: 1 };
+        return { toSource: new Int32Array(), matchedRatio: 1 };
     }
 
-    let matched = 0;
-    for (const block of collectMatchingBlocks(rendered, indexCharacterPositions(source), source.length)) {
-        for (let k = 0; k < block.length; k++) {
-            toSource[block.renderedFrom + k] = block.sourceFrom + k;
+    const align = (excluded?: Uint8Array): TextAlignment => {
+        const toSource = new Int32Array(rendered.length).fill(-1);
+        let matched = 0;
+        for (const block of collectMatchingBlocks(rendered, indexCharacterPositions(source, excluded), source.length)) {
+            for (let k = 0; k < block.length; k++) {
+                toSource[block.renderedFrom + k] = block.sourceFrom + k;
+            }
+            matched += block.length;
         }
-        matched += block.length;
+
+        return { toSource, matchedRatio: matched / rendered.length };
+    };
+
+    const syntaxMask = rawHtmlSyntaxMask(source);
+    if (!syntaxMask) {
+        return align();
     }
 
-    return { toSource, matchedRatio: matched / rendered.length };
+    // Prefer matches outside raw-HTML syntax when that does not sacrifice any rendered text.
+    // If the source contains tag-shaped literal code, the unrestricted alignment wins instead.
+    const preferred = align(syntaxMask);
+    if (preferred.matchedRatio === 1) {
+        return preferred;
+    }
+
+    const unrestricted = align();
+    return preferred.matchedRatio >= unrestricted.matchedRatio ? preferred : unrestricted;
 }
 
 /**

--- a/src/contentScript/tableRuntime/interaction/clickCursorPlacement.ts
+++ b/src/contentScript/tableRuntime/interaction/clickCursorPlacement.ts
@@ -1,0 +1,54 @@
+import type { EditorState } from '@codemirror/state';
+import { unsanitizeRootText } from '../../editorBridge/cellTextCodec';
+import type { InitialCursorPos } from '../../shared/cursorPlacement';
+import { alignRenderedToSource, mapCaretToSource } from '../../shared/textAlignment';
+import type { RenderedCaretHit } from '../../tableWidget/cellCaretHit';
+import type { ResolvedActiveCell } from '../activeCell/resolvedActiveCell';
+
+/**
+ * Turns a press on a rendered cell into the caret placement the nested editor should open
+ * with, so clicking inside rendered Markdown lands the caret at the corresponding place in
+ * the Markdown source rather than at the start of the cell.
+ */
+
+/**
+ * Alignment quality below which the placement is abandoned.
+ *
+ * The rendered text of a normal cell aligns almost completely; a cell that is mostly
+ * formula, emoji shortcodes or HTML entities does not, and the anchors left over are too
+ * sparse to place a caret from. Half is well clear of both cases: it is a floor on
+ * "recognisably the same text", not a tuned threshold.
+ */
+const MIN_MATCHED_RATIO = 0.5;
+
+/**
+ * Resolves the caret placement for a press on `resolvedCell`.
+ *
+ * Returns undefined - not a placement of `'start'` - when there is nothing better to offer,
+ * which leaves the open request mirroring the main editor's own selection exactly as it did
+ * before. That is the established fallback for every other unplaced entry.
+ *
+ * The offset is measured against the cell text as it stands now. An entry that repairs the
+ * table into canonical form can restripe the cell's padding underneath it, so the offset is
+ * clamped where it is applied rather than trusted verbatim.
+ */
+export function resolveClickCursorPos(
+    state: EditorState,
+    resolvedCell: ResolvedActiveCell,
+    hit: RenderedCaretHit | null
+): InitialCursorPos | undefined {
+    if (!hit) {
+        return undefined;
+    }
+
+    // The nested editor opens on the unsanitized cell text, so aligning against that text
+    // yields an offset in the coordinates the placement is applied in - no further mapping.
+    const localText = unsanitizeRootText(state.doc.sliceString(resolvedCell.editableFrom, resolvedCell.editableTo));
+
+    const alignment = alignRenderedToSource(hit.renderedText, localText);
+    if (!alignment || alignment.matchedRatio < MIN_MATCHED_RATIO) {
+        return undefined;
+    }
+
+    return { localOffset: mapCaretToSource(alignment, hit.renderedOffset, localText.length) };
+}

--- a/src/contentScript/tableRuntime/interaction/clickCursorPlacement.ts
+++ b/src/contentScript/tableRuntime/interaction/clickCursorPlacement.ts
@@ -1,7 +1,8 @@
 import type { EditorState } from '@codemirror/state';
-import { unsanitizeRootText } from '../../editorBridge/cellTextCodec';
+import { syntaxTree } from '@codemirror/language';
+import { toLocalSelection, unsanitizeRootText } from '../../editorBridge/cellTextCodec';
 import type { InitialCursorPos } from '../../shared/cursorPlacement';
-import { alignRenderedToSource, mapCaretToSource } from '../../shared/textAlignment';
+import { alignRenderedToSource, mapCaretToSource, type ExcludedSourceRange } from '../../shared/textAlignment';
 import type { RenderedCaretHit } from '../../tableWidget/cellCaretHit';
 import type { ResolvedActiveCell } from '../activeCell/resolvedActiveCell';
 
@@ -20,6 +21,47 @@ import type { ResolvedActiveCell } from '../activeCell/resolvedActiveCell';
  * "recognisably the same text", not a tuned threshold.
  */
 const MIN_MATCHED_RATIO = 0.5;
+
+/** Markdown syntax whose source text is absent from the rendered cell. */
+const EXCLUDED_SOURCE_NODE_NAMES = new Set(['HTMLTag', 'Comment', 'ProcessingInstruction']);
+
+/**
+ * Raw-HTML syntax ranges in the coordinates of the text the nested editor opens.
+ *
+ * CodeMirror already distinguishes real HTML from tag-shaped inline code and autolinks, so
+ * these ranges are more precise than recognising HTML-shaped strings a second time. Root-cell
+ * ranges are projected through the same pipe and line-break decoding as the nested text.
+ */
+function excludedSourceRanges(
+    state: EditorState,
+    resolvedCell: ResolvedActiveCell,
+    rootText: string,
+    localText: string
+): ExcludedSourceRange[] {
+    const ranges: ExcludedSourceRange[] = [];
+    syntaxTree(state).iterate({
+        from: resolvedCell.editableFrom,
+        to: resolvedCell.editableTo,
+        enter: (node) => {
+            if (!EXCLUDED_SOURCE_NODE_NAMES.has(node.name)) {
+                return;
+            }
+
+            const rootFrom = Math.max(node.from, resolvedCell.editableFrom) - resolvedCell.editableFrom;
+            const rootTo = Math.min(node.to, resolvedCell.editableTo) - resolvedCell.editableFrom;
+            const localRange = toLocalSelection({ anchor: rootFrom, head: rootTo }, rootText);
+            const from = Math.min(localRange.anchor, localRange.head);
+            const to = Math.max(localRange.anchor, localRange.head);
+
+            // `<br>` is HTML syntax in the table source but a real newline in the nested editor
+            // and rendered-text index, so it must remain available as an alignment anchor.
+            if (from < to && localText.slice(from, to) !== '\n') {
+                ranges.push({ from, to });
+            }
+        },
+    });
+    return ranges;
+}
 
 /**
  * Resolves the caret placement for a press on `resolvedCell`.
@@ -43,7 +85,8 @@ export function resolveClickCursorPos(
 
     // The nested editor opens on the unsanitized cell text, so aligning against that text
     // yields an offset in the coordinates the placement is applied in - no further mapping.
-    const localText = unsanitizeRootText(state.doc.sliceString(resolvedCell.editableFrom, resolvedCell.editableTo));
+    const rootText = state.doc.sliceString(resolvedCell.editableFrom, resolvedCell.editableTo);
+    const localText = unsanitizeRootText(rootText);
     if (hit.renderedText.length === 0 && localText.length > 0) {
         // Images and skipped MathML contribute no rendered text. Their sole flattened offset
         // cannot distinguish a press before the content from one after it, so keep the established
@@ -51,7 +94,11 @@ export function resolveClickCursorPos(
         return undefined;
     }
 
-    const alignment = alignRenderedToSource(hit.renderedText, localText);
+    const alignment = alignRenderedToSource(
+        hit.renderedText,
+        localText,
+        excludedSourceRanges(state, resolvedCell, rootText, localText)
+    );
     if (!alignment || alignment.matchedRatio < MIN_MATCHED_RATIO) {
         return undefined;
     }

--- a/src/contentScript/tableRuntime/interaction/clickCursorPlacement.ts
+++ b/src/contentScript/tableRuntime/interaction/clickCursorPlacement.ts
@@ -44,6 +44,12 @@ export function resolveClickCursorPos(
     // The nested editor opens on the unsanitized cell text, so aligning against that text
     // yields an offset in the coordinates the placement is applied in - no further mapping.
     const localText = unsanitizeRootText(state.doc.sliceString(resolvedCell.editableFrom, resolvedCell.editableTo));
+    if (hit.renderedText.length === 0 && localText.length > 0) {
+        // Images and skipped MathML contribute no rendered text. Their sole flattened offset
+        // cannot distinguish a press before the content from one after it, so keep the established
+        // mirrored-selection fallback instead of claiming every press belongs at source offset 0.
+        return undefined;
+    }
 
     const alignment = alignRenderedToSource(hit.renderedText, localText);
     if (!alignment || alignment.matchedRatio < MIN_MATCHED_RATIO) {

--- a/src/contentScript/tableRuntime/interaction/mouseCellDragSelection.ts
+++ b/src/contentScript/tableRuntime/interaction/mouseCellDragSelection.ts
@@ -11,6 +11,9 @@ import { getViewportHeight, resolveViewportBounds } from '../../shared/editorVie
 import { clamp } from '../../shared/numberUtils';
 import { isPrimaryMouseButton, isPrimaryMousePointer } from '../../shared/mouseEvents';
 import { SELECTOR_CELL, getWidgetSelector, readCellCoords } from '../../tableWidget/domHelpers';
+import { readRenderedCaretHit, type RenderedCaretHit } from '../../tableWidget/cellCaretHit';
+import { resolveClickCursorPos } from './clickCursorPlacement';
+import type { InitialCursorPos } from '../../shared/cursorPlacement';
 import { CellDragAutoScroller } from './mouseCellDragAutoScroll';
 
 const DRAG_START_DISTANCE_PX = 5;
@@ -44,6 +47,27 @@ interface MouseCellGesture {
     lastFocus: CellCoords | null;
     lastClientX: number;
     lastClientY: number;
+    /**
+     * Caret the press pointed at, read while the rendered content was still mounted.
+     * Only a press on a rendered cell carries one: an active-editor press already has a
+     * nested editor to place its own caret, and a drag discards it.
+     */
+    pressCaretHit: RenderedCaretHit | null;
+}
+
+/**
+ * What a pointer release resolved to, read before the release dispatches anything.
+ *
+ * Both the anchor and the caret placement depend on the document and the widget DOM as the
+ * press left them, and settling the release changes both.
+ */
+interface GestureRelease {
+    /** The pressed anchor against the current document, or null when it no longer resolves. */
+    resolvedAnchor: ResolvedActiveCell | null;
+    /** Caret the press pointed at, for a click that reopens the anchor. */
+    cursorPos: InitialCursorPos | undefined;
+    /** The drag ended back on the cell it started from, so that cell takes the caret again. */
+    reactivateAnchor: boolean;
 }
 
 /** Squared distance between two points. */
@@ -137,45 +161,73 @@ class MouseCellDragSelectionController {
             return;
         }
 
-        const pointedCell = this.resolveCellAtPoint(event, gesture);
-        const resolvedAnchor = gesture.origin === 'renderedCell' ? this.resolveCurrentRenderedAnchor(gesture) : null;
-        const shouldReactivateAnchor =
-            gesture.dragged && pointedCell !== null && isSameCellCoords(gesture.resolvedCell.activeCell, pointedCell);
+        const release = this.resolveRelease(event, gesture);
         const willReactivateAnchor =
-            shouldReactivateAnchor && (gesture.origin === 'activeEditor' || resolvedAnchor !== null);
-        const shouldConsume = gesture.origin === 'renderedCell' || gesture.dragged;
-        if (shouldConsume) {
+            release.reactivateAnchor && (gesture.origin === 'activeEditor' || release.resolvedAnchor !== null);
+
+        if (gesture.origin === 'renderedCell' || gesture.dragged) {
             event.preventDefault();
             event.stopPropagation();
         }
+
         // Only an active-editor drag can hand its own still-open anchor back; a rendered-cell
         // drag reopens the anchor below, so whatever cell it left active is cleared first.
         this.finishGesture({
-            keepActiveCell: shouldReactivateAnchor && gesture.origin === 'activeEditor',
+            keepActiveCell: release.reactivateAnchor && gesture.origin === 'activeEditor',
             focusSelection: !willReactivateAnchor,
         });
 
-        if (gesture.origin === 'renderedCell' && !gesture.dragged) {
-            if (resolvedAnchor) {
-                requestOpenCell(this.view, {
-                    resolvedCell: resolvedAnchor,
-                    clearCellSelection: Boolean(getCellSelection(this.view.state)),
-                });
-            }
-        } else if (shouldReactivateAnchor && gesture.origin === 'renderedCell') {
-            if (resolvedAnchor) {
-                requestOpenCell(this.view, {
-                    resolvedCell: resolvedAnchor,
-                    clearCellSelection: true,
-                });
-            }
-        } else if (shouldReactivateAnchor) {
-            // The anchor editor never left the DOM, so contracting back to it only needs
-            // to discard the provisional rectangle and restore keyboard focus.
-            this.view.dispatch({ effects: clearCellSelectionEffect.of(undefined) });
-            refocusNestedEditor(this.view);
-        }
+        this.settleRelease(gesture, release);
     };
+
+    /**
+     * Reads everything about the release that depends on the view as the press left it.
+     *
+     * Resolved before `finishGesture` dispatches, so the caret placement is aligned against
+     * the cell text that was actually pressed.
+     */
+    private resolveRelease(event: PointerEvent, gesture: MouseCellGesture): GestureRelease {
+        const pointedCell = this.resolveCellAtPoint(event, gesture);
+        const resolvedAnchor = gesture.origin === 'renderedCell' ? this.resolveCurrentRenderedAnchor(gesture) : null;
+
+        return {
+            resolvedAnchor,
+            cursorPos: resolvedAnchor
+                ? resolveClickCursorPos(this.view.state, resolvedAnchor, gesture.pressCaretHit)
+                : undefined,
+            reactivateAnchor:
+                gesture.dragged &&
+                pointedCell !== null &&
+                isSameCellCoords(gesture.resolvedCell.activeCell, pointedCell),
+        };
+    }
+
+    /** Hands the released gesture to whichever cell should own the caret now. */
+    private settleRelease(gesture: MouseCellGesture, release: GestureRelease): void {
+        if (gesture.origin !== 'renderedCell') {
+            if (release.reactivateAnchor) {
+                // The anchor editor never left the DOM, so contracting back to it only needs
+                // to discard the provisional rectangle and restore keyboard focus.
+                this.view.dispatch({ effects: clearCellSelectionEffect.of(undefined) });
+                refocusNestedEditor(this.view);
+            }
+            return;
+        }
+
+        // An anchor that no longer resolves cannot be reopened, and a drag that ended
+        // anywhere but its anchor leaves its own selection standing.
+        if (!release.resolvedAnchor || (gesture.dragged && !release.reactivateAnchor)) {
+            return;
+        }
+
+        requestOpenCell(this.view, {
+            resolvedCell: release.resolvedAnchor,
+            clearCellSelection: gesture.dragged || Boolean(getCellSelection(this.view.state)),
+            // A drag that contracted back onto its anchor asked for a cell selection, not for
+            // a caret at the point the press happened to start from.
+            initialCursorPos: gesture.dragged ? undefined : release.cursorPos,
+        });
+    }
 
     private readonly onPointerCancel = (event: PointerEvent): void => {
         if (this.gesture?.pointerId === event.pointerId) {
@@ -226,6 +278,8 @@ class MouseCellDragSelectionController {
             lastFocus: null,
             lastClientX: event.clientX,
             lastClientY: event.clientY,
+            pressCaretHit:
+                options.origin === 'renderedCell' ? readRenderedCaretHit(cell, event.clientX, event.clientY) : null,
         });
 
         if (options.origin === 'renderedCell') {

--- a/src/contentScript/tableRuntime/interaction/mouseCellDragSelection.ts
+++ b/src/contentScript/tableRuntime/interaction/mouseCellDragSelection.ts
@@ -192,9 +192,10 @@ class MouseCellDragSelectionController {
 
         return {
             resolvedAnchor,
-            cursorPos: resolvedAnchor
-                ? resolveClickCursorPos(this.view.state, resolvedAnchor, gesture.pressCaretHit)
-                : undefined,
+            cursorPos:
+                !gesture.dragged && resolvedAnchor
+                    ? resolveClickCursorPos(this.view.state, resolvedAnchor, gesture.pressCaretHit)
+                    : undefined,
             reactivateAnchor:
                 gesture.dragged &&
                 pointedCell !== null &&

--- a/src/contentScript/tableWidget/cellCaretHit.ts
+++ b/src/contentScript/tableWidget/cellCaretHit.ts
@@ -1,0 +1,182 @@
+import { CLASS_CELL_CONTENT } from '../shared/tableDomClasses';
+
+/**
+ * Turns a point inside a rendered cell into an offset in that cell's rendered text.
+ *
+ * This is the half of click-to-caret placement that owns widget DOM; converting the
+ * result back into a Markdown offset belongs to the runtime, which has the document.
+ */
+
+/** A press inside a rendered cell, expressed against the text the reader can see. */
+export interface RenderedCaretHit {
+    /** Flattened text of the cell's rendered content, as {@link indexRenderedText} defines it. */
+    renderedText: string;
+    /** Caret offset within `renderedText`. */
+    renderedOffset: number;
+}
+
+/** Where a node's text sits in the flattened rendered text. */
+interface TextSpan {
+    start: number;
+    end: number;
+}
+
+export interface RenderedTextIndex {
+    text: string;
+    spans: Map<Node, TextSpan>;
+}
+
+/**
+ * Elements whose descendant text bears no useful resemblance to the Markdown that produced
+ * it. KaTeX output is rewritten into MathML during post-processing, so its text is a
+ * transcription of the formula rather than of the `$...$` source. Skipping the subtree
+ * leaves the formula as one unmatched gap the alignment can step over, instead of a run of
+ * characters that align convincingly to the wrong places.
+ */
+const OPAQUE_LOCAL_NAMES = new Set(['math']);
+
+const LINE_BREAK_LOCAL_NAME = 'br';
+
+/**
+ * Flattens a rendered cell's text and records where each node's text landed.
+ *
+ * `<br>` counts as a single character because that is what it is in the cell's own text: a
+ * newline has to survive a GFM table row as `<br>`, and the nested editor shows it as `\n`
+ * again. Counting it as one keeps the flattened text directly comparable to the text the
+ * editor will open with.
+ *
+ * Spans are recorded for every node visited, including the ones inside skipped subtrees, so
+ * a caret reported against any of them still resolves to a position.
+ */
+export function indexRenderedText(root: HTMLElement): RenderedTextIndex {
+    const spans = new Map<Node, TextSpan>();
+    let text = '';
+
+    const visit = (node: Node): void => {
+        const start = text.length;
+
+        if (node.nodeType === Node.TEXT_NODE) {
+            text += (node as Text).data;
+        } else if (node.nodeType === Node.ELEMENT_NODE) {
+            const element = node as Element;
+            if (element.localName === LINE_BREAK_LOCAL_NAME) {
+                text += '\n';
+            } else if (!OPAQUE_LOCAL_NAMES.has(element.localName)) {
+                for (const child of Array.from(element.childNodes)) {
+                    visit(child);
+                }
+            }
+        }
+
+        spans.set(node, { start, end: text.length });
+    };
+
+    for (const child of Array.from(root.childNodes)) {
+        visit(child);
+    }
+    spans.set(root, { start: 0, end: text.length });
+
+    return { text, spans };
+}
+
+/**
+ * Converts a DOM caret position into an offset in the flattened text.
+ *
+ * A caret in a text node offsets into its characters; a caret in an element offsets into
+ * its child list, and resolves to the start of the child it precedes. Returns null for a
+ * node the index never saw, which means the caret was not inside the cell content.
+ */
+export function flatOffsetFromDomPosition(index: RenderedTextIndex, node: Node, offset: number): number | null {
+    const span = index.spans.get(node);
+    if (!span) {
+        return null;
+    }
+
+    if (node.nodeType === Node.TEXT_NODE) {
+        const data = (node as Text).data;
+        return span.start + Math.min(Math.max(offset, 0), data.length);
+    }
+
+    const children = node.childNodes;
+    if (offset <= 0) {
+        return span.start;
+    }
+    if (offset >= children.length) {
+        return span.end;
+    }
+
+    return index.spans.get(children[offset])?.start ?? span.end;
+}
+
+interface CaretDomPosition {
+    node: Node;
+    offset: number;
+}
+
+/**
+ * Document APIs for hit-testing a caret, neither of which is in every engine's lib types.
+ *
+ * `caretRangeFromPoint` is the Chromium and WebKit spelling, which covers Joplin desktop and
+ * both mobile webviews; `caretPositionFromPoint` is the standard one, which Firefox ships.
+ */
+interface CaretHitTestDocument {
+    caretRangeFromPoint?: (x: number, y: number) => Range | null;
+    caretPositionFromPoint?: (x: number, y: number) => { offsetNode: Node; offset: number } | null;
+}
+
+function caretFromPoint(doc: Document, clientX: number, clientY: number): CaretDomPosition | null {
+    const hitTest = doc as Document & CaretHitTestDocument;
+
+    const range = hitTest.caretRangeFromPoint?.(clientX, clientY);
+    if (range) {
+        return { node: range.startContainer, offset: range.startOffset };
+    }
+
+    const position = hitTest.caretPositionFromPoint?.(clientX, clientY);
+    return position ? { node: position.offsetNode, offset: position.offset } : null;
+}
+
+/**
+ * Offset for a press that missed the content box, which is what clicking a cell's padding
+ * produces. Past the content's end in reading order means the end of the text and before its
+ * start means the beginning; anything else has no obvious answer and declines.
+ */
+function offsetOutsideContent(
+    content: HTMLElement,
+    textLength: number,
+    clientX: number,
+    clientY: number
+): number | null {
+    const rect = content.getBoundingClientRect();
+
+    if (clientY > rect.bottom || (clientY >= rect.top && clientX > rect.right)) {
+        return textLength;
+    }
+    if (clientY < rect.top || clientX < rect.left) {
+        return 0;
+    }
+
+    return null;
+}
+
+/**
+ * Reads the caret a press at (`clientX`, `clientY`) implies within `cell`'s rendered content.
+ *
+ * Returns null when the cell has no rendered content wrapper or the press cannot be
+ * resolved against it, which callers treat as "no placement to offer".
+ */
+export function readRenderedCaretHit(cell: HTMLElement, clientX: number, clientY: number): RenderedCaretHit | null {
+    const content = cell.querySelector(`:scope > .${CLASS_CELL_CONTENT}`) as HTMLElement | null;
+    if (!content) {
+        return null;
+    }
+
+    const index = indexRenderedText(content);
+    const caret = caretFromPoint(cell.ownerDocument, clientX, clientY);
+    const renderedOffset =
+        caret && content.contains(caret.node)
+            ? flatOffsetFromDomPosition(index, caret.node, caret.offset)
+            : offsetOutsideContent(content, index.text.length, clientX, clientY);
+
+    return renderedOffset === null ? null : { renderedText: index.text, renderedOffset };
+}

--- a/src/contentScript/tableWidget/cellCaretHit.ts
+++ b/src/contentScript/tableWidget/cellCaretHit.ts
@@ -45,8 +45,8 @@ const LINE_BREAK_LOCAL_NAME = 'br';
  * again. Counting it as one keeps the flattened text directly comparable to the text the
  * editor will open with.
  *
- * Spans are recorded for every node visited, including the ones inside skipped subtrees, so
- * a caret reported against any of them still resolves to a position.
+ * Spans are recorded for every node visited. Descendants of opaque subtrees are not visited,
+ * so a caret reported inside one declines placement and uses the established fallback.
  */
 export function indexRenderedText(root: HTMLElement): RenderedTextIndex {
     const spans = new Map<Node, TextSpan>();

--- a/src/contentScript/tableWidget/tableWidgetInteractions.ts
+++ b/src/contentScript/tableWidget/tableWidgetInteractions.ts
@@ -9,6 +9,8 @@ import { resolveTableContextFromEventTarget } from '../tableRuntime/tablePositio
 import { linkOpenerFacet } from '../services/linkOpener';
 import { isPrimaryMouseButton, isPrimaryMousePointer } from '../shared/mouseEvents';
 import { SELECTOR_CELL, getWidgetSelector, readCellCoords } from './domHelpers';
+import { readRenderedCaretHit } from './cellCaretHit';
+import { resolveClickCursorPos } from '../tableRuntime/interaction/clickCursorPlacement';
 import { requestOpenCell } from '../tableRuntime/openCellRequest';
 import { createResolvedActiveCell, type ResolvedActiveCell } from '../tableRuntime/activeCell/resolvedActiveCell';
 import {
@@ -272,9 +274,14 @@ function activateCellFromMouseDown(view: EditorView, event: MouseEvent, cell: HT
         return true;
     }
 
+    // Read the press against the rendered content before the open request replaces it, so
+    // the caret lands where the reader pointed rather than at the start of the cell.
+    const caretHit = readRenderedCaretHit(cell, event.clientX, event.clientY);
+
     requestOpenCell(view, {
         resolvedCell,
         clearCellSelection: hasSelection,
+        initialCursorPos: resolveClickCursorPos(view.state, resolvedCell, caretHit),
     });
 
     return true;


### PR DESCRIPTION
Implement click-to-caret functionality that places the caret at the clicked location within a cell when opened.

For cells containing markup, this is a heuristic so there are some limitations, but it works well with any reasonable markdown table cell content in my testing