### PR TITLE
ux: center the floating toolbar

### DIFF
--- a/docs/Architecture/Table-Display.md
+++ b/docs/Architecture/Table-Display.md
@@ -103,10 +103,5 @@ rect with the window: a scroller that already sits inside the window survives un
 document is clipped back to the window. The floating toolbar uses those bounds to decide visibility and placement;
 cell-drag auto-scroll uses them for its edge zones and for clamping its hit test.
 
-The toolbar anchors to a box combining both elements the widget is made of, handed to Floating UI as a virtual
-element. Horizontally it centres on the widget's `<table>` clipped to the widget root, so it tracks the visible slice
-of a table that is wider than the editor. Vertically it uses the root, whose border box also covers the horizontal
-scrollbar the root renders for such a table, at whatever width the host theme gives it.
-
 Auto-scroll picks its scroll target from the same distinction, testing whether `scrollDOM` has any overflow to move
 and falling back to `document.scrollingElement` when it does not.

--- a/docs/Architecture/Table-Display.md
+++ b/docs/Architecture/Table-Display.md
@@ -103,9 +103,10 @@ rect with the window: a scroller that already sits inside the window survives un
 document is clipped back to the window. The floating toolbar uses those bounds to decide visibility and placement;
 cell-drag auto-scroll uses them for its edge zones and for clamping its hit test.
 
-The toolbar centres horizontally on the widget's `<table>`, not on the full-width widget root. Because that table
-scrolls inside the root when it is wider than the editor, the anchor is the table rect clipped to the root, handed to
-Floating UI as a virtual element so the toolbar tracks the visible slice.
+The toolbar anchors to a box combining both elements the widget is made of, handed to Floating UI as a virtual
+element. Horizontally it centres on the widget's `<table>` clipped to the widget root, so it tracks the visible slice
+of a table that is wider than the editor. Vertically it uses the root, whose border box also covers the horizontal
+scrollbar the root renders for such a table, at whatever width the host theme gives it.
 
 Auto-scroll picks its scroll target from the same distinction, testing whether `scrollDOM` has any overflow to move
 and falling back to `document.scrollingElement` when it does not.

--- a/docs/Architecture/Table-Display.md
+++ b/docs/Architecture/Table-Display.md
@@ -103,5 +103,9 @@ rect with the window: a scroller that already sits inside the window survives un
 document is clipped back to the window. The floating toolbar uses those bounds to decide visibility and placement;
 cell-drag auto-scroll uses them for its edge zones and for clamping its hit test.
 
+The toolbar centres horizontally on the widget's `<table>`, not on the full-width widget root. Because that table
+scrolls inside the root when it is wider than the editor, the anchor is the table rect clipped to the root, handed to
+Floating UI as a virtual element so the toolbar tracks the visible slice.
+
 Auto-scroll picks its scroll target from the same distinction, testing whether `scrollDOM` has any overflow to move
 and falling back to `document.scrollingElement` when it does not.

--- a/docs/Architecture/Table-Display.md
+++ b/docs/Architecture/Table-Display.md
@@ -105,3 +105,9 @@ cell-drag auto-scroll uses them for its edge zones and for clamping its hit test
 
 Auto-scroll picks its scroll target from the same distinction, testing whether `scrollDOM` has any overflow to move
 and falling back to `document.scrollingElement` when it does not.
+
+## Floating Toolbar
+
+The toolbar uses a Floating UI virtual anchor. Horizontally, it uses the table rect clipped to the widget root so it
+centres on the visible table slice; vertically, it uses the widget root so bottom placement clears the horizontal
+scrollbar.

--- a/src/contentScript/__tests__/toolbarPositioning.test.ts
+++ b/src/contentScript/__tests__/toolbarPositioning.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import {
-    clipTableRectToWidget,
     computePinnedAbsolutePlacement,
     computePinnedFixedPlacement,
     isFinitePoint,
     isObscuringTopPlacement,
     isTableOutsideViewport,
+    resolveToolbarAnchorRect,
     resolveToolbarPlacementMode,
     shouldPinAbove,
     TOOLBAR_VIEWPORT_PADDING_PX,
@@ -33,48 +33,53 @@ function domRectLike(partial: Partial<ToolbarRect>): ToolbarRect {
 
 const TOOLBAR_HEIGHT = 30;
 
-describe('clipTableRectToWidget', () => {
-    const widgetRect = rect({ left: 100, width: 600 });
+describe('resolveToolbarAnchorRect', () => {
+    const widgetRect = rect({ top: 0, bottom: 90, height: 90, left: 100, width: 600 });
 
-    it('leaves a table narrower than its widget untouched', () => {
-        const clipped = clipTableRectToWidget(rect({ top: 10, bottom: 60, left: 100, width: 200 }), widgetRect);
+    it('centres horizontally on a table narrower than its widget', () => {
+        const anchor = resolveToolbarAnchorRect(rect({ top: 8, bottom: 70, left: 100, width: 200 }), widgetRect);
 
-        expect(clipped).toEqual(rect({ top: 10, bottom: 60, left: 100, width: 200 }));
+        expect(anchor.left).toBe(100);
+        expect(anchor.width).toBe(200);
     });
 
     it('clips a table wider than its widget to the visible slice', () => {
-        const clipped = clipTableRectToWidget(rect({ top: 10, bottom: 60, left: 100, width: 2000 }), widgetRect);
+        const anchor = resolveToolbarAnchorRect(rect({ top: 8, bottom: 70, left: 100, width: 2000 }), widgetRect);
 
-        expect(clipped.left).toBe(100);
-        expect(clipped.width).toBe(600);
+        expect(anchor.left).toBe(100);
+        expect(anchor.width).toBe(600);
     });
 
     it('follows the visible slice when the table is scrolled horizontally', () => {
-        const clipped = clipTableRectToWidget(rect({ top: 10, bottom: 60, left: -400, width: 2000 }), widgetRect);
+        const anchor = resolveToolbarAnchorRect(rect({ top: 8, bottom: 70, left: -400, width: 2000 }), widgetRect);
 
-        expect(clipped.left).toBe(100);
-        expect(clipped.width).toBe(600);
+        expect(anchor.left).toBe(100);
+        expect(anchor.width).toBe(600);
     });
 
-    it('preserves the vertical bounds of the table', () => {
-        const clipped = clipTableRectToWidget(rect({ top: 10, bottom: 60, left: -400, width: 2000 }), widgetRect);
+    it('takes its vertical bounds from the widget, which covers the horizontal scrollbar', () => {
+        // The widget extends 20px below the table: its padding plus the scrollbar the overflowing
+        // table makes it render. Anchoring to the table would put the toolbar over that scrollbar.
+        const anchor = resolveToolbarAnchorRect(rect({ top: 8, bottom: 70, left: 100, width: 2000 }), widgetRect);
 
-        expect(clipped.top).toBe(10);
-        expect(clipped.bottom).toBe(60);
+        expect(anchor.top).toBe(0);
+        expect(anchor.bottom).toBe(90);
+        expect(anchor.height).toBe(90);
     });
 
-    it('keeps the vertical bounds of a DOMRect, whose values are prototype accessors', () => {
-        const tableRect = domRectLike({ top: 10, bottom: 60, height: 50, left: -400, width: 2000 });
+    it('keeps the bounds of DOMRects, whose values are prototype accessors', () => {
+        const anchor = resolveToolbarAnchorRect(
+            domRectLike({ top: 8, bottom: 70, height: 62, left: -400, width: 2000 }),
+            domRectLike({ top: 0, bottom: 90, height: 90, left: 100, width: 600 })
+        );
 
-        const clipped = clipTableRectToWidget(tableRect, widgetRect);
-
-        expect(clipped).toEqual({ top: 10, bottom: 60, height: 50, left: 100, width: 600 });
+        expect(anchor).toEqual({ top: 0, bottom: 90, height: 90, left: 100, width: 600 });
     });
 
     it('reports zero width when the rects do not overlap', () => {
-        const clipped = clipTableRectToWidget(rect({ left: 5000, width: 100 }), widgetRect);
+        const anchor = resolveToolbarAnchorRect(rect({ left: 5000, width: 100 }), widgetRect);
 
-        expect(clipped.width).toBe(0);
+        expect(anchor.width).toBe(0);
     });
 });
 
@@ -151,7 +156,7 @@ describe('computePinnedAbsolutePlacement', () => {
     it('centres on the table and positions against the top edge relative to the offset parent', () => {
         const placement = computePinnedAbsolutePlacement({
             ...base,
-            tableRect: rect({ top: 350, bottom: 900, left: 120, width: 300 }),
+            anchorRect: rect({ top: 350, bottom: 900, left: 120, width: 300 }),
             pinAbove: true,
         });
 
@@ -162,7 +167,7 @@ describe('computePinnedAbsolutePlacement', () => {
     it('centres on the table and positions against the bottom edge when pinning below', () => {
         const placement = computePinnedAbsolutePlacement({
             ...base,
-            tableRect: rect({ top: -400, bottom: 200, left: 120, width: 300 }),
+            anchorRect: rect({ top: -400, bottom: 200, left: 120, width: 300 }),
             pinAbove: false,
         });
 
@@ -172,7 +177,7 @@ describe('computePinnedAbsolutePlacement', () => {
     it('clamps the toolbar inside the editor panel', () => {
         const placement = computePinnedAbsolutePlacement({
             ...base,
-            tableRect: rect({ top: 350, bottom: 900, left: 5000, width: 300 }),
+            anchorRect: rect({ top: 350, bottom: 900, left: 5000, width: 300 }),
             pinAbove: true,
         });
 
@@ -182,7 +187,7 @@ describe('computePinnedAbsolutePlacement', () => {
     it('clamps to the left padding when centring a narrow table would overflow the panel', () => {
         const placement = computePinnedAbsolutePlacement({
             ...base,
-            tableRect: rect({ top: 350, bottom: 900, left: 50, width: 60 }),
+            anchorRect: rect({ top: 350, bottom: 900, left: 50, width: 60 }),
             pinAbove: true,
         });
 
@@ -193,7 +198,7 @@ describe('computePinnedAbsolutePlacement', () => {
         const placement = computePinnedAbsolutePlacement({
             ...base,
             viewRect: rect({ top: 100, left: 50, width: 100, height: 400 }),
-            tableRect: rect({ top: 350, bottom: 900, left: 5000, width: 300 }),
+            anchorRect: rect({ top: 350, bottom: 900, left: 5000, width: 300 }),
             pinAbove: true,
         });
 
@@ -204,7 +209,7 @@ describe('computePinnedAbsolutePlacement', () => {
         const placement = computePinnedAbsolutePlacement({
             ...base,
             viewport: { top: 100, bottom: 110, height: 10 },
-            tableRect: rect({ top: -400, bottom: 105, left: 120 }),
+            anchorRect: rect({ top: -400, bottom: 105, left: 120 }),
             pinAbove: false,
         });
 
@@ -223,7 +228,7 @@ describe('computePinnedFixedPlacement', () => {
     it('centres on the table in viewport-relative coordinates when pinning above', () => {
         const placement = computePinnedFixedPlacement({
             ...base,
-            tableRect: rect({ top: 500, bottom: 1200, left: 30, width: 340 }),
+            anchorRect: rect({ top: 500, bottom: 1200, left: 30, width: 340 }),
             pinAbove: true,
         });
 
@@ -234,7 +239,7 @@ describe('computePinnedFixedPlacement', () => {
     it('centres on the table in viewport-relative coordinates when pinning below', () => {
         const placement = computePinnedFixedPlacement({
             ...base,
-            tableRect: rect({ top: -500, bottom: 300, left: 30, width: 340 }),
+            anchorRect: rect({ top: -500, bottom: 300, left: 30, width: 340 }),
             pinAbove: false,
         });
 
@@ -244,7 +249,7 @@ describe('computePinnedFixedPlacement', () => {
     it('clamps the toolbar inside the viewport width', () => {
         const placement = computePinnedFixedPlacement({
             ...base,
-            tableRect: rect({ top: 500, bottom: 1200, left: 380, width: 340 }),
+            anchorRect: rect({ top: 500, bottom: 1200, left: 380, width: 340 }),
             pinAbove: true,
         });
 
@@ -254,7 +259,7 @@ describe('computePinnedFixedPlacement', () => {
     it('clamps to the left padding when centring a narrow table would overflow the viewport', () => {
         const placement = computePinnedFixedPlacement({
             ...base,
-            tableRect: rect({ top: 500, bottom: 1200, left: -60, width: 120 }),
+            anchorRect: rect({ top: 500, bottom: 1200, left: -60, width: 120 }),
             pinAbove: true,
         });
 

--- a/src/contentScript/__tests__/toolbarPositioning.test.ts
+++ b/src/contentScript/__tests__/toolbarPositioning.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+    clipTableRectToWidget,
     computePinnedAbsolutePlacement,
     computePinnedFixedPlacement,
     isFinitePoint,
@@ -16,7 +17,66 @@ function rect(partial: Partial<ToolbarRect>): ToolbarRect {
     return { top: 0, bottom: 0, left: 0, width: 0, height: 0, ...partial };
 }
 
+/**
+ * Mimics a real `DOMRect`, which exposes its values as prototype accessors rather than own
+ * properties. The toolbar measures with `getBoundingClientRect()`, so clipping must read fields
+ * explicitly instead of spreading.
+ */
+function domRectLike(partial: Partial<ToolbarRect>): ToolbarRect {
+    const prototype = {};
+    for (const [key, value] of Object.entries(rect(partial))) {
+        Object.defineProperty(prototype, key, { get: () => value, enumerable: false });
+    }
+
+    return Object.create(prototype) as ToolbarRect;
+}
+
 const TOOLBAR_HEIGHT = 30;
+
+describe('clipTableRectToWidget', () => {
+    const widgetRect = rect({ left: 100, width: 600 });
+
+    it('leaves a table narrower than its widget untouched', () => {
+        const clipped = clipTableRectToWidget(rect({ top: 10, bottom: 60, left: 100, width: 200 }), widgetRect);
+
+        expect(clipped).toEqual(rect({ top: 10, bottom: 60, left: 100, width: 200 }));
+    });
+
+    it('clips a table wider than its widget to the visible slice', () => {
+        const clipped = clipTableRectToWidget(rect({ top: 10, bottom: 60, left: 100, width: 2000 }), widgetRect);
+
+        expect(clipped.left).toBe(100);
+        expect(clipped.width).toBe(600);
+    });
+
+    it('follows the visible slice when the table is scrolled horizontally', () => {
+        const clipped = clipTableRectToWidget(rect({ top: 10, bottom: 60, left: -400, width: 2000 }), widgetRect);
+
+        expect(clipped.left).toBe(100);
+        expect(clipped.width).toBe(600);
+    });
+
+    it('preserves the vertical bounds of the table', () => {
+        const clipped = clipTableRectToWidget(rect({ top: 10, bottom: 60, left: -400, width: 2000 }), widgetRect);
+
+        expect(clipped.top).toBe(10);
+        expect(clipped.bottom).toBe(60);
+    });
+
+    it('keeps the vertical bounds of a DOMRect, whose values are prototype accessors', () => {
+        const tableRect = domRectLike({ top: 10, bottom: 60, height: 50, left: -400, width: 2000 });
+
+        const clipped = clipTableRectToWidget(tableRect, widgetRect);
+
+        expect(clipped).toEqual({ top: 10, bottom: 60, height: 50, left: 100, width: 600 });
+    });
+
+    it('reports zero width when the rects do not overlap', () => {
+        const clipped = clipTableRectToWidget(rect({ left: 5000, width: 100 }), widgetRect);
+
+        expect(clipped.width).toBe(0);
+    });
+});
 
 describe('isTableOutsideViewport', () => {
     const viewport: ViewportBounds = { top: 100, bottom: 500, height: 400 };
@@ -40,13 +100,13 @@ describe('resolveToolbarPlacementMode', () => {
     it('anchors above when the table top is visible with room for the toolbar', () => {
         const tableRect = rect({ top: 200, bottom: 300 });
 
-        expect(resolveToolbarPlacementMode(tableRect, TOOLBAR_HEIGHT, viewport)).toBe('top-start');
+        expect(resolveToolbarPlacementMode(tableRect, TOOLBAR_HEIGHT, viewport)).toBe('top');
     });
 
     it('anchors below when the table top is visible but crowded against the viewport top', () => {
         const tableRect = rect({ top: 110, bottom: 300 });
 
-        expect(resolveToolbarPlacementMode(tableRect, TOOLBAR_HEIGHT, viewport)).toBe('bottom-start');
+        expect(resolveToolbarPlacementMode(tableRect, TOOLBAR_HEIGHT, viewport)).toBe('bottom');
     });
 
     it('pins when neither table edge has room', () => {
@@ -64,7 +124,7 @@ describe('resolveToolbarPlacementMode', () => {
     it('anchors below when the table top is out of view but the bottom has room', () => {
         const tableRect = rect({ top: -50, bottom: 300 });
 
-        expect(resolveToolbarPlacementMode(tableRect, TOOLBAR_HEIGHT, viewport)).toBe('bottom-start');
+        expect(resolveToolbarPlacementMode(tableRect, TOOLBAR_HEIGHT, viewport)).toBe('bottom');
     });
 });
 
@@ -88,41 +148,52 @@ describe('computePinnedAbsolutePlacement', () => {
         offsetParentTop: 80,
     };
 
-    it('positions against the top edge relative to the offset parent', () => {
+    it('centres on the table and positions against the top edge relative to the offset parent', () => {
         const placement = computePinnedAbsolutePlacement({
             ...base,
-            tableRect: rect({ top: 350, bottom: 900, left: 120 }),
+            tableRect: rect({ top: 350, bottom: 900, left: 120, width: 300 }),
             pinAbove: true,
         });
 
-        expect(placement).toEqual({ x: 70, y: 25, strategy: 'absolute' });
+        // Table centre is 270, which is 220 relative to the panel; the 200px toolbar starts at 120.
+        expect(placement).toEqual({ x: 120, y: 25, strategy: 'absolute' });
     });
 
-    it('positions against the bottom edge when pinning below', () => {
+    it('centres on the table and positions against the bottom edge when pinning below', () => {
         const placement = computePinnedAbsolutePlacement({
             ...base,
-            tableRect: rect({ top: -400, bottom: 200, left: 120 }),
+            tableRect: rect({ top: -400, bottom: 200, left: 120, width: 300 }),
             pinAbove: false,
         });
 
-        expect(placement).toEqual({ x: 70, y: 385, strategy: 'absolute' });
+        expect(placement).toEqual({ x: 120, y: 385, strategy: 'absolute' });
     });
 
     it('clamps the toolbar inside the editor panel', () => {
         const placement = computePinnedAbsolutePlacement({
             ...base,
-            tableRect: rect({ top: 350, bottom: 900, left: 5000 }),
+            tableRect: rect({ top: 350, bottom: 900, left: 5000, width: 300 }),
             pinAbove: true,
         });
 
         expect(placement.x).toBe(600 - 200 - TOOLBAR_VIEWPORT_PADDING_PX);
     });
 
+    it('clamps to the left padding when centring a narrow table would overflow the panel', () => {
+        const placement = computePinnedAbsolutePlacement({
+            ...base,
+            tableRect: rect({ top: 350, bottom: 900, left: 50, width: 60 }),
+            pinAbove: true,
+        });
+
+        expect(placement.x).toBe(TOOLBAR_VIEWPORT_PADDING_PX);
+    });
+
     it('falls back to the padding when the panel is narrower than the toolbar', () => {
         const placement = computePinnedAbsolutePlacement({
             ...base,
             viewRect: rect({ top: 100, left: 50, width: 100, height: 400 }),
-            tableRect: rect({ top: 350, bottom: 900, left: 5000 }),
+            tableRect: rect({ top: 350, bottom: 900, left: 5000, width: 300 }),
             pinAbove: true,
         });
 
@@ -149,34 +220,45 @@ describe('computePinnedFixedPlacement', () => {
         viewportWidth: 400,
     };
 
-    it('uses viewport-relative coordinates when pinning above', () => {
+    it('centres on the table in viewport-relative coordinates when pinning above', () => {
         const placement = computePinnedFixedPlacement({
             ...base,
-            tableRect: rect({ top: 500, bottom: 1200, left: 30 }),
+            tableRect: rect({ top: 500, bottom: 1200, left: 30, width: 340 }),
             pinAbove: true,
         });
 
-        expect(placement).toEqual({ x: 30, y: 5, strategy: 'fixed' });
+        // Table centre is 200, so the 200px toolbar starts at 100.
+        expect(placement).toEqual({ x: 100, y: 5, strategy: 'fixed' });
     });
 
-    it('uses viewport-relative coordinates when pinning below', () => {
+    it('centres on the table in viewport-relative coordinates when pinning below', () => {
         const placement = computePinnedFixedPlacement({
             ...base,
-            tableRect: rect({ top: -500, bottom: 300, left: 30 }),
+            tableRect: rect({ top: -500, bottom: 300, left: 30, width: 340 }),
             pinAbove: false,
         });
 
-        expect(placement).toEqual({ x: 30, y: 765, strategy: 'fixed' });
+        expect(placement).toEqual({ x: 100, y: 765, strategy: 'fixed' });
     });
 
     it('clamps the toolbar inside the viewport width', () => {
         const placement = computePinnedFixedPlacement({
             ...base,
-            tableRect: rect({ top: 500, bottom: 1200, left: 380 }),
+            tableRect: rect({ top: 500, bottom: 1200, left: 380, width: 340 }),
             pinAbove: true,
         });
 
         expect(placement.x).toBe(400 - 200 - TOOLBAR_VIEWPORT_PADDING_PX);
+    });
+
+    it('clamps to the left padding when centring a narrow table would overflow the viewport', () => {
+        const placement = computePinnedFixedPlacement({
+            ...base,
+            tableRect: rect({ top: 500, bottom: 1200, left: -60, width: 120 }),
+            pinAbove: true,
+        });
+
+        expect(placement.x).toBe(TOOLBAR_VIEWPORT_PADDING_PX);
     });
 });
 
@@ -193,14 +275,14 @@ describe('isFinitePoint', () => {
 
 describe('isObscuringTopPlacement', () => {
     it('flags a top placement pushed against the viewport top', () => {
-        expect(isObscuringTopPlacement('top-start', 2)).toBe(true);
+        expect(isObscuringTopPlacement('top', 2)).toBe(true);
     });
 
     it('ignores a top placement with clearance', () => {
-        expect(isObscuringTopPlacement('top-start', 40)).toBe(false);
+        expect(isObscuringTopPlacement('top', 40)).toBe(false);
     });
 
     it('ignores bottom placements', () => {
-        expect(isObscuringTopPlacement('bottom-start', 0)).toBe(false);
+        expect(isObscuringTopPlacement('bottom', 0)).toBe(false);
     });
 });

--- a/src/contentScript/tableWidget/domHelpers.ts
+++ b/src/contentScript/tableWidget/domHelpers.ts
@@ -124,6 +124,18 @@ export function findTableWidgetElement(view: EditorView, tableId: TableId): HTML
 }
 
 /**
+ * Returns the `<table>` a widget root renders its cells into.
+ *
+ * Scoped to a direct child so it never matches a raw HTML table inside a cell's rendered Markdown.
+ *
+ * @param widgetElement - A widget root from `findTableWidgetElement()`.
+ * @returns The widget's own table element, or `null` if the widget has not rendered one.
+ */
+export function findWidgetTableElement(widgetElement: HTMLElement): HTMLElement | null {
+    return widgetElement.querySelector(`:scope > .${CLASS_TABLE_WIDGET_TABLE}`);
+}
+
+/**
  * Helper to locate a specific cell element in the DOM for a given table.
  *
  * @param view - The main EditorView

--- a/src/contentScript/toolbar/tableToolbarPlugin.ts
+++ b/src/contentScript/toolbar/tableToolbarPlugin.ts
@@ -1,10 +1,18 @@
 import { ViewPlugin, ViewUpdate, EditorView } from '@codemirror/view';
 import { activeCellField, type ActiveCell } from '../tableState/activeCellState';
-import { computePosition, autoUpdate, offset, shift, hide, type Middleware } from '@floating-ui/dom';
+import {
+    computePosition,
+    autoUpdate,
+    offset,
+    shift,
+    hide,
+    type Middleware,
+    type VirtualElement,
+} from '@floating-ui/dom';
 import { syncAnnotation } from '../editorBridge/syncAnnotation';
 import { rebuildTableWidgetsEffect } from '../tableState/tableWidgetEffects';
 import { CLASS_FLOATING_TOOLBAR } from '../tableWidget/domHelpers';
-import { findTableWidgetElement } from '../tableWidget/domHelpers';
+import { findTableWidgetElement, findWidgetTableElement } from '../tableWidget/domHelpers';
 import { makeTableId } from '../tableModel/types';
 import { getToolbarButtonGroups, renderToolbarButtonGroups, type ToolbarActionId } from './toolbarLayout';
 import { getDocumentWindow, getViewDocument } from '../shared/domContext';
@@ -13,6 +21,7 @@ import { getResolvedActiveCell } from '../tableRuntime/activeCell/resolvedActive
 import { runStructuralAction } from '../tableRuntime/operations/structuralActions';
 import { hostEditorConfigFacet } from '../services/hostEditorConfig';
 import {
+    clipTableRectToWidget,
     computePinnedAbsolutePlacement,
     computePinnedFixedPlacement,
     isFinitePoint,
@@ -23,6 +32,7 @@ import {
     TOOLBAR_OFFSET_PX,
     TOOLBAR_VIEWPORT_PADDING_PX,
     type ToolbarPlacement,
+    type ToolbarRect,
 } from './toolbarPositioning';
 import {
     getViewportHeight,
@@ -33,7 +43,10 @@ import {
 
 /** Everything resolved once per `autoUpdate` registration and reused by every reposition. */
 interface PositioningContext {
-    referenceElement: HTMLElement;
+    /** The widget's `<table>`; the toolbar centres on it rather than on the full-width widget. */
+    tableElement: HTMLElement;
+    /** The widget root, which clips the table horizontally when the table overflows it. */
+    widgetElement: HTMLElement;
     scrollDOM: HTMLElement;
     doc: Document;
     viewWindow: Window;
@@ -44,7 +57,8 @@ interface PositioningContext {
 /** Measurements taken fresh on every reposition. */
 interface ToolbarGeometry {
     toolbarRect: DOMRect;
-    tableRect: DOMRect;
+    /** The table's visible slice: what the toolbar anchors to in every placement mode. */
+    tableRect: ToolbarRect;
     viewport: ViewportBounds;
 }
 
@@ -242,9 +256,10 @@ export class TableToolbarPlugin {
             return;
         }
 
-        const referenceElement = findTableWidgetElement(this.view, makeTableId(this.currentActiveCell.tableFrom));
+        const widgetElement = findTableWidgetElement(this.view, makeTableId(this.currentActiveCell.tableFrom));
+        const tableElement = widgetElement && findWidgetTableElement(widgetElement);
 
-        if (!referenceElement) {
+        if (!widgetElement || !tableElement) {
             this.cleanupPositioning();
             this.hideToolbar();
             return;
@@ -256,7 +271,8 @@ export class TableToolbarPlugin {
         const scrollDOM = this.view.scrollDOM;
         const doc = getViewDocument(this.view);
         const ctx: PositioningContext = {
-            referenceElement,
+            tableElement,
+            widgetElement,
             scrollDOM,
             doc,
             viewWindow: getDocumentWindow(doc),
@@ -268,8 +284,10 @@ export class TableToolbarPlugin {
             this.cleanupViewportListeners = this.attachViewportListeners();
         }
 
+        // Observing the table (not the widget root) also repositions on horizontal scroll of the
+        // widget's overflow container, keeping the toolbar over the visible slice.
         this.cleanupAutoUpdate = autoUpdate(
-            referenceElement,
+            tableElement,
             this.dom,
             () => {
                 void this.positionToolbar(ctx);
@@ -291,7 +309,7 @@ export class TableToolbarPlugin {
         this.prepareToolbarForPositioning();
 
         // Check if reference element is still in the DOM
-        if (!ctx.referenceElement.isConnected) {
+        if (!ctx.tableElement.isConnected) {
             // Don't cleanup here - just hide and let the next update() call handle cleanup
             this.hideToolbar();
             return;
@@ -307,7 +325,7 @@ export class TableToolbarPlugin {
         const placement =
             mode === 'pinned'
                 ? this.resolvePinnedPlacement(ctx, geometry)
-                : await this.resolveAnchoredPlacement(ctx, mode);
+                : await this.resolveAnchoredPlacement(ctx, geometry, mode);
 
         if (!placement) {
             this.hideToolbar();
@@ -321,7 +339,10 @@ export class TableToolbarPlugin {
     private readGeometry(ctx: PositioningContext): ToolbarGeometry {
         return {
             toolbarRect: this.dom.getBoundingClientRect(),
-            tableRect: ctx.referenceElement.getBoundingClientRect(),
+            tableRect: clipTableRectToWidget(
+                ctx.tableElement.getBoundingClientRect(),
+                ctx.widgetElement.getBoundingClientRect()
+            ),
             viewport: resolveViewportBounds(ctx.scrollDOM.getBoundingClientRect(), getViewportHeight(ctx.viewWindow)),
         };
     }
@@ -332,10 +353,12 @@ export class TableToolbarPlugin {
      */
     private async resolveAnchoredPlacement(
         ctx: PositioningContext,
-        mode: 'top-start' | 'bottom-start'
+        geometry: ToolbarGeometry,
+        mode: 'top' | 'bottom'
     ): Promise<ToolbarPlacement | null> {
+        const anchor = createVirtualAnchor(ctx.tableElement, geometry.tableRect);
         const middleware = createPositioningMiddleware();
-        const result = await computePosition(ctx.referenceElement, this.dom, { placement: mode, middleware });
+        const result = await computePosition(anchor, this.dom, { placement: mode, middleware });
 
         if (result.middlewareData.hide?.referenceHidden) {
             return null;
@@ -347,8 +370,8 @@ export class TableToolbarPlugin {
         }
 
         if (isObscuringTopPlacement(result.placement, result.y)) {
-            const fallback = await computePosition(ctx.referenceElement, this.dom, {
-                placement: 'bottom-start',
+            const fallback = await computePosition(anchor, this.dom, {
+                placement: 'bottom',
                 middleware,
             });
             if (!fallback.middlewareData.hide?.referenceHidden) {
@@ -412,6 +435,20 @@ export class TableToolbarPlugin {
             viewWindow.visualViewport?.removeEventListener('resize', handler);
         };
     }
+}
+
+/**
+ * Anchors Floating UI to the table's visible slice rather than to an element rect. `contextElement`
+ * keeps Floating UI's clipping-boundary and offset-parent resolution behaving as it would for a
+ * real element reference, so `shift`/`hide` still respect the widget's overflow container.
+ */
+function createVirtualAnchor(contextElement: HTMLElement, rect: ToolbarRect): VirtualElement {
+    const { top, bottom, left, width, height } = rect;
+
+    return {
+        contextElement,
+        getBoundingClientRect: () => ({ x: left, y: top, top, bottom, left, right: left + width, width, height }),
+    };
 }
 
 function createPositioningMiddleware(): Middleware[] {

--- a/src/contentScript/toolbar/tableToolbarPlugin.ts
+++ b/src/contentScript/toolbar/tableToolbarPlugin.ts
@@ -21,12 +21,12 @@ import { getResolvedActiveCell } from '../tableRuntime/activeCell/resolvedActive
 import { runStructuralAction } from '../tableRuntime/operations/structuralActions';
 import { hostEditorConfigFacet } from '../services/hostEditorConfig';
 import {
-    clipTableRectToWidget,
     computePinnedAbsolutePlacement,
     computePinnedFixedPlacement,
     isFinitePoint,
     isObscuringTopPlacement,
     isTableOutsideViewport,
+    resolveToolbarAnchorRect,
     resolveToolbarPlacementMode,
     shouldPinAbove,
     TOOLBAR_OFFSET_PX,
@@ -45,7 +45,7 @@ import {
 interface PositioningContext {
     /** The widget's `<table>`; the toolbar centres on it rather than on the full-width widget. */
     tableElement: HTMLElement;
-    /** The widget root, which clips the table horizontally when the table overflows it. */
+    /** The widget root: it clips the table horizontally, and owns the vertical bounds. */
     widgetElement: HTMLElement;
     scrollDOM: HTMLElement;
     doc: Document;
@@ -57,8 +57,8 @@ interface PositioningContext {
 /** Measurements taken fresh on every reposition. */
 interface ToolbarGeometry {
     toolbarRect: DOMRect;
-    /** The table's visible slice: what the toolbar anchors to in every placement mode. */
-    tableRect: ToolbarRect;
+    /** The box the toolbar anchors to in every placement mode. */
+    anchorRect: ToolbarRect;
     viewport: ViewportBounds;
 }
 
@@ -316,12 +316,12 @@ export class TableToolbarPlugin {
         }
 
         const geometry = this.readGeometry(ctx);
-        if (isTableOutsideViewport(geometry.tableRect, geometry.viewport)) {
+        if (isTableOutsideViewport(geometry.anchorRect, geometry.viewport)) {
             this.hideToolbar();
             return;
         }
 
-        const mode = resolveToolbarPlacementMode(geometry.tableRect, geometry.toolbarRect.height, geometry.viewport);
+        const mode = resolveToolbarPlacementMode(geometry.anchorRect, geometry.toolbarRect.height, geometry.viewport);
         const placement =
             mode === 'pinned'
                 ? this.resolvePinnedPlacement(ctx, geometry)
@@ -339,7 +339,7 @@ export class TableToolbarPlugin {
     private readGeometry(ctx: PositioningContext): ToolbarGeometry {
         return {
             toolbarRect: this.dom.getBoundingClientRect(),
-            tableRect: clipTableRectToWidget(
+            anchorRect: resolveToolbarAnchorRect(
                 ctx.tableElement.getBoundingClientRect(),
                 ctx.widgetElement.getBoundingClientRect()
             ),
@@ -356,7 +356,7 @@ export class TableToolbarPlugin {
         geometry: ToolbarGeometry,
         mode: 'top' | 'bottom'
     ): Promise<ToolbarPlacement | null> {
-        const anchor = createVirtualAnchor(ctx.tableElement, geometry.tableRect);
+        const anchor = createVirtualAnchor(ctx.tableElement, geometry.anchorRect);
         const middleware = createPositioningMiddleware();
         const result = await computePosition(anchor, this.dom, { placement: mode, middleware });
 
@@ -384,12 +384,12 @@ export class TableToolbarPlugin {
 
     /** Pinned mode: toolbar sticks to the viewport edge when the table top/bottom is out of view. */
     private resolvePinnedPlacement(ctx: PositioningContext, geometry: ToolbarGeometry): ToolbarPlacement | null {
-        const { tableRect, toolbarRect, viewport } = geometry;
-        const pinAbove = shouldPinAbove(tableRect, viewport);
+        const { anchorRect, toolbarRect, viewport } = geometry;
+        const pinAbove = shouldPinAbove(anchorRect, viewport);
 
         const placement = ctx.isInternalScroll
             ? computePinnedAbsolutePlacement({
-                  tableRect,
+                  anchorRect,
                   toolbarRect,
                   viewport,
                   viewRect: this.view.dom.getBoundingClientRect(),
@@ -397,7 +397,7 @@ export class TableToolbarPlugin {
                   pinAbove,
               })
             : computePinnedFixedPlacement({
-                  tableRect,
+                  anchorRect,
                   toolbarRect,
                   viewport,
                   viewportWidth: getViewportWidth(ctx.viewWindow),

--- a/src/contentScript/toolbar/toolbarPositioning.ts
+++ b/src/contentScript/toolbar/toolbarPositioning.ts
@@ -31,29 +31,34 @@ export interface ToolbarPlacement extends ToolbarPoint {
 export type ToolbarPlacementMode = 'top' | 'bottom' | 'pinned';
 
 /**
- * Clips the table horizontally to its widget container, which scrolls the table when it is wider
- * than the editor. Anchoring to this slice centres the toolbar over the part of the table that is
- * actually on screen, rather than over an off-screen midpoint.
+ * The box the toolbar anchors to, combining both elements the widget is made of:
+ *
+ * - Horizontally, the table clipped to the widget root, which scrolls the table when it is wider
+ *   than the editor. Centring on that slice keeps the toolbar over the part of the table that is
+ *   actually on screen instead of over an off-screen midpoint.
+ * - Vertically, the widget root, whose border box also covers the horizontal scrollbar the root
+ *   renders when the table overflows. Anchoring to the table itself would sit the toolbar on top
+ *   of that scrollbar, at whatever width the host theme gives it.
  */
-export function clipTableRectToWidget(tableRect: ToolbarRect, widgetRect: ToolbarRect): ToolbarRect {
+export function resolveToolbarAnchorRect(tableRect: ToolbarRect, widgetRect: ToolbarRect): ToolbarRect {
     const left = Math.max(tableRect.left, widgetRect.left);
     const right = Math.min(tableRect.left + tableRect.width, widgetRect.left + widgetRect.width);
 
     // Built field by field, not spread: callers pass a `DOMRect`, whose properties live on the
-    // prototype, so spreading one would silently drop every vertical bound.
+    // prototype, so spreading one would silently drop every bound it is meant to carry.
     return {
-        top: tableRect.top,
-        bottom: tableRect.bottom,
-        height: tableRect.height,
+        top: widgetRect.top,
+        bottom: widgetRect.bottom,
+        height: widgetRect.height,
         left,
         width: Math.max(0, right - left),
     };
 }
 
 /** True when the table has scrolled entirely past either viewport edge. */
-export function isTableOutsideViewport(tableRect: ToolbarRect, viewport: ViewportBounds): boolean {
-    const tableAboveViewport = tableRect.bottom <= viewport.top;
-    const tableBelowViewport = tableRect.top >= viewport.bottom;
+export function isTableOutsideViewport(anchorRect: ToolbarRect, viewport: ViewportBounds): boolean {
+    const tableAboveViewport = anchorRect.bottom <= viewport.top;
+    const tableBelowViewport = anchorRect.top >= viewport.bottom;
 
     return tableAboveViewport || tableBelowViewport;
 }
@@ -63,20 +68,20 @@ export function isTableOutsideViewport(tableRect: ToolbarRect, viewport: Viewpor
  * table edge is both visible and has room for the toolbar.
  */
 export function resolveToolbarPlacementMode(
-    tableRect: ToolbarRect,
+    anchorRect: ToolbarRect,
     toolbarHeight: number,
     viewport: ViewportBounds
 ): ToolbarPlacementMode {
-    const topVisible = tableRect.top >= viewport.top && tableRect.top <= viewport.bottom;
+    const topVisible = anchorRect.top >= viewport.top && anchorRect.top <= viewport.bottom;
     const hasRoomAbove =
-        tableRect.top - toolbarHeight - TOOLBAR_OFFSET_PX >= viewport.top + TOOLBAR_VIEWPORT_PADDING_PX;
+        anchorRect.top - toolbarHeight - TOOLBAR_OFFSET_PX >= viewport.top + TOOLBAR_VIEWPORT_PADDING_PX;
     if (topVisible && hasRoomAbove) {
         return 'top';
     }
 
-    const bottomVisible = tableRect.bottom >= viewport.top && tableRect.bottom <= viewport.bottom;
+    const bottomVisible = anchorRect.bottom >= viewport.top && anchorRect.bottom <= viewport.bottom;
     const hasRoomBelow =
-        viewport.bottom - tableRect.bottom - toolbarHeight - TOOLBAR_OFFSET_PX >= TOOLBAR_VIEWPORT_PADDING_PX;
+        viewport.bottom - anchorRect.bottom - toolbarHeight - TOOLBAR_OFFSET_PX >= TOOLBAR_VIEWPORT_PADDING_PX;
     if (bottomVisible && hasRoomBelow) {
         return 'bottom';
     }
@@ -85,8 +90,8 @@ export function resolveToolbarPlacementMode(
 }
 
 /** Pins to whichever viewport edge the table's midpoint has scrolled away from. */
-export function shouldPinAbove(tableRect: ToolbarRect, viewport: ViewportBounds): boolean {
-    return (tableRect.top + tableRect.bottom) / 2 > viewport.top + viewport.height / 2;
+export function shouldPinAbove(anchorRect: ToolbarRect, viewport: ViewportBounds): boolean {
+    return (anchorRect.top + anchorRect.bottom) / 2 > viewport.top + viewport.height / 2;
 }
 
 /**
@@ -94,15 +99,15 @@ export function shouldPinAbove(tableRect: ToolbarRect, viewport: ViewportBounds)
  * clamped so the toolbar stays inside `containerWidth`.
  */
 function computeCenteredX(params: {
-    tableRect: ToolbarRect;
+    anchorRect: ToolbarRect;
     toolbarWidth: number;
     containerLeft: number;
     containerWidth: number;
 }): number {
-    const { tableRect, toolbarWidth, containerLeft, containerWidth } = params;
+    const { anchorRect, toolbarWidth, containerLeft, containerWidth } = params;
 
     const maxX = Math.max(TOOLBAR_VIEWPORT_PADDING_PX, containerWidth - toolbarWidth - TOOLBAR_VIEWPORT_PADDING_PX);
-    const centeredX = tableRect.left - containerLeft + tableRect.width / 2 - toolbarWidth / 2;
+    const centeredX = anchorRect.left - containerLeft + anchorRect.width / 2 - toolbarWidth / 2;
 
     return clamp(centeredX, TOOLBAR_VIEWPORT_PADDING_PX, maxX);
 }
@@ -112,17 +117,17 @@ function computeCenteredX(params: {
  * offset parent, kept within the editor panel bounds.
  */
 export function computePinnedAbsolutePlacement(params: {
-    tableRect: ToolbarRect;
+    anchorRect: ToolbarRect;
     toolbarRect: ToolbarRect;
     viewport: ViewportBounds;
     viewRect: ToolbarRect;
     offsetParentTop: number;
     pinAbove: boolean;
 }): ToolbarPlacement {
-    const { tableRect, toolbarRect, viewport, viewRect, offsetParentTop, pinAbove } = params;
+    const { anchorRect, toolbarRect, viewport, viewRect, offsetParentTop, pinAbove } = params;
 
     const x = computeCenteredX({
-        tableRect,
+        anchorRect,
         toolbarWidth: toolbarRect.width,
         containerLeft: viewRect.left,
         containerWidth: viewRect.width,
@@ -141,16 +146,16 @@ export function computePinnedAbsolutePlacement(params: {
  * The mobile editor disables pinch-zoom (maximum-scale=1), so the page offset is always 0.
  */
 export function computePinnedFixedPlacement(params: {
-    tableRect: ToolbarRect;
+    anchorRect: ToolbarRect;
     toolbarRect: ToolbarRect;
     viewport: ViewportBounds;
     viewportWidth: number;
     pinAbove: boolean;
 }): ToolbarPlacement {
-    const { tableRect, toolbarRect, viewport, viewportWidth, pinAbove } = params;
+    const { anchorRect, toolbarRect, viewport, viewportWidth, pinAbove } = params;
 
     const x = computeCenteredX({
-        tableRect,
+        anchorRect,
         toolbarWidth: toolbarRect.width,
         containerLeft: 0,
         containerWidth: viewportWidth,

--- a/src/contentScript/toolbar/toolbarPositioning.ts
+++ b/src/contentScript/toolbar/toolbarPositioning.ts
@@ -28,7 +28,27 @@ export interface ToolbarPlacement extends ToolbarPoint {
  * Anchored placements are handed to Floating UI; `pinned` means the table edge we would
  * anchor to is off-screen, so the toolbar sticks to the viewport edge instead.
  */
-export type ToolbarPlacementMode = 'top-start' | 'bottom-start' | 'pinned';
+export type ToolbarPlacementMode = 'top' | 'bottom' | 'pinned';
+
+/**
+ * Clips the table horizontally to its widget container, which scrolls the table when it is wider
+ * than the editor. Anchoring to this slice centres the toolbar over the part of the table that is
+ * actually on screen, rather than over an off-screen midpoint.
+ */
+export function clipTableRectToWidget(tableRect: ToolbarRect, widgetRect: ToolbarRect): ToolbarRect {
+    const left = Math.max(tableRect.left, widgetRect.left);
+    const right = Math.min(tableRect.left + tableRect.width, widgetRect.left + widgetRect.width);
+
+    // Built field by field, not spread: callers pass a `DOMRect`, whose properties live on the
+    // prototype, so spreading one would silently drop every vertical bound.
+    return {
+        top: tableRect.top,
+        bottom: tableRect.bottom,
+        height: tableRect.height,
+        left,
+        width: Math.max(0, right - left),
+    };
+}
 
 /** True when the table has scrolled entirely past either viewport edge. */
 export function isTableOutsideViewport(tableRect: ToolbarRect, viewport: ViewportBounds): boolean {
@@ -51,14 +71,14 @@ export function resolveToolbarPlacementMode(
     const hasRoomAbove =
         tableRect.top - toolbarHeight - TOOLBAR_OFFSET_PX >= viewport.top + TOOLBAR_VIEWPORT_PADDING_PX;
     if (topVisible && hasRoomAbove) {
-        return 'top-start';
+        return 'top';
     }
 
     const bottomVisible = tableRect.bottom >= viewport.top && tableRect.bottom <= viewport.bottom;
     const hasRoomBelow =
         viewport.bottom - tableRect.bottom - toolbarHeight - TOOLBAR_OFFSET_PX >= TOOLBAR_VIEWPORT_PADDING_PX;
     if (bottomVisible && hasRoomBelow) {
-        return 'bottom-start';
+        return 'bottom';
     }
 
     return 'pinned';
@@ -67,6 +87,24 @@ export function resolveToolbarPlacementMode(
 /** Pins to whichever viewport edge the table's midpoint has scrolled away from. */
 export function shouldPinAbove(tableRect: ToolbarRect, viewport: ViewportBounds): boolean {
     return (tableRect.top + tableRect.bottom) / 2 > viewport.top + viewport.height / 2;
+}
+
+/**
+ * Centres the toolbar on the table horizontally, in coordinates relative to `containerLeft`,
+ * clamped so the toolbar stays inside `containerWidth`.
+ */
+function computeCenteredX(params: {
+    tableRect: ToolbarRect;
+    toolbarWidth: number;
+    containerLeft: number;
+    containerWidth: number;
+}): number {
+    const { tableRect, toolbarWidth, containerLeft, containerWidth } = params;
+
+    const maxX = Math.max(TOOLBAR_VIEWPORT_PADDING_PX, containerWidth - toolbarWidth - TOOLBAR_VIEWPORT_PADDING_PX);
+    const centeredX = tableRect.left - containerLeft + tableRect.width / 2 - toolbarWidth / 2;
+
+    return clamp(centeredX, TOOLBAR_VIEWPORT_PADDING_PX, maxX);
 }
 
 /**
@@ -83,11 +121,12 @@ export function computePinnedAbsolutePlacement(params: {
 }): ToolbarPlacement {
     const { tableRect, toolbarRect, viewport, viewRect, offsetParentTop, pinAbove } = params;
 
-    const maxX = Math.max(
-        TOOLBAR_VIEWPORT_PADDING_PX,
-        viewRect.width - toolbarRect.width - TOOLBAR_VIEWPORT_PADDING_PX
-    );
-    const x = clamp(tableRect.left - viewRect.left, TOOLBAR_VIEWPORT_PADDING_PX, maxX);
+    const x = computeCenteredX({
+        tableRect,
+        toolbarWidth: toolbarRect.width,
+        containerLeft: viewRect.left,
+        containerWidth: viewRect.width,
+    });
 
     const topInParent = viewport.top - offsetParentTop + TOOLBAR_VIEWPORT_PADDING_PX;
     const bottomInParent = viewport.bottom - offsetParentTop - toolbarRect.height - TOOLBAR_VIEWPORT_PADDING_PX;
@@ -110,8 +149,12 @@ export function computePinnedFixedPlacement(params: {
 }): ToolbarPlacement {
     const { tableRect, toolbarRect, viewport, viewportWidth, pinAbove } = params;
 
-    const maxX = Math.max(TOOLBAR_VIEWPORT_PADDING_PX, viewportWidth - toolbarRect.width - TOOLBAR_VIEWPORT_PADDING_PX);
-    const x = clamp(tableRect.left, TOOLBAR_VIEWPORT_PADDING_PX, maxX);
+    const x = computeCenteredX({
+        tableRect,
+        toolbarWidth: toolbarRect.width,
+        containerLeft: 0,
+        containerWidth: viewportWidth,
+    });
 
     const y = pinAbove
         ? viewport.top + TOOLBAR_VIEWPORT_PADDING_PX


### PR DESCRIPTION
Center the floating toolbar for better alignment with the table. Address a regression that caused the toolbar to overlap the table's horizontal scrollbar.