### PR TITLE
fix: multi-cell paste inside the active cell editor in the web app

### DIFF
--- a/docs/Architecture/Nested-Editor-Architecture.md
+++ b/docs/Architecture/Nested-Editor-Architecture.md
@@ -105,6 +105,7 @@ Blocks unintended main editor edits during cell editing (Android IME focus issue
 - Treats the editable span as the allowed in-cell edit range while the semantic span remains the render/parse source.
 - Allows external updates not overlapping table.
 - Whitelists `syncAnnotation` transactions.
+- Whitelists `tableClipboardRewriteAnnotation` transactions: table clipboard rewrites replace the whole table by design, so the active-cell range check does not apply to them.
 - Whitelists structural operations with `rebuildTableWidgetsEffect`.
 - Sanitizes context-menu paste (newlines → `<br>`, pipes escaped).
 - Upgrades root-editor `input.paste` transactions into multi-cell table paste when Joplin routes Cmd/Ctrl+V to the main editor while a nested editor is open.

--- a/docs/Architecture/Structural-Commands-and-Serialization.md
+++ b/docs/Architecture/Structural-Commands-and-Serialization.md
@@ -42,6 +42,8 @@ not preserve stale table context.
 ### 1b. Selection Clipboard Entry (`tableRuntime/selection/cellSelectionClipboard.ts`)
 
 - Document-level `copy`/`cut`/`paste` capture handles selection-mode clipboard operations and any nested-editor paste flows that surface as real DOM paste events.
+- A `paste` handler on the nested editor itself is the fallback for a paste the document-level capture declined; it fires only when that capture left the event unhandled, and non-table text falls through to CodeMirror's own paste handling.
+- Rewrites carry `tableClipboardRewriteAnnotation` so the main-editor guard lets them through instead of rejecting them for reaching outside the active cell.
 - `Ctrl+X` is selection-only: copy markdown fragment, then run the shared selection-removal rewrite and keep the resulting selection state.
 - `Ctrl+V` is anchor-based: selection top-left wins; otherwise an active nested editor can supply the anchor cell.
 - Valid pasted markdown table fragments may expand the target table with new body rows and columns.

--- a/src/contentScript/__tests__/mainEditorGuard.test.ts
+++ b/src/contentScript/__tests__/mainEditorGuard.test.ts
@@ -3,6 +3,10 @@ import { activeCellField, getActiveCell, setActiveCellEffect, type ActiveCell } 
 import { cellSelectionField, getCellSelection } from '../tableState/cellSelectionState';
 import { activateInsertedTableEffect, insertedTableActivationField } from '../tableState/insertedTableActivation';
 import { createMainEditorActiveCellGuard } from '../editorBridge/mainEditorGuard';
+import {
+    buildMultiCellPasteRewrite,
+    createTableClipboardRewriteSpec,
+} from '../tableRuntime/selection/cellSelectionClipboard';
 import { computeMarkdownTableCellRanges } from '../tableModel/markdownTableCellRanges';
 import { searchForceSourceModeField, setSearchForceSourceModeEffect } from '../tableState/searchForceSourceMode';
 import { sourceModeField, toggleSourceModeEffect } from '../tableState/sourceMode';
@@ -79,6 +83,25 @@ describe('createMainEditorActiveCellGuard', () => {
         });
 
         expect(tr.state.doc.toString()).toContain('| H |');
+    });
+
+    it('applies a table clipboard rewrite dispatched while the nested editor is open', () => {
+        // The document-level clipboard capture dispatches this rewrite straight at the main
+        // editor. It replaces the whole table, so without a guard bypass the active-cell
+        // sanitization would reject it and the paste would silently do nothing.
+        const state = createActiveHeaderState();
+        const rewrite = buildMultiCellPasteRewrite(
+            state,
+            { tableFrom: 0, anchor: { section: 'header', row: 0, col: 0 }, source: 'activeCell' },
+            ['| P1 | P2 |', '| --- | --- |', '| Q1 | Q2 |'].join('\n')
+        );
+        expect(rewrite).not.toBeNull();
+
+        const tr = state.update(createTableClipboardRewriteSpec(state, rewrite!));
+
+        expect(tr.state.doc.toString()).toBe(['| P1 | P2 |', '| --- | --- |', '| Q1 | Q2 |'].join('\n'));
+        expect(getActiveCell(tr.state)).toBeNull();
+        expect(getCellSelection(tr.state)).not.toBeNull();
     });
 
     it('allows structural table edits that force rebuild', () => {

--- a/src/contentScript/__tests__/nestedEditorDomHandlers.test.ts
+++ b/src/contentScript/__tests__/nestedEditorDomHandlers.test.ts
@@ -6,6 +6,21 @@ import { afterEach, describe, expect, it, vi, type Mock } from 'vitest';
 import { EditorSelection, EditorState } from '@codemirror/state';
 import { drawSelection, EditorView } from '@codemirror/view';
 import { createNestedEditorDomHandlers } from '../nestedEditor/domHandlers';
+import { handleTableClipboardTextPaste } from '../tableRuntime/selection/cellSelectionClipboard';
+
+vi.mock('../tableRuntime/selection/cellSelectionClipboard', () => ({
+    handleTableClipboardTextPaste: vi.fn(() => false),
+}));
+
+const handleTableClipboardTextPasteMock = vi.mocked(handleTableClipboardTextPaste);
+
+function dispatchPaste(target: HTMLElement, text: string): void {
+    const event = new Event('paste', { bubbles: true, cancelable: true });
+    Object.defineProperty(event, 'clipboardData', {
+        value: { getData: (type: string) => (type === 'text/plain' ? text : '') },
+    });
+    target.dispatchEvent(event);
+}
 
 if (!Range.prototype.getClientRects) {
     Object.defineProperty(Range.prototype, 'getClientRects', {
@@ -42,6 +57,8 @@ function createNestedView(params: { parent: HTMLElement; syncSelectionToMain: Mo
 describe('nestedEditor dom handlers', () => {
     afterEach(() => {
         document.body.innerHTML = '';
+        handleTableClipboardTextPasteMock.mockReset();
+        handleTableClipboardTextPasteMock.mockReturnValue(false);
     });
 
     it('stops left-clicks inside selected text from bubbling to the parent editor', () => {
@@ -92,6 +109,37 @@ describe('nestedEditor dom handlers', () => {
 
         expect(syncSelectionToMain).toHaveBeenCalledTimes(1);
         expect(parentMouseDown).not.toHaveBeenCalled();
+
+        nestedView.destroy();
+    });
+
+    it('routes a table fragment pasted into the nested editor through the multi-cell rewrite', () => {
+        const parent = document.createElement('div');
+        document.body.appendChild(parent);
+        const nestedView = createNestedView({ parent, syncSelectionToMain: vi.fn() });
+        handleTableClipboardTextPasteMock.mockReturnValue(true);
+
+        const clipboardText = ['| P1 | P2 |', '| --- | --- |', '| Q1 | Q2 |'].join('\n');
+        dispatchPaste(nestedView.contentDOM, clipboardText);
+
+        expect(handleTableClipboardTextPasteMock).toHaveBeenCalledWith(clipboardText, expect.anything(), {
+            nestedEditorOpen: true,
+        });
+        // The rewrite owns the paste, so nothing lands in the cell editor itself.
+        expect(nestedView.state.doc.toString()).toBe('selected text');
+
+        nestedView.destroy();
+    });
+
+    it('lets a non-table paste fall through to the nested editor', () => {
+        const parent = document.createElement('div');
+        document.body.appendChild(parent);
+        const nestedView = createNestedView({ parent, syncSelectionToMain: vi.fn() });
+
+        dispatchPaste(nestedView.contentDOM, 'plain');
+
+        expect(handleTableClipboardTextPasteMock).toHaveBeenCalledTimes(1);
+        expect(nestedView.state.doc.toString()).toBe('plain text');
 
         nestedView.destroy();
     });

--- a/src/contentScript/editorBridge/mainEditorGuardPolicy.ts
+++ b/src/contentScript/editorBridge/mainEditorGuardPolicy.ts
@@ -9,6 +9,7 @@ import { changesOverlapRange, isFullDocumentReplace } from '../shared/transactio
 import { normalizeBeforeEditAnnotation } from '../tableRuntime/tableCanonicalForm';
 import {
     buildMultiCellPasteRewrite,
+    tableClipboardRewriteAnnotation,
     type TableClipboardRewrite,
 } from '../tableRuntime/selection/cellSelectionClipboard';
 import {
@@ -106,13 +107,19 @@ function clearActiveCellDecision(tr: Transaction): GuardDecision {
 
 /**
  * Transactions the guard never inspects: they either carry no document change or are
- * already produced by the plugin itself (nested editor sync, normalize-before-edit).
+ * already produced by the plugin itself (nested editor sync, normalize-before-edit,
+ * table clipboard rewrites).
+ *
+ * Clipboard rewrites replace the whole table by design, so without this bypass the
+ * active-cell sanitization below would reject the ones dispatched from the document-level
+ * clipboard capture while a nested editor is open.
  */
 function isGuardBypassTransaction(tr: Transaction): boolean {
     return (
         !tr.docChanged ||
         Boolean(tr.annotation(syncAnnotation)) ||
-        Boolean(tr.annotation(normalizeBeforeEditAnnotation))
+        Boolean(tr.annotation(normalizeBeforeEditAnnotation)) ||
+        Boolean(tr.annotation(tableClipboardRewriteAnnotation))
     );
 }
 

--- a/src/contentScript/nestedEditor/domHandlers.ts
+++ b/src/contentScript/nestedEditor/domHandlers.ts
@@ -214,26 +214,22 @@ export function createNestedEditorDomHandlers(
         ensureRootSelectionForCommand: () => void;
     }
 ): Extension[] {
-    let pendingClipboardText: string | null = null;
-
     return [
-        // Paste hits the root editor as an input.paste event and then gets sync'd back to nested editor
-        EditorView.clipboardInputFilter.of((text) => {
-            pendingClipboardText = text;
-            return text;
-        }),
-        EditorView.inputHandler.of((_view, _from, _to, _text) => {
-            if (pendingClipboardText === null) {
-                return false;
-            }
-
-            const clipboardText = pendingClipboardText;
-            pendingClipboardText = null;
-            return handleTableClipboardTextPaste(clipboardText, mainView, {
-                nestedEditorOpen: true,
-            });
-        }),
         EditorView.domEventHandlers({
+            // Last stop for a paste that reaches the nested editor directly: the document-level
+            // clipboard capture runs first and marks the event handled, so this only fires when
+            // that capture declined it. A markdown-table fragment still belongs to the multi-cell
+            // rewrite; anything else falls through to CodeMirror's own paste handling.
+            paste: (e) => {
+                const clipboardText = e.clipboardData?.getData('text/plain');
+                if (!clipboardText) {
+                    return false;
+                }
+
+                return handleTableClipboardTextPaste(clipboardText, mainView, {
+                    nestedEditorOpen: true,
+                });
+            },
             beforeinput: (e) => {
                 e.stopPropagation();
                 return false;

--- a/src/contentScript/tableRuntime/selection/cellSelectionClipboard.ts
+++ b/src/contentScript/tableRuntime/selection/cellSelectionClipboard.ts
@@ -1,4 +1,4 @@
-import { EditorSelection, type EditorState, type TransactionSpec } from '@codemirror/state';
+import { Annotation, EditorSelection, type EditorState, type TransactionSpec } from '@codemirror/state';
 import { EditorView, ViewPlugin } from '@codemirror/view';
 import { ClipboardTableFragment, MarkdownTable, type TableAlignment } from '../../tableModel/MarkdownTable';
 import { clearActiveCellEffect } from '../../tableState/activeCellState';
@@ -21,6 +21,13 @@ import type { CellCoords, TableRect } from '../../tableModel/types';
 import { canHandleTableClipboardShortcut, canHandleTableSelectionKeydown } from './cellSelectionShortcutScope';
 import { isNestedEditorOpen } from '../../nestedEditor/nestedEditorController';
 import { clamp } from '../../shared/numberUtils';
+
+/**
+ * Marks a transaction as one of this module's own table rewrites. The main-editor guard
+ * treats those as trusted: the rewrite replaces the whole table, which the guard would
+ * otherwise reject for reaching outside the active cell while a nested editor is open.
+ */
+export const tableClipboardRewriteAnnotation = Annotation.define<boolean>();
 
 export interface TableClipboardTarget {
     tableFrom: number;
@@ -375,7 +382,7 @@ export function createTableClipboardRewriteSpec(state: EditorState, rewrite: Tab
             : {}),
         selection: EditorSelection.single(rewrite.selectionAnchorPos),
         effects,
-        annotations: cellSelectionTransitionAnnotation.of(true),
+        annotations: [cellSelectionTransitionAnnotation.of(true), tableClipboardRewriteAnnotation.of(true)],
         scrollIntoView: false,
     };
 }


### PR DESCRIPTION
The document-level clipboard capture dispatches a whole-table rewrite, which the main-editor guard rejected for reaching outside the active cell while a nested editor was open, so the paste did nothing. Mark those rewrites with `tableClipboardRewriteAnnotation` and let the guard bypass them.

Also replace the nested editor's clipboardInputFilter/inputHandler pair with a real `paste` handler: CodeMirror's doPaste never consults inputHandler, so that fallback never fired and left stale clipboard text behind.