### PR TITLE
fix: wrap link cells vertically instead of expanding them horizontally

### DIFF
--- a/src/contentScript/__tests__/decorationPlugins.test.ts
+++ b/src/contentScript/__tests__/decorationPlugins.test.ts
@@ -5,9 +5,9 @@
 import { EditorState } from '@codemirror/state';
 import { EditorView } from '@codemirror/view';
 import { afterEach, describe, expect, it } from 'vitest';
-import { linkDestinationWrapPlugin } from '../nestedEditor/decorationPlugins';
+import { linkWrapPlugin } from '../nestedEditor/decorationPlugins';
 import { createNestedEditorMarkdownExtension } from '../nestedEditor/nestedEditorMarkdown';
-import { CLASS_NESTED_EDITOR_URL } from '../shared/tableDomClasses';
+import { CLASS_NESTED_EDITOR_LINK } from '../shared/tableDomClasses';
 
 let mountedView: EditorView | null = null;
 
@@ -16,31 +16,47 @@ afterEach(() => {
     mountedView = null;
 });
 
+function wrappedTextFor(doc: string): string[] {
+    const parent = document.createElement('div');
+    mountedView = new EditorView({
+        parent,
+        state: EditorState.create({
+            doc,
+            extensions: [createNestedEditorMarkdownExtension(), linkWrapPlugin],
+        }),
+    });
+
+    return [...parent.querySelectorAll(`.${CLASS_NESTED_EDITOR_LINK}`)].map((element) => element.textContent ?? '');
+}
+
 describe('nested editor decoration plugins', () => {
-    it('wraps link and image destinations without marking visible URL text', () => {
-        const parent = document.createElement('div');
-        const doc = [
+    it('wraps whole links and images, including the label, without marking visible URL text', () => {
+        const wrappedText = wrappedTextFor(
+            [
+                '[label](https://formatted.example/path)',
+                'https://bare.example/path',
+                '<https://autolink.example/path>',
+                '![alt](https://image.example/path)',
+                '![resource](:/0123456789abcdef0123456789abcdef)',
+            ].join(' ')
+        );
+
+        expect(wrappedText).toEqual([
             '[label](https://formatted.example/path)',
-            'https://bare.example/path',
-            '<https://autolink.example/path>',
             '![alt](https://image.example/path)',
             '![resource](:/0123456789abcdef0123456789abcdef)',
-        ].join(' ');
-        mountedView = new EditorView({
-            parent,
-            state: EditorState.create({
-                doc,
-                extensions: [createNestedEditorMarkdownExtension(), linkDestinationWrapPlugin],
-            }),
-        });
-
-        const wrappedText = [...parent.querySelectorAll(`.${CLASS_NESTED_EDITOR_URL}`)].map(
-            (element) => element.textContent
-        );
-        expect(wrappedText).toEqual([
-            'https://formatted.example/path',
-            'https://image.example/path',
-            ':/0123456789abcdef0123456789abcdef',
         ]);
+    });
+
+    it('covers a label that has no wrap opportunities of its own', () => {
+        const label = 'a'.repeat(58) + 'b';
+
+        expect(wrappedTextFor(`[${label}](https://sqlserverbuilds.example/#build)`)).toEqual([
+            `[${label}](https://sqlserverbuilds.example/#build)`,
+        ]);
+    });
+
+    it('leaves links without a destination alone', () => {
+        expect(wrappedTextFor('[reference][label] and [shortcut] and plain [brackets]')).toEqual([]);
     });
 });

--- a/src/contentScript/nestedEditor/decorationPlugins.ts
+++ b/src/contentScript/nestedEditor/decorationPlugins.ts
@@ -67,12 +67,11 @@ export const inlineCodePlugin = createSyntaxMarkPlugin((node) =>
 
 /**
  * Marks `[label](destination)` links and `![alt](destination)` images so the theme rule for
- * `CLASS_NESTED_EDITOR_LINK` in `nestedEditorTheme.ts` can wrap them aggressively, keeping them
- * inside the width cap `tableStyles.ts` puts on the editor.
+ * `CLASS_NESTED_EDITOR_LINK` in `nestedEditorTheme.ts` can lay each one out as its own
+ * width-capped box.
  *
- * The whole node is marked, not just the destination: `.cm-content` is a flex item, so its
- * automatic minimum size is its min-content width, and a label with no spaces would hold that
- * above the cap and be clipped by the hidden scroller rather than wrapped.
+ * The whole node is marked, not just the destination, so that the cap covers a label that has no
+ * wrap opportunities of its own.
  *
  * Only nodes with a destination qualify, which excludes bare URLs and autolinks (they render in
  * full, so the rendered cell already reserves their width) along with reference links, whose

--- a/src/contentScript/nestedEditor/decorationPlugins.ts
+++ b/src/contentScript/nestedEditor/decorationPlugins.ts
@@ -2,20 +2,19 @@ import { Decoration, DecorationSet, EditorView, MatchDecorator, ViewPlugin, View
 import { syntaxTree } from '@codemirror/language';
 import { Range } from '@codemirror/state';
 import type { SyntaxNodeRef } from '@lezer/common';
-import { CLASS_NESTED_EDITOR_URL } from '../shared/tableDomClasses';
+import { CLASS_NESTED_EDITOR_LINK } from '../shared/tableDomClasses';
 
 const INLINE_CODE_NODE_NAME = 'InlineCode';
 const LINK_NODE_NAME = 'Link';
 const IMAGE_NODE_NAME = 'Image';
 const URL_NODE_NAME = 'URL';
 
-type SyntaxNodePredicate = (node: SyntaxNodeRef) => boolean;
+const LINK_NODE_NAMES = new Set([LINK_NODE_NAME, IMAGE_NODE_NAME]);
 
-function computeSyntaxMarkDecorations(
-    view: EditorView,
-    className: string,
-    matches: SyntaxNodePredicate
-): DecorationSet {
+/** Returns the class to mark `node` with, or `null` to leave it undecorated. */
+type SyntaxNodeClassifier = (node: SyntaxNodeRef) => string | null;
+
+function computeSyntaxMarkDecorations(view: EditorView, classify: SyntaxNodeClassifier): DecorationSet {
     const marks: Range<Decoration>[] = [];
     const tree = syntaxTree(view.state);
     for (const { from, to } of view.visibleRanges) {
@@ -23,30 +22,32 @@ function computeSyntaxMarkDecorations(
             from,
             to,
             enter: (node) => {
-                if (matches(node)) {
+                const className = classify(node);
+                if (className !== null) {
                     marks.push(Decoration.mark({ class: className }).range(node.from, node.to));
                 }
             },
         });
     }
 
-    return Decoration.set(marks);
+    // Sorted rather than assumed ordered: `visibleRanges` is iterated separately per range.
+    return Decoration.set(marks, true);
 }
 
 /**
- * Builds a ViewPlugin that marks every syntax node matching `matches` with `className`.
+ * Builds a ViewPlugin that marks every syntax node `classify` returns a class for.
  *
  * Decorations are only recomputed on doc/viewport changes, not on late parse completion.
  * That is safe because `nestedEditorController` warms the parse tree with `ensureSyntaxTree`
  * before mounting the view, so the first computation already sees a complete tree.
  */
-function createSyntaxMarkPlugin(className: string, matches: SyntaxNodePredicate) {
+function createSyntaxMarkPlugin(classify: SyntaxNodeClassifier) {
     return ViewPlugin.define(
         (view) => ({
-            decorations: computeSyntaxMarkDecorations(view, className, matches),
+            decorations: computeSyntaxMarkDecorations(view, classify),
             update(update: ViewUpdate) {
                 if (update.docChanged || update.viewportChanged) {
-                    this.decorations = computeSyntaxMarkDecorations(update.view, className, matches);
+                    this.decorations = computeSyntaxMarkDecorations(update.view, classify);
                 }
             },
         }),
@@ -60,20 +61,26 @@ function createSyntaxMarkPlugin(className: string, matches: SyntaxNodePredicate)
  * Decorates the entire `InlineCode` syntax node (including backticks) with a unified class.
  * allowing for a continuous border/background around the whole segment.
  */
-export const inlineCodePlugin = createSyntaxMarkPlugin('cm-inline-code', (node) => node.name === INLINE_CODE_NODE_NAME);
-
-const WRAPPED_DESTINATION_PARENTS = new Set([LINK_NODE_NAME, IMAGE_NODE_NAME]);
+export const inlineCodePlugin = createSyntaxMarkPlugin((node) =>
+    node.name === INLINE_CODE_NODE_NAME ? 'cm-inline-code' : null
+);
 
 /**
- * Marks only the destinations in `[label](destination)` links and `![alt](destination)`
- * images, so the theme rule for `CLASS_NESTED_EDITOR_URL` in `nestedEditorTheme.ts` can wrap
- * them aggressively. Bare URLs are excluded: they render in full, so the rendered cell already
- * reserves their width.
+ * Marks `[label](destination)` links and `![alt](destination)` images so the theme rule for
+ * `CLASS_NESTED_EDITOR_LINK` in `nestedEditorTheme.ts` can wrap them aggressively, keeping them
+ * inside the width cap `tableStyles.ts` puts on the editor.
+ *
+ * The whole node is marked, not just the destination: `.cm-content` is a flex item, so its
+ * automatic minimum size is its min-content width, and a label with no spaces would hold that
+ * above the cap and be clipped by the hidden scroller rather than wrapped.
+ *
+ * Only nodes with a destination qualify, which excludes bare URLs and autolinks (they render in
+ * full, so the rendered cell already reserves their width) along with reference links, whose
+ * source is no wider than what it renders to.
  */
-export const linkDestinationWrapPlugin = createSyntaxMarkPlugin(CLASS_NESTED_EDITOR_URL, (node) => {
-    const parentName = node.node.parent?.name;
-    return node.name === URL_NODE_NAME && parentName !== undefined && WRAPPED_DESTINATION_PARENTS.has(parentName);
-});
+export const linkWrapPlugin = createSyntaxMarkPlugin((node) =>
+    LINK_NODE_NAMES.has(node.name) && node.node.getChild(URL_NODE_NAME) !== null ? CLASS_NESTED_EDITOR_LINK : null
+);
 
 /**
  * Decorates `==mark==` syntax with a highlight class.

--- a/src/contentScript/nestedEditor/nestedEditorController.ts
+++ b/src/contentScript/nestedEditor/nestedEditorController.ts
@@ -1,7 +1,7 @@
 import { ensureSyntaxTree } from '@codemirror/language';
 import { EditorSelection, EditorState, Transaction, type Extension } from '@codemirror/state';
 import { drawSelection, EditorView, ViewPlugin, ViewUpdate } from '@codemirror/view';
-import { inlineCodePlugin, insertPlugin, linkDestinationWrapPlugin, markPlugin } from './decorationPlugins';
+import { inlineCodePlugin, insertPlugin, linkWrapPlugin, markPlugin } from './decorationPlugins';
 import { createNestedEditorDomHandlers, createNestedEditorKeymap, mirrorLocalSelectionToMain } from './domHandlers';
 import { createJoplinSyntaxHighlighting } from './joplinHighlightStyle';
 import { createNestedEditorMarkdownExtension } from './nestedEditorMarkdown';
@@ -148,7 +148,7 @@ class NestedEditorController {
                 }),
                 createNestedEditorMarkdownExtension(),
                 inlineCodePlugin,
-                linkDestinationWrapPlugin,
+                linkWrapPlugin,
                 markPlugin,
                 insertPlugin,
                 createJoplinSyntaxHighlighting(isDarkTheme),

--- a/src/contentScript/nestedEditor/nestedEditorTheme.ts
+++ b/src/contentScript/nestedEditor/nestedEditorTheme.ts
@@ -3,6 +3,14 @@ import { Extension } from '@codemirror/state';
 import { CLASS_NESTED_EDITOR_LINK } from '../shared/tableDomClasses';
 
 /**
+ * Width a link's source is allowed to occupy in the cell editor before it wraps.
+ *
+ * Wide enough that most links wrap only once or twice, narrow enough that revealing one does not
+ * noticeably widen the table.
+ */
+const LINK_MAX_WIDTH = '40ch';
+
+/**
  * Creates a theme for the nested cell editor that adapts to light/dark mode.
  * Configures selection highlighting, scrolling behavior, and syntax decoration styles.
  *
@@ -77,13 +85,21 @@ export function createNestedEditorTheme(isDarkTheme: boolean): Extension {
                 textDecorationStyle: 'solid',
             },
             [`.${CLASS_NESTED_EDITOR_LINK}`]: {
-                // A link's source can be substantially wider than what it renders to, so it is
-                // allowed to break at any character. `anywhere` rather than `break-word` because
-                // only `anywhere` lowers min-content width, and `.cm-content` is a flex item whose
-                // automatic minimum size is exactly that: under `break-word` an unbreakable label
-                // holds the item above the width cap in `tableStyles.ts` and the hidden scroller
-                // clips it instead of wrapping it. Breaks still prefer whitespace, so a label with
-                // spaces wraps between words the way the rendered cell does.
+                // A link's source is far wider than what it renders to, so activating a cell that
+                // holds one used to widen the column: auto table layout hands each column its
+                // max-content width whenever the table still fits, and no `overflow-wrap` value
+                // lowers max-content. Laying the link out as its own box caps what it contributes
+                // to max-content, so the cell grows vertically instead.
+                //
+                // The cap belongs on the link rather than on the editor or the line, which the
+                // link shares with ordinary text: capping either of those truncates long non-link
+                // text, which should still be free to widen the cell.
+                display: 'inline-block',
+                maxWidth: LINK_MAX_WIDTH,
+                // `anywhere` rather than `break-word` because only `anywhere` lowers min-content
+                // width. A label with no wrap opportunities of its own would otherwise hold the
+                // box above the cap and overflow it. Breaks still prefer whitespace, so a label
+                // with spaces wraps between words the way the rendered cell does.
                 overflowWrap: 'anywhere',
             },
         },

--- a/src/contentScript/nestedEditor/nestedEditorTheme.ts
+++ b/src/contentScript/nestedEditor/nestedEditorTheme.ts
@@ -1,6 +1,6 @@
 import { EditorView } from '@codemirror/view';
 import { Extension } from '@codemirror/state';
-import { CLASS_NESTED_EDITOR_URL } from '../shared/tableDomClasses';
+import { CLASS_NESTED_EDITOR_LINK } from '../shared/tableDomClasses';
 
 /**
  * Creates a theme for the nested cell editor that adapts to light/dark mode.
@@ -76,9 +76,14 @@ export function createNestedEditorTheme(isDarkTheme: boolean): Extension {
                 textDecoration: 'underline',
                 textDecorationStyle: 'solid',
             },
-            [`.${CLASS_NESTED_EDITOR_URL}`]: {
-                // URL source can be substantially wider than its rendered link label. Allowing
-                // breaks at any character keeps it from increasing the table's intrinsic width.
+            [`.${CLASS_NESTED_EDITOR_LINK}`]: {
+                // A link's source can be substantially wider than what it renders to, so it is
+                // allowed to break at any character. `anywhere` rather than `break-word` because
+                // only `anywhere` lowers min-content width, and `.cm-content` is a flex item whose
+                // automatic minimum size is exactly that: under `break-word` an unbreakable label
+                // holds the item above the width cap in `tableStyles.ts` and the hidden scroller
+                // clips it instead of wrapping it. Breaks still prefer whitespace, so a label with
+                // spaces wraps between words the way the rendered cell does.
                 overflowWrap: 'anywhere',
             },
         },

--- a/src/contentScript/shared/tableDomClasses.ts
+++ b/src/contentScript/shared/tableDomClasses.ts
@@ -2,4 +2,4 @@ export const CLASS_CELL_ACTIVE = 'cm-table-cell-active';
 export const CLASS_CELL_CONTENT = 'cm-table-cell-content';
 export const CLASS_CELL_EDITOR = 'cm-table-cell-editor';
 export const CLASS_CELL_EDITOR_HIDDEN = 'cm-table-cell-editor-hidden';
-export const CLASS_NESTED_EDITOR_URL = 'cm-nested-editor-url';
+export const CLASS_NESTED_EDITOR_LINK = 'cm-nested-editor-link';

--- a/src/contentScript/tableWidget/tableStyles.ts
+++ b/src/contentScript/tableWidget/tableStyles.ts
@@ -4,6 +4,7 @@ import {
     CLASS_CELL_CONTENT,
     CLASS_CELL_EDITOR,
     CLASS_CELL_EDITOR_HIDDEN,
+    CLASS_NESTED_EDITOR_LINK,
 } from '../shared/tableDomClasses';
 import { CLASS_TABLE_WIDGET_TABLE, getWidgetSelector } from './domHelpers';
 
@@ -14,6 +15,18 @@ import { CLASS_TABLE_WIDGET_TABLE, getWidgetSelector } from './domHelpers';
  * `selectionTint.ts` redraws a gridline at exactly this width.
  */
 export const CELL_BORDER_WIDTH = '1px';
+
+/**
+ * Width cap applied to the nested editor while it holds a link or image.
+ *
+ * `overflow-wrap: anywhere` on `CLASS_NESTED_EDITOR_LINK` only adds soft wrap opportunities to the
+ * *min-content* width; a link's source still contributes its full length to *max-content*. Auto
+ * table layout hands each column its max-content width whenever the table fits, so revealing a
+ * link's source widened the column until the table hit the widget edge before any wrapping
+ * happened. Capping the editor's width caps what it contributes to max-content, so the wrapping
+ * engages immediately and the cell grows vertically instead.
+ */
+const LINK_EDITOR_MAX_WIDTH = '40ch';
 
 /**
  * Base styles for the table widget, split by responsibility:
@@ -113,6 +126,11 @@ export const tableStyles = EditorView.baseTheme({
         {
             display: 'none',
         },
+    // Scoped to cells that actually contain a link/image destination so ordinary cells keep
+    // expanding freely as you type rather than being locked to a fixed editing width.
+    [`.${CLASS_CELL_EDITOR}:has(.${CLASS_NESTED_EDITOR_LINK})`]: {
+        maxWidth: LINK_EDITOR_MAX_WIDTH,
+    },
     [`.${CLASS_CELL_EDITOR} .cm-editor`]: {
         width: '100%',
     },

--- a/src/contentScript/tableWidget/tableStyles.ts
+++ b/src/contentScript/tableWidget/tableStyles.ts
@@ -4,7 +4,6 @@ import {
     CLASS_CELL_CONTENT,
     CLASS_CELL_EDITOR,
     CLASS_CELL_EDITOR_HIDDEN,
-    CLASS_NESTED_EDITOR_LINK,
 } from '../shared/tableDomClasses';
 import { CLASS_TABLE_WIDGET_TABLE, getWidgetSelector } from './domHelpers';
 
@@ -15,18 +14,6 @@ import { CLASS_TABLE_WIDGET_TABLE, getWidgetSelector } from './domHelpers';
  * `selectionTint.ts` redraws a gridline at exactly this width.
  */
 export const CELL_BORDER_WIDTH = '1px';
-
-/**
- * Width cap applied to the nested editor while it holds a link or image.
- *
- * `overflow-wrap: anywhere` on `CLASS_NESTED_EDITOR_LINK` only adds soft wrap opportunities to the
- * *min-content* width; a link's source still contributes its full length to *max-content*. Auto
- * table layout hands each column its max-content width whenever the table fits, so revealing a
- * link's source widened the column until the table hit the widget edge before any wrapping
- * happened. Capping the editor's width caps what it contributes to max-content, so the wrapping
- * engages immediately and the cell grows vertically instead.
- */
-const LINK_EDITOR_MAX_WIDTH = '40ch';
 
 /**
  * Base styles for the table widget, split by responsibility:
@@ -126,11 +113,6 @@ export const tableStyles = EditorView.baseTheme({
         {
             display: 'none',
         },
-    // Scoped to cells that actually contain a link/image destination so ordinary cells keep
-    // expanding freely as you type rather than being locked to a fixed editing width.
-    [`.${CLASS_CELL_EDITOR}:has(.${CLASS_NESTED_EDITOR_LINK})`]: {
-        maxWidth: LINK_EDITOR_MAX_WIDTH,
-    },
     [`.${CLASS_CELL_EDITOR} .cm-editor`]: {
         width: '100%',
     },


### PR DESCRIPTION
Activating a cell containing a markdown link reveals the link's source, which widened the column and shifted the whole table sideways. #195 mitigated this by wrapping the link's destination aggressively, but wrapping alone cannot fix it.

## Why wrapping alone doesn't work

`overflow-wrap` lowers an element's **min-content** width. Nothing lowers **max-content**, and auto table layout hands each column its max-content width whenever the table still fits. So the column kept growing until the table hit the widget edge, and only then did the wrapping engage.

## The fix

Lay each `[label](destination)` link and `![alt](destination)` image out as its own inline-block with `max-width: 40ch`. An inline-block's max-content contribution is clamped by its own max-width, so the link no longer widens the column and the cell grows vertically instead.

Three details that matter:

- **The cap sits on the link itself**, not on the cell editor or the line containing it. Those are shared with ordinary text, and capping them truncates long non-link text, which should still be free to widen the cell.
- **The whole link node is marked**, not just the destination, so a label with no wrap opportunities of its own is covered too.
- **`overflow-wrap: anywhere`, not `break-word`.** Only `anywhere` lowers min-content width; without that, an unbreakable label holds the box above the cap and overflows it. Breaks still prefer whitespace, so a label with spaces wraps between words the way the rendered cell does.

Bare URLs, autolinks and reference links are excluded: they render at their source width or narrower, so the rendered cell already reserves the space.

## Measured

Chromium, against the CodeMirror + table CSS chain. `no link` is the same cell with the link line deleted, as the reference for how wide the cell *should* be:

| cell contents | cell width | clipped |
| --- | --- | --- |
| link + long unbreakable token, separate lines | 726px | no |
| ...same cell, no link | **726px** | no |
| link alone | 363px | no |
| link + long token on one line | 1071px | no |
| link with a 59-character label | 363px | no |

The first two rows are the property being aimed for: the cell is sized entirely by its non-link content, and the link contributes nothing beyond its cap.

## Known behavior

When a cell is wide because of other content, the link still wraps at 40ch rather than using the extra room. Capping an element's max-content contribution without also capping its used width isn't expressible in CSS.
