### PR TITLE
feat: tile clipboard fragments to selection

### DIFF
--- a/docs/Architecture/Interaction-and-Navigation.md
+++ b/docs/Architecture/Interaction-and-Navigation.md
@@ -70,6 +70,9 @@ covers the region actually written, so a rectangle that was not an exact fit sho
 than the rectangle still pastes one complete copy and may expand the table. An open nested editor owns its own cell and
 always pastes anchored there.
 
+Clipboard text that is not a table fills the selection as a single cell value, with line breaks and pipes sanitized so
+they cannot break the row.
+
 Mouse dragging can also create a rectangular selection. Drag ownership and deferred active-cell updates are described
 in [Table-Runtime-Invariants.md](./Table-Runtime-Invariants.md#cell-drag-ownership).
 

--- a/docs/Architecture/Interaction-and-Navigation.md
+++ b/docs/Architecture/Interaction-and-Navigation.md
@@ -63,6 +63,13 @@ keyboard, clipboard, and history commands while this mode is active.
 - **Copy/Cut/Paste** operates on the rectangle and may expand the table.
 - **Undo/Redo** uses main-editor history.
 
+Paste sizes itself to the selection: `tableModel/clipboardFragmentTiling.ts` repeats the clipboard fragment across the
+rectangle from its top-left, writing only whole repetitions. A single copied cell therefore fills the rectangle, and a
+2x2 fragment covers 4x4 of a 5x5 rectangle, leaving the trailing row and column untouched. The post-paste selection
+covers the region actually written, so a rectangle that was not an exact fit shows the shortfall. A fragment larger
+than the rectangle still pastes one complete copy and may expand the table. An open nested editor owns its own cell and
+always pastes anchored there.
+
 Mouse dragging can also create a rectangular selection. Drag ownership and deferred active-cell updates are described
 in [Table-Runtime-Invariants.md](./Table-Runtime-Invariants.md#cell-drag-ownership).
 

--- a/src/contentScript/__tests__/cellSelectionClipboard.test.ts
+++ b/src/contentScript/__tests__/cellSelectionClipboard.test.ts
@@ -569,10 +569,7 @@ describe('cellSelectionClipboard', () => {
         );
     });
 
-    it.each([
-        ['blank text', '   \n  '],
-        ['tab-separated spreadsheet text', 'a\tb\nc\td'],
-    ])('declines %s so the selection keeps its content', (_label, clipboardText) => {
+    it('declines blank text so the selection keeps its content', () => {
         let state = createMarkdownState(doc, [cellSelectionField]);
         state = state.update({
             effects: setCellSelectionEffect.of(
@@ -582,7 +579,7 @@ describe('cellSelectionClipboard', () => {
 
         const target = resolveTableClipboardTarget(state, { nestedEditorOpen: false });
 
-        expect(buildMultiCellPasteRewrite(state, target!, clipboardText)).toBeNull();
+        expect(buildMultiCellPasteRewrite(state, target!, '   \n  ')).toBeNull();
     });
 
     it('handles nested-editor paste through the main capture path', () => {

--- a/src/contentScript/__tests__/cellSelectionClipboard.test.ts
+++ b/src/contentScript/__tests__/cellSelectionClipboard.test.ts
@@ -513,16 +513,76 @@ describe('cellSelectionClipboard', () => {
         expect(rewrite?.clearActiveCell).toBe(true);
     });
 
-    it('returns null for invalid clipboard markdown', () => {
+    it('leaves plain clipboard text to the nested editor when an active cell owns the paste', () => {
         const state = createMarkdownState(doc);
         const target = {
             tableFrom: 0,
             anchor: { section: 'body', row: 0, col: 1 } as const,
-            source: 'selection' as const,
-            rect: { minRow: 1, maxRow: 1, minCol: 1, maxCol: 1 },
+            source: 'activeCell' as const,
         };
 
         expect(buildMultiCellPasteRewrite(state, target, 'plain text')).toBeNull();
+    });
+
+    it('fills the selection with clipboard text that is not a table', () => {
+        let state = createMarkdownState(doc, [cellSelectionField]);
+        state = state.update({
+            effects: setCellSelectionEffect.of(
+                selection({ section: 'body', row: 0, col: 1 }, { section: 'body', row: 1, col: 2 })
+            ),
+        }).state;
+
+        const target = resolveTableClipboardTarget(state, { nestedEditorOpen: false });
+        const rewrite = buildMultiCellPasteRewrite(state, target!, 'plain text');
+
+        expect(rewrite?.tableText).toBe(
+            [
+                String.raw`| H\|1 | H2 | H3 |`,
+                '| :--- | ---: | --- |',
+                '| a | plain text | plain text |',
+                '| x | plain text | plain text |',
+            ].join('\n')
+        );
+        expect(rewrite?.selection).toEqual(
+            selection({ section: 'body', row: 0, col: 1 }, { section: 'body', row: 1, col: 2 })
+        );
+    });
+
+    it('sanitizes line breaks and pipes out of filled clipboard text', () => {
+        let state = createMarkdownState(doc, [cellSelectionField]);
+        state = state.update({
+            effects: setCellSelectionEffect.of(
+                selection({ section: 'body', row: 0, col: 1 }, { section: 'body', row: 0, col: 1 })
+            ),
+        }).state;
+
+        const target = resolveTableClipboardTarget(state, { nestedEditorOpen: false });
+        const rewrite = buildMultiCellPasteRewrite(state, target!, 'one\ntwo|three');
+
+        expect(rewrite?.tableText).toBe(
+            [
+                String.raw`| H\|1 | H2 | H3 |`,
+                '| :--- | ---: | --- |',
+                String.raw`| a | one<br>two\|three |  |`,
+                '| x | <br> | z |',
+            ].join('\n')
+        );
+    });
+
+    it.each([
+        ['blank text', '   \n  '],
+        ['tab-separated spreadsheet text', 'a\tb\nc\td'],
+    ])('declines %s so the selection keeps its content', (_label, clipboardText) => {
+        let state = createMarkdownState(doc, [cellSelectionField]);
+        state = state.update({
+            effects: setCellSelectionEffect.of(
+                selection({ section: 'body', row: 0, col: 1 }, { section: 'body', row: 1, col: 2 })
+            ),
+        }).state;
+
+        const target = resolveTableClipboardTarget(state, { nestedEditorOpen: false });
+
+        expect(buildMultiCellPasteRewrite(state, target!, clipboardText)).toBeNull();
     });
 
     it('handles nested-editor paste through the main capture path', () => {

--- a/src/contentScript/__tests__/cellSelectionClipboard.test.ts
+++ b/src/contentScript/__tests__/cellSelectionClipboard.test.ts
@@ -152,6 +152,7 @@ describe('cellSelectionClipboard', () => {
             tableFrom: 0,
             anchor: { section: 'header', row: 0, col: 1 },
             source: 'selection',
+            rect: { minRow: 0, maxRow: 2, minCol: 1, maxCol: 2 },
         });
     });
 
@@ -225,6 +226,7 @@ describe('cellSelectionClipboard', () => {
             tableFrom: 0,
             anchor: { section: 'body', row: 0, col: 1 },
             source: 'selection',
+            rect: { minRow: 1, maxRow: 2, minCol: 1, maxCol: 2 },
         });
     });
 
@@ -383,7 +385,9 @@ describe('cellSelectionClipboard', () => {
         );
     });
 
-    it('builds a paste rewrite from the selection top-left even when the pasted range is smaller', () => {
+    it('covers the whole repetitions that fit and reports the shortfall through the selection', () => {
+        // A 2x1 fragment over a 3x2 selection: two copies across, one down, so the
+        // selection's last row keeps its original content.
         let state = createMarkdownState(doc, [cellSelectionField]);
         state = state.update({
             effects: setCellSelectionEffect.of(
@@ -396,12 +400,83 @@ describe('cellSelectionClipboard', () => {
 
         expect(rewrite).not.toBeNull();
         expect(rewrite?.tableText).toBe(
-            [String.raw`| H\|1 | P1 | H3 |`, '| :--- | ---: | --- |', '| a | Q1 |  |', '| x | <br> | z |'].join('\n')
+            [String.raw`| H\|1 | P1 | P1 |`, '| :--- | ---: | --- |', '| a | Q1 | Q1 |', '| x | <br> | z |'].join('\n')
         );
         expect(rewrite?.selection).toEqual(
-            selection({ section: 'header', row: 0, col: 1 }, { section: 'body', row: 0, col: 1 })
+            selection({ section: 'header', row: 0, col: 1 }, { section: 'body', row: 0, col: 2 })
         );
         expect(rewrite?.clearActiveCell).toBe(false);
+    });
+
+    it('fills the whole selection when a single copied cell is pasted over it', () => {
+        let state = createMarkdownState(doc, [cellSelectionField]);
+        state = state.update({
+            effects: setCellSelectionEffect.of(
+                selection({ section: 'body', row: 0, col: 1 }, { section: 'body', row: 1, col: 2 })
+            ),
+        }).state;
+
+        const target = resolveTableClipboardTarget(state, { nestedEditorOpen: false });
+        const rewrite = buildMultiCellPasteRewrite(state, target!, ['| P1 |', '| --- |'].join('\n'));
+
+        expect(rewrite?.tableText).toBe(
+            [String.raw`| H\|1 | H2 | H3 |`, '| :--- | ---: | --- |', '| a | P1 | P1 |', '| x | P1 | P1 |'].join('\n')
+        );
+        expect(rewrite?.selection).toEqual(
+            selection({ section: 'body', row: 0, col: 1 }, { section: 'body', row: 1, col: 2 })
+        );
+    });
+
+    it('tiles a fragment across a selection that is an exact multiple of it', () => {
+        let state = createMarkdownState(doc, [cellSelectionField]);
+        state = state.update({
+            effects: setCellSelectionEffect.of(
+                selection({ section: 'body', row: 0, col: 1 }, { section: 'body', row: 1, col: 2 })
+            ),
+        }).state;
+
+        const target = resolveTableClipboardTarget(state, { nestedEditorOpen: false });
+        const rewrite = buildMultiCellPasteRewrite(state, target!, ['| P1 | P2 |', '| --- | --- |'].join('\n'));
+
+        expect(rewrite?.tableText).toBe(
+            [String.raw`| H\|1 | H2 | H3 |`, '| :--- | ---: | --- |', '| a | P1 | P2 |', '| x | P1 | P2 |'].join('\n')
+        );
+    });
+
+    it('leaves table alignments untouched when tiling into existing columns', () => {
+        let state = createMarkdownState(doc, [cellSelectionField]);
+        state = state.update({
+            effects: setCellSelectionEffect.of(
+                selection({ section: 'header', row: 0, col: 1 }, { section: 'body', row: 1, col: 1 })
+            ),
+        }).state;
+
+        const target = resolveTableClipboardTarget(state, { nestedEditorOpen: false });
+        const rewrite = buildMultiCellPasteRewrite(state, target!, ['| P1 |', '| :---: |'].join('\n'));
+
+        expect(rewrite?.tableText).toBe(
+            [String.raw`| H\|1 | P1 | H3 |`, '| :--- | ---: | --- |', '| a | P1 |  |', '| x | P1 | z |'].join('\n')
+        );
+    });
+
+    it('does not tile into a selection when a nested editor owns the paste', () => {
+        let state = createMarkdownState(doc, [activeCellField, cellSelectionField]);
+        state = state.update({
+            effects: setActiveCellEffect.of({
+                tableFrom: 0,
+                section: 'body',
+                row: 0,
+                col: 1,
+            }),
+        }).state;
+
+        const target = resolveTableClipboardTarget(state, { nestedEditorOpen: true });
+        const rewrite = buildMultiCellPasteRewrite(state, target!, ['| P1 |', '| --- |'].join('\n'));
+
+        expect(target?.source).toBe('activeCell');
+        expect(rewrite?.tableText).toBe(
+            [String.raw`| H\|1 | H2 | H3 |`, '| :--- | ---: | --- |', '| a | P1 |  |', '| x | <br> | z |'].join('\n')
+        );
     });
 
     it('builds an expanding paste rewrite from the active nested-editor cell', () => {
@@ -444,6 +519,7 @@ describe('cellSelectionClipboard', () => {
             tableFrom: 0,
             anchor: { section: 'body', row: 0, col: 1 } as const,
             source: 'selection' as const,
+            rect: { minRow: 1, maxRow: 1, minCol: 1, maxCol: 1 },
         };
 
         expect(buildMultiCellPasteRewrite(state, target, 'plain text')).toBeNull();

--- a/src/contentScript/__tests__/cellTextCodec.test.ts
+++ b/src/contentScript/__tests__/cellTextCodec.test.ts
@@ -4,12 +4,11 @@ import {
     convertNewlinesToBr,
     escapeUnescapedPipes,
     sanitizeCellChanges,
-    sanitizeLocalText,
     toLocalSelection,
     toRootSelection,
     unsanitizeRootText,
 } from '../editorBridge/cellTextCodec';
-import { normalizeBrTags } from '../shared/cellTextNormalization';
+import { normalizeBrTags, sanitizeLocalText } from '../shared/cellTextNormalization';
 import { MarkdownTable } from '../tableModel/MarkdownTable';
 
 describe('escapeUnescapedPipes', () => {

--- a/src/contentScript/__tests__/clipboardFragmentTiling.test.ts
+++ b/src/contentScript/__tests__/clipboardFragmentTiling.test.ts
@@ -60,6 +60,12 @@ describe('tileFragmentToRect', () => {
         expect(result.alignments).toEqual(['left', 'right', 'left', 'right']);
     });
 
+    it('treats missing source alignments as null when tiling', () => {
+        const result = tileFragmentToRect(fragment([['A', 'B']], ['left']), rect(1, 4));
+
+        expect(result.alignments).toEqual(['left', null, 'left', null]);
+    });
+
     it('covers only the whole repetitions that fit when the rectangle is not an exact multiple', () => {
         const result = tileFragmentToRect(
             fragment([

--- a/src/contentScript/__tests__/clipboardFragmentTiling.test.ts
+++ b/src/contentScript/__tests__/clipboardFragmentTiling.test.ts
@@ -1,0 +1,107 @@
+import { tileFragmentToRect } from '../tableModel/clipboardFragmentTiling';
+import type { ClipboardTableFragment, TableAlignment } from '../tableModel/MarkdownTable';
+import type { TableRect } from '../tableModel/types';
+
+function fragment(cells: string[][], alignments?: TableAlignment[]): ClipboardTableFragment {
+    return {
+        cells,
+        alignments: alignments ?? new Array<TableAlignment>(cells[0]?.length ?? 0).fill(null),
+    };
+}
+
+/** A rectangle of the given size, offset so the tiling never depends on it starting at 0. */
+function rect(rowCount: number, colCount: number): TableRect {
+    const minRow = 1;
+    const minCol = 2;
+
+    return { minRow, maxRow: minRow + rowCount - 1, minCol, maxCol: minCol + colCount - 1 };
+}
+
+describe('tileFragmentToRect', () => {
+    it('fills the whole rectangle from a single cell', () => {
+        const result = tileFragmentToRect(fragment([['A']]), rect(2, 3));
+
+        expect(result.cells).toEqual([
+            ['A', 'A', 'A'],
+            ['A', 'A', 'A'],
+        ]);
+    });
+
+    it('repeats a fragment that divides the rectangle evenly on both axes', () => {
+        const result = tileFragmentToRect(
+            fragment([
+                ['A', 'B'],
+                ['C', 'D'],
+            ]),
+            rect(4, 4)
+        );
+
+        expect(result.cells).toEqual([
+            ['A', 'B', 'A', 'B'],
+            ['C', 'D', 'C', 'D'],
+            ['A', 'B', 'A', 'B'],
+            ['C', 'D', 'C', 'D'],
+        ]);
+    });
+
+    it('repeats along one axis when the other already matches', () => {
+        const result = tileFragmentToRect(fragment([['A', 'B']]), rect(3, 2));
+
+        expect(result.cells).toEqual([
+            ['A', 'B'],
+            ['A', 'B'],
+            ['A', 'B'],
+        ]);
+    });
+
+    it('tiles the alignments alongside the cells', () => {
+        const result = tileFragmentToRect(fragment([['A', 'B']], ['left', 'right']), rect(1, 4));
+
+        expect(result.alignments).toEqual(['left', 'right', 'left', 'right']);
+    });
+
+    it('covers only the whole repetitions that fit when the rectangle is not an exact multiple', () => {
+        const result = tileFragmentToRect(
+            fragment([
+                ['A', 'B'],
+                ['C', 'D'],
+            ]),
+            rect(5, 5)
+        );
+
+        expect(result.cells).toEqual([
+            ['A', 'B', 'A', 'B'],
+            ['C', 'D', 'C', 'D'],
+            ['A', 'B', 'A', 'B'],
+            ['C', 'D', 'C', 'D'],
+        ]);
+    });
+
+    it('repeats an axis that fits while overflowing one that does not', () => {
+        const result = tileFragmentToRect(fragment([['A'], ['B'], ['C']]), rect(2, 4));
+
+        expect(result.cells).toEqual([
+            ['A', 'A', 'A', 'A'],
+            ['B', 'B', 'B', 'B'],
+            ['C', 'C', 'C', 'C'],
+        ]);
+    });
+
+    it('leaves the fragment alone when only a single copy fits', () => {
+        const source = fragment([
+            ['A', 'B'],
+            ['C', 'D'],
+        ]);
+
+        expect(tileFragmentToRect(source, rect(1, 1))).toBe(source);
+        expect(tileFragmentToRect(source, rect(3, 3))).toBe(source);
+    });
+
+    it('leaves ragged or empty fragments alone', () => {
+        const ragged = fragment([['A', 'B'], ['C']]);
+        const empty = fragment([]);
+
+        expect(tileFragmentToRect(ragged, rect(2, 2))).toBe(ragged);
+        expect(tileFragmentToRect(empty, rect(2, 2))).toBe(empty);
+    });
+});

--- a/src/contentScript/editorBridge/cellTextCodec.ts
+++ b/src/contentScript/editorBridge/cellTextCodec.ts
@@ -1,5 +1,5 @@
 import { Transaction } from '@codemirror/state';
-import { normalizeBrTags } from '../shared/cellTextNormalization';
+import { normalizeBrTags, sanitizeLocalText } from '../shared/cellTextNormalization';
 import { clamp } from '../shared/numberUtils';
 
 export interface LocalSelection {
@@ -18,8 +18,6 @@ export interface SanitizeChangesResult {
 }
 
 const SELECTION_MARK = '\u0000';
-const UNESCAPED_PIPE_PATTERN = /(?<!\\)(\\\\)*\|/g;
-const LINE_BREAK_PATTERN = /\r\n|\n|\r/g;
 
 export function escapeUnescapedPipes(text: string): string {
     return escapeUnescapedPipesWithContext(text, 0);
@@ -57,10 +55,6 @@ export function convertNewlinesToBr(text: string): string {
 
 export function unsanitizeRootText(rootText: string): string {
     return rootText.split('<br>').join('\n').split('\\|').join('|');
-}
-
-export function sanitizeLocalText(localText: string): string {
-    return normalizeBrTags(localText).replace(LINE_BREAK_PATTERN, '<br>').replace(UNESCAPED_PIPE_PATTERN, '\\$&');
 }
 
 function toSpan(selection: LocalSelection): { from: number; to: number; forward: boolean } {

--- a/src/contentScript/nestedEditor/nestedEditorController.ts
+++ b/src/contentScript/nestedEditor/nestedEditorController.ts
@@ -7,13 +7,8 @@ import { createJoplinSyntaxHighlighting } from './joplinHighlightStyle';
 import { createNestedEditorMarkdownExtension } from './nestedEditorMarkdown';
 import { selectAllInCell } from './markdownCommands';
 import { createNestedEditorTheme } from './nestedEditorTheme';
-import {
-    LocalSelection,
-    sanitizeLocalText,
-    toLocalSelection,
-    toRootSelection,
-    unsanitizeRootText,
-} from '../editorBridge/cellTextCodec';
+import { LocalSelection, toLocalSelection, toRootSelection, unsanitizeRootText } from '../editorBridge/cellTextCodec';
+import { sanitizeLocalText } from '../shared/cellTextNormalization';
 import { forceRootDomSelection } from '../editorBridge/rootDomSelection';
 import { syncAnnotation } from '../editorBridge/syncAnnotation';
 import { hasSyncAnnotation } from '../shared/transactionUtils';

--- a/src/contentScript/shared/cellTextNormalization.ts
+++ b/src/contentScript/shared/cellTextNormalization.ts
@@ -3,3 +3,14 @@ const NON_CANONICAL_BR_PATTERN = /<br\s*\/>/gi;
 export function normalizeBrTags(text: string): string {
     return text.replace(NON_CANONICAL_BR_PATTERN, '<br>');
 }
+
+const LINE_BREAK_PATTERN = /\r\n|\n|\r/g;
+const UNESCAPED_PIPE_PATTERN = /(?<!\\)(\\\\)*\|/g;
+
+/**
+ * Converts arbitrary text into a value that is safe to store in a table cell: line breaks
+ * become `<br>` and unescaped pipes are escaped, so neither can break out of the row.
+ */
+export function sanitizeLocalText(localText: string): string {
+    return normalizeBrTags(localText).replace(LINE_BREAK_PATTERN, '<br>').replace(UNESCAPED_PIPE_PATTERN, '\\$&');
+}

--- a/src/contentScript/tableModel/clipboardFragmentTiling.ts
+++ b/src/contentScript/tableModel/clipboardFragmentTiling.ts
@@ -35,12 +35,15 @@ function measureRect(rect: TableRect): GridSize {
  * once, leaving the alignments exactly as the fragment supplied them. Tiling them anyway
  * keeps the result a valid fragment on its own.
  */
-function tileAlignments(alignments: readonly TableAlignment[], colCount: number): TableAlignment[] {
-    if (alignments.length === 0) {
-        return new Array<TableAlignment>(colCount).fill(null);
-    }
-
-    return Array.from({ length: colCount }, (_value, col) => alignments[col % alignments.length]);
+function tileAlignments(
+    alignments: readonly TableAlignment[],
+    fragmentColCount: number,
+    tiledColCount: number
+): TableAlignment[] {
+    return Array.from(
+        { length: tiledColCount },
+        (_value, col) => alignments[col % fragmentColCount] ?? null
+    );
 }
 
 /**
@@ -88,5 +91,8 @@ export function tileFragmentToRect(fragment: ClipboardTableFragment, rect: Table
         return Array.from({ length: colCount }, (_cell, col) => sourceRow[col % fragmentSize.colCount]);
     });
 
-    return { cells, alignments: tileAlignments(fragment.alignments, colCount) };
+    return {
+        cells,
+        alignments: tileAlignments(fragment.alignments, fragmentSize.colCount, colCount),
+    };
 }

--- a/src/contentScript/tableModel/clipboardFragmentTiling.ts
+++ b/src/contentScript/tableModel/clipboardFragmentTiling.ts
@@ -1,0 +1,92 @@
+import type { ClipboardTableFragment, TableAlignment } from './MarkdownTable';
+import type { TableRect } from './types';
+
+/** Cell-grid dimensions of a rectangular clipboard fragment or selection rectangle. */
+interface GridSize {
+    rowCount: number;
+    colCount: number;
+}
+
+/** Null when the fragment is empty or ragged, i.e. it has no well-defined grid size. */
+function measureFragment(fragment: ClipboardTableFragment): GridSize | null {
+    const rowCount = fragment.cells.length;
+    const colCount = fragment.cells[0]?.length ?? 0;
+
+    if (rowCount <= 0 || colCount <= 0) {
+        return null;
+    }
+
+    return fragment.cells.every((row) => row.length === colCount) ? { rowCount, colCount } : null;
+}
+
+function measureRect(rect: TableRect): GridSize {
+    return {
+        rowCount: rect.maxRow - rect.minRow + 1,
+        colCount: rect.maxCol - rect.minCol + 1,
+    };
+}
+
+/**
+ * Repeats the fragment's alignments across the tiled width.
+ *
+ * Alignments only take effect for columns a paste creates, and repeated columns always
+ * land inside the rectangle, hence inside the table. A paste can still create columns by
+ * overflowing a fragment wider than the rectangle, but that case repeats the columns
+ * once, leaving the alignments exactly as the fragment supplied them. Tiling them anyway
+ * keeps the result a valid fragment on its own.
+ */
+function tileAlignments(alignments: readonly TableAlignment[], colCount: number): TableAlignment[] {
+    if (alignments.length === 0) {
+        return new Array<TableAlignment>(colCount).fill(null);
+    }
+
+    return Array.from({ length: colCount }, (_value, col) => alignments[col % alignments.length]);
+}
+
+/**
+ * The number of whole fragment repetitions that fit along one axis.
+ *
+ * Always at least one: a fragment wider or taller than the rectangle still pastes a
+ * single complete copy, overflowing the selection the way an unsized paste does.
+ */
+function wholeRepetitions(available: number, fragmentLength: number): number {
+    return Math.max(1, Math.floor(available / fragmentLength));
+}
+
+/**
+ * Repeats a clipboard fragment to cover a selection rectangle.
+ *
+ * Only whole repetitions are written, so no copy is ever truncated mid-fragment: a 1x1
+ * fragment fills any rectangle, a 2x2 fragment covers a 4x4 rectangle exactly, and the
+ * same fragment over a 5x5 rectangle produces 4x4 and leaves the trailing row and column
+ * alone. Callers set the post-paste selection from the region actually written, which is
+ * what tells the user the rectangle was not an exact fit.
+ *
+ * Ragged or empty fragments, and rectangles that fit exactly one copy, are returned
+ * unchanged for a single anchored paste.
+ *
+ * @example
+ * // fragment [['A']] over rows 0-1, cols 0-1 -> [['A', 'A'], ['A', 'A']]
+ */
+export function tileFragmentToRect(fragment: ClipboardTableFragment, rect: TableRect): ClipboardTableFragment {
+    const fragmentSize = measureFragment(fragment);
+    if (!fragmentSize) {
+        return fragment;
+    }
+
+    const available = measureRect(rect);
+    const rowCount = wholeRepetitions(available.rowCount, fragmentSize.rowCount) * fragmentSize.rowCount;
+    const colCount = wholeRepetitions(available.colCount, fragmentSize.colCount) * fragmentSize.colCount;
+
+    if (rowCount === fragmentSize.rowCount && colCount === fragmentSize.colCount) {
+        return fragment;
+    }
+
+    const cells = Array.from({ length: rowCount }, (_value, row) => {
+        const sourceRow = fragment.cells[row % fragmentSize.rowCount];
+
+        return Array.from({ length: colCount }, (_cell, col) => sourceRow[col % fragmentSize.colCount]);
+    });
+
+    return { cells, alignments: tileAlignments(fragment.alignments, colCount) };
+}

--- a/src/contentScript/tableRuntime/selection/cellSelectionClipboard.ts
+++ b/src/contentScript/tableRuntime/selection/cellSelectionClipboard.ts
@@ -375,8 +375,8 @@ export function buildMultiCellPasteRewrite(
         return null;
     }
 
-    // A selection asks for its whole rectangle to be filled; anything the fragment cannot
-    // tile evenly falls back to a single paste anchored at the rectangle's top-left.
+    // Tile whole fragment repetitions from the selection's top-left. Any trailing partial
+    // repetition stays untouched, while a fragment larger than the selection still pastes once.
     const placedFragment = target.source === 'selection' ? tileFragmentToRect(fragment, target.rect) : fragment;
 
     const result = ctx.table.pasteFragmentAt(target.anchor, placedFragment);

--- a/src/contentScript/tableRuntime/selection/cellSelectionClipboard.ts
+++ b/src/contentScript/tableRuntime/selection/cellSelectionClipboard.ts
@@ -16,6 +16,7 @@ import { createActiveCellForTableText } from '../activeCell/activeCellFactory';
 import { getResolvedActiveCell } from '../activeCell/resolvedActiveCell';
 import { resolveTableContextAtPos } from '../tableResolution';
 import { getCellRange } from '../../tableModel/markdownTableCellRanges';
+import { tileFragmentToRect } from '../../tableModel/clipboardFragmentTiling';
 import type { TableContext } from '../../tableModel/tableContext';
 import type { CellCoords, TableRect } from '../../tableModel/types';
 import { canHandleTableClipboardShortcut, canHandleTableSelectionKeydown } from './cellSelectionShortcutScope';
@@ -29,11 +30,23 @@ import { clamp } from '../../shared/numberUtils';
  */
 export const tableClipboardRewriteAnnotation = Annotation.define<boolean>();
 
-export interface TableClipboardTarget {
-    tableFrom: number;
-    anchor: CellCoords;
-    source: 'selection' | 'activeCell';
-}
+/**
+ * Where a clipboard operation lands. A selection carries its rectangle so a paste can
+ * size itself to the selection; an active cell has only its anchor, and always pastes
+ * from there.
+ */
+export type TableClipboardTarget =
+    | {
+          tableFrom: number;
+          anchor: CellCoords;
+          source: 'activeCell';
+      }
+    | {
+          tableFrom: number;
+          anchor: CellCoords;
+          source: 'selection';
+          rect: TableRect;
+      };
 
 export interface TableClipboardRewrite {
     tableFrom: number;
@@ -159,6 +172,7 @@ export function resolveTableClipboardTarget(
         tableFrom: selection.tableFrom,
         anchor: fromUnifiedRow(rect.minRow, rect.minCol),
         source: 'selection',
+        rect,
     };
 }
 
@@ -339,7 +353,11 @@ export function buildMultiCellPasteRewrite(
         return null;
     }
 
-    const result = ctx.table.pasteFragmentAt(target.anchor, fragment);
+    // A selection asks for its whole rectangle to be filled; anything the fragment cannot
+    // tile evenly falls back to a single paste anchored at the rectangle's top-left.
+    const placedFragment = target.source === 'selection' ? tileFragmentToRect(fragment, target.rect) : fragment;
+
+    const result = ctx.table.pasteFragmentAt(target.anchor, placedFragment);
     if (!result) {
         return null;
     }

--- a/src/contentScript/tableRuntime/selection/cellSelectionClipboard.ts
+++ b/src/contentScript/tableRuntime/selection/cellSelectionClipboard.ts
@@ -22,6 +22,7 @@ import type { CellCoords, TableRect } from '../../tableModel/types';
 import { canHandleTableClipboardShortcut, canHandleTableSelectionKeydown } from './cellSelectionShortcutScope';
 import { isNestedEditorOpen } from '../../nestedEditor/nestedEditorController';
 import { clamp } from '../../shared/numberUtils';
+import { sanitizeLocalText } from '../../shared/cellTextNormalization';
 
 /**
  * Marks a transaction as one of this module's own table rewrites. The main-editor guard
@@ -338,6 +339,31 @@ export function buildSelectionRemovalRewrite(
     });
 }
 
+/**
+ * Turns clipboard text that is not a table into the single cell it represents, so a
+ * selection can be filled with it. Only a cell selection asks for this: an active cell
+ * owns its own paste, and returning null there leaves the text to the nested editor's
+ * ordinary insertion.
+ *
+ * Tab-separated text is declined. Spreadsheets put a whole copied range on the clipboard
+ * that way, and collapsing a range into one cell value would overwrite the selection with
+ * something the user never copied. Leaving it unhandled keeps the existing no-op.
+ */
+function createPlainTextFragment(clipboardText: string, target: TableClipboardTarget): ClipboardTableFragment | null {
+    if (target.source !== 'selection') {
+        return null;
+    }
+
+    if (clipboardText.trim().length === 0) {
+        return null;
+    }
+
+    return {
+        cells: [[sanitizeLocalText(clipboardText)]],
+        alignments: [null],
+    };
+}
+
 export function buildMultiCellPasteRewrite(
     state: EditorState,
     target: TableClipboardTarget,
@@ -348,7 +374,7 @@ export function buildMultiCellPasteRewrite(
         return null;
     }
 
-    const fragment = parseMarkdownTableClipboard(clipboardText);
+    const fragment = parseMarkdownTableClipboard(clipboardText) ?? createPlainTextFragment(clipboardText, target);
     if (!fragment) {
         return null;
     }

--- a/src/contentScript/tableRuntime/selection/cellSelectionClipboard.ts
+++ b/src/contentScript/tableRuntime/selection/cellSelectionClipboard.ts
@@ -344,10 +344,6 @@ export function buildSelectionRemovalRewrite(
  * selection can be filled with it. Only a cell selection asks for this: an active cell
  * owns its own paste, and returning null there leaves the text to the nested editor's
  * ordinary insertion.
- *
- * Tab-separated text is declined. Spreadsheets put a whole copied range on the clipboard
- * that way, and collapsing a range into one cell value would overwrite the selection with
- * something the user never copied. Leaving it unhandled keeps the existing no-op.
  */
 function createPlainTextFragment(clipboardText: string, target: TableClipboardTarget): ClipboardTableFragment | null {
     if (target.source !== 'selection') {


### PR DESCRIPTION
Implement functionality to tile pasted fragments and plain clipboard text over the selected area, ensuring proper handling of line breaks and unescaped pipes.