### PR TITLE
perf: avoid redundant selection class mutations

### DIFF
--- a/src/contentScript/__tests__/measuredClassSync.test.ts
+++ b/src/contentScript/__tests__/measuredClassSync.test.ts
@@ -89,9 +89,31 @@ describe('measuredClassSyncPlugin', () => {
         expect(retainedObserver.takeCount()).toBe(0);
         expect(removedObserver.takeCount()).toBe(0);
         expect(addedObserver.takeCount()).toBe(0);
+        expect(retained.classList.contains(CLASS_NAME)).toBe(true);
+        expect(removed.classList.contains(CLASS_NAME)).toBe(false);
+        expect(added.classList.contains(CLASS_NAME)).toBe(true);
 
         retainedObserver.disconnect();
         removedObserver.disconnect();
         addedObserver.disconnect();
+    });
+
+    it('removes the class from the elements it marked when the view is destroyed', async () => {
+        const parent = document.createElement('div');
+        const marked = document.createElement('div');
+        document.body.append(parent, marked);
+
+        const view = new EditorView({
+            parent,
+            extensions: [measuredClassSyncPlugin(CLASS_NAME, () => [marked])],
+        });
+        mountedViews.push(view);
+        await flushMeasure(view);
+
+        expect(marked.classList.contains(CLASS_NAME)).toBe(true);
+
+        mountedViews.pop()?.destroy();
+
+        expect(marked.classList.contains(CLASS_NAME)).toBe(false);
     });
 });

--- a/src/contentScript/__tests__/measuredClassSync.test.ts
+++ b/src/contentScript/__tests__/measuredClassSync.test.ts
@@ -1,0 +1,97 @@
+/** @vitest-environment jsdom */
+
+import { StateEffect } from '@codemirror/state';
+import { EditorView } from '@codemirror/view';
+import { afterEach, describe, expect, it } from 'vitest';
+import { measuredClassSyncPlugin } from '../tableWidget/measuredClassSync';
+
+const CLASS_NAME = 'tracked';
+const refreshEffect = StateEffect.define<void>();
+const mountedViews: EditorView[] = [];
+
+/** Resolves after every measure already queued on the view has written its DOM changes. */
+function flushMeasure(view: EditorView): Promise<void> {
+    return new Promise((resolve) => {
+        view.requestMeasure({
+            read: () => undefined,
+            write: () => resolve(),
+        });
+    });
+}
+
+interface MutationTracker {
+    disconnect: () => void;
+    takeCount: () => number;
+}
+
+function observeClassMutations(element: HTMLElement): MutationTracker {
+    let deliveredCount = 0;
+    const observer = new MutationObserver((records) => {
+        deliveredCount += records.length;
+    });
+    observer.observe(element, { attributes: true, attributeFilter: ['class'] });
+
+    return {
+        disconnect: () => observer.disconnect(),
+        takeCount: () => {
+            const count = deliveredCount + observer.takeRecords().length;
+            deliveredCount = 0;
+            return count;
+        },
+    };
+}
+
+afterEach(() => {
+    while (mountedViews.length > 0) {
+        mountedViews.pop()?.destroy();
+    }
+    document.body.replaceChildren();
+});
+
+describe('measuredClassSyncPlugin', () => {
+    it('mutates classes only for elements whose collected membership changed', async () => {
+        const parent = document.createElement('div');
+        const retained = document.createElement('div');
+        const removed = document.createElement('div');
+        const added = document.createElement('div');
+        document.body.append(parent, retained, removed, added);
+
+        let collected = [retained, removed];
+        const view = new EditorView({
+            parent,
+            extensions: [measuredClassSyncPlugin(CLASS_NAME, () => collected)],
+        });
+        mountedViews.push(view);
+        await flushMeasure(view);
+
+        expect(retained.classList.contains(CLASS_NAME)).toBe(true);
+        expect(removed.classList.contains(CLASS_NAME)).toBe(true);
+        expect(added.classList.contains(CLASS_NAME)).toBe(false);
+
+        const retainedObserver = observeClassMutations(retained);
+        const removedObserver = observeClassMutations(removed);
+        const addedObserver = observeClassMutations(added);
+
+        collected = [retained, added];
+        view.dispatch({ effects: refreshEffect.of(undefined) });
+        await flushMeasure(view);
+
+        expect(retainedObserver.takeCount()).toBe(0);
+        expect(removedObserver.takeCount()).toBe(1);
+        expect(addedObserver.takeCount()).toBe(1);
+        expect(retained.classList.contains(CLASS_NAME)).toBe(true);
+        expect(removed.classList.contains(CLASS_NAME)).toBe(false);
+        expect(added.classList.contains(CLASS_NAME)).toBe(true);
+
+        view.dispatch({ effects: refreshEffect.of(undefined) });
+        await flushMeasure(view);
+
+        expect(retainedObserver.takeCount()).toBe(0);
+        expect(removedObserver.takeCount()).toBe(0);
+        expect(addedObserver.takeCount()).toBe(0);
+
+        retainedObserver.disconnect();
+        removedObserver.disconnect();
+        addedObserver.disconnect();
+    });
+});

--- a/src/contentScript/tableWidget/measuredClassSync.ts
+++ b/src/contentScript/tableWidget/measuredClassSync.ts
@@ -12,6 +12,9 @@ export type ClassSyncCollector = (view: EditorView) => HTMLElement[];
  * because the transactions that change the selection can also rebuild the table widget, and
  * `PluginValue.update()` may run before the replacement DOM is mounted — reading the DOM
  * there would find the outgoing elements.
+ *
+ * Only membership changes are written, so this plugin must be the sole writer of `className`
+ * on the collected elements: a class stripped by anyone else is never restored.
  */
 class MeasuredClassSync implements PluginValue {
     private applied = new Set<HTMLElement>();

--- a/src/contentScript/tableWidget/measuredClassSync.ts
+++ b/src/contentScript/tableWidget/measuredClassSync.ts
@@ -41,6 +41,25 @@ class MeasuredClassSync implements PluginValue {
         this.applied.clear();
     }
 
+    /** Applies only the membership differences between the previous and next collections. */
+    private sync(elements: HTMLElement[]): void {
+        const next = new Set(elements);
+
+        for (const element of this.applied) {
+            if (!next.has(element)) {
+                element.classList.remove(this.className);
+            }
+        }
+
+        for (const element of next) {
+            if (!this.applied.has(element)) {
+                element.classList.add(this.className);
+            }
+        }
+
+        this.applied = next;
+    }
+
     private scheduleSync(): void {
         this.view.requestMeasure({
             key: this,
@@ -50,12 +69,7 @@ class MeasuredClassSync implements PluginValue {
                     return;
                 }
 
-                this.clear();
-
-                for (const element of elements) {
-                    element.classList.add(this.className);
-                    this.applied.add(element);
-                }
+                this.sync(elements);
             },
         });
     }
@@ -63,7 +77,7 @@ class MeasuredClassSync implements PluginValue {
 
 /**
  * A view plugin that applies `className` to exactly the elements `collect` returns, refreshing
- * on every view update and removing the class from everything else it previously marked.
+ * on every view update and mutating only elements whose membership changed.
  */
 export function measuredClassSyncPlugin(className: string, collect: ClassSyncCollector): Extension {
     return ViewPlugin.define((view) => new MeasuredClassSync(view, className, collect));


### PR DESCRIPTION
Optimize the `measuredClassSync` plugin to only mutate classes for elements whose membership has changed, improving performance by reducing unnecessary DOM updates.