### PR TITLE
fix: cursor cannot leave a table over another plugin's hidden decorations

### DIFF
--- a/src/contentScript/__tests__/outsideTableInteraction.test.ts
+++ b/src/contentScript/__tests__/outsideTableInteraction.test.ts
@@ -1,0 +1,138 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { EditorView, type BlockInfo } from '@codemirror/view';
+import { activeCellField, getActiveCell, setActiveCellEffect } from '../tableState/activeCellState';
+import { handleOutsideMouseDown } from '../tableRuntime/interaction/outsideTableInteraction';
+
+const DOC = 'above\nbelow';
+const INITIAL_SELECTION = 2;
+const VALID_CLICK_POSITION = 8;
+const SECOND_LINE_START = 6;
+
+const mountedViews: EditorView[] = [];
+
+function mountActiveView(): EditorView {
+    const parent = document.createElement('div');
+    document.body.appendChild(parent);
+
+    const view = new EditorView({
+        parent,
+        doc: DOC,
+        selection: { anchor: INITIAL_SELECTION },
+        extensions: [activeCellField],
+    });
+    activateCell(view);
+    mountedViews.push(view);
+    return view;
+}
+
+function activateCell(view: EditorView): void {
+    view.dispatch({
+        effects: setActiveCellEffect.of({
+            tableFrom: 0,
+            section: 'header',
+            row: 0,
+            col: 0,
+        }),
+    });
+}
+
+function makeOutsideMouseDown(view: EditorView): MouseEvent {
+    const target = document.createElement('span');
+    view.contentDOM.appendChild(target);
+
+    const event = new MouseEvent('mousedown', {
+        bubbles: true,
+        cancelable: true,
+        button: 0,
+        clientX: 24,
+        clientY: 12,
+    });
+    Object.defineProperty(event, 'target', { value: target });
+    return event;
+}
+
+/** Stands in for the height map, which reports a line start rather than an exact column. */
+function stubHeightMap(view: EditorView, from: number): void {
+    vi.spyOn(view, 'lineBlockAtHeight').mockReturnValue({ from } as BlockInfo);
+}
+
+afterEach(() => {
+    while (mountedViews.length > 0) {
+        mountedViews.pop()?.destroy();
+    }
+    document.body.replaceChildren();
+    vi.restoreAllMocks();
+});
+
+describe('outside table interaction', () => {
+    it('moves the caret to the mapped coordinate and closes the table', () => {
+        const view = mountActiveView();
+        vi.spyOn(view, 'posAtCoords').mockReturnValue(VALID_CLICK_POSITION);
+        const lineBlockAtHeight = vi.spyOn(view, 'lineBlockAtHeight');
+        const focus = vi.spyOn(view, 'focus').mockImplementation(() => undefined);
+
+        const handled = handleOutsideMouseDown(view, makeOutsideMouseDown(view));
+
+        expect(handled).toBe(true);
+        expect(view.state.selection.main.anchor).toBe(VALID_CLICK_POSITION);
+        expect(getActiveCell(view.state)).toBeNull();
+        expect(focus).toHaveBeenCalledOnce();
+        expect(lineBlockAtHeight).not.toHaveBeenCalled();
+    });
+
+    it.each([
+        ['null', null],
+        ['undefined', undefined],
+        ['NaN', Number.NaN],
+        ['negative', -1],
+        ['fractional', 1.5],
+        ['past the document end', DOC.length + 1],
+    ])('falls back to the height map when coordinate mapping returns %s', (_label, mappedPos) => {
+        const view = mountActiveView();
+        vi.spyOn(view, 'posAtCoords').mockReturnValue(mappedPos as never);
+        stubHeightMap(view, SECOND_LINE_START);
+        const focus = vi.spyOn(view, 'focus').mockImplementation(() => undefined);
+
+        const handled = handleOutsideMouseDown(view, makeOutsideMouseDown(view));
+
+        // Consuming the event keeps CodeMirror's own handler from repeating the failed
+        // mapping and dispatching its unusable result.
+        expect(handled).toBe(true);
+        expect(view.state.selection.main.anchor).toBe(SECOND_LINE_START);
+        expect(getActiveCell(view.state)).toBeNull();
+        expect(focus).toHaveBeenCalledOnce();
+    });
+
+    it('leaves the caret alone when the height map cannot place the pointer either', () => {
+        const view = mountActiveView();
+        vi.spyOn(view, 'posAtCoords').mockReturnValue(undefined as never);
+        stubHeightMap(view, Number.NaN);
+        const focus = vi.spyOn(view, 'focus').mockImplementation(() => undefined);
+
+        const handled = handleOutsideMouseDown(view, makeOutsideMouseDown(view));
+
+        expect(handled).toBe(false);
+        expect(view.state.selection.main.anchor).toBe(INITIAL_SELECTION);
+        expect(getActiveCell(view.state)).toBeNull();
+        expect(focus).not.toHaveBeenCalled();
+    });
+
+    it('accepts both document boundaries as valid positions', () => {
+        const view = mountActiveView();
+        const posAtCoords = vi.spyOn(view, 'posAtCoords');
+        vi.spyOn(view, 'focus').mockImplementation(() => undefined);
+
+        posAtCoords.mockReturnValueOnce(0);
+        expect(handleOutsideMouseDown(view, makeOutsideMouseDown(view))).toBe(true);
+        expect(view.state.selection.main.anchor).toBe(0);
+
+        activateCell(view);
+        posAtCoords.mockReturnValueOnce(DOC.length);
+        expect(handleOutsideMouseDown(view, makeOutsideMouseDown(view))).toBe(true);
+        expect(view.state.selection.main.anchor).toBe(DOC.length);
+    });
+});

--- a/src/contentScript/tableRuntime/interaction/outsideTableInteraction.ts
+++ b/src/contentScript/tableRuntime/interaction/outsideTableInteraction.ts
@@ -5,6 +5,7 @@ import { clearActiveCellEffect, getActiveCell } from '../../tableState/activeCel
 import { clearCellSelectionEffect, getCellSelection } from '../../tableState/cellSelectionState';
 import { CLASS_FLOATING_TOOLBAR, getWidgetSelector } from '../../tableWidget/domHelpers';
 import { isNestedEditorOpen } from '../../nestedEditor/nestedEditorController';
+import { logger } from '../../../logger';
 
 function getEventTargetElement(event: MouseEvent | PointerEvent): Element | null {
     const target = event.target;
@@ -76,12 +77,50 @@ function moveCaretAndClearTableState(
     }
 }
 
-/** Fallback when the pointer maps to no document position: clear state, leave the caret alone. */
+/** Last resort when no mapping places the pointer: clear state, leave the caret alone. */
 function clearTableStateInPlace(view: EditorView, live: LiveTableState): void {
     if (!live.hasActiveCell && !live.hasCellSelection) {
         return;
     }
     view.dispatch({ effects: buildClearEffects(live) });
+}
+
+/**
+ * Validates a position returned from coordinate mapping before it reaches EditorSelection.
+ *
+ * `posAtCoords` is typed as always returning a number for the imprecise overload, but it
+ * returns `undefined` in practice when another plugin's decorations defeat its DOM scan.
+ * EditorSelection accepts such a value: its own check only rejects a range past the end of
+ * the document, so `undefined` reaches the state fields and throws from `doc.lineAt` in
+ * whichever one reads the selection anchor.
+ */
+function isValidDocumentPosition(position: unknown, docLength: number): position is number {
+    if (typeof position !== 'number') {
+        return false;
+    }
+    return Number.isInteger(position) && position >= 0 && position <= docLength;
+}
+
+/**
+ * The clicked document position, or null when neither mapping can supply a usable one.
+ *
+ * The fallback reads the height map instead of the DOM, so it survives the decorations that
+ * defeat `posAtCoords` and yields a document position by construction. It only resolves the
+ * clicked line rather than the column, which is enough to move the caret out of the table.
+ */
+function resolveClickPosition(view: EditorView, event: MouseEvent | PointerEvent): number | null {
+    const docLength = view.state.doc.length;
+
+    const mapped = view.posAtCoords({ x: event.clientX, y: event.clientY }, false);
+    if (isValidDocumentPosition(mapped, docLength)) {
+        return mapped;
+    }
+
+    logger.debug('Coordinate mapping returned no usable position; estimating from height map', {
+        mapped,
+    });
+    const estimated = view.lineBlockAtHeight(event.clientY - view.documentTop).from;
+    return isValidDocumentPosition(estimated, docLength) ? estimated : null;
 }
 
 function handleOutsideTableInteraction(
@@ -100,22 +139,26 @@ function handleOutsideTableInteraction(
         return false;
     }
 
-    const clickPos = view.posAtCoords({ x: event.clientX, y: event.clientY });
+    const clickPos = resolveClickPosition(view, event);
     if (clickPos === null) {
         clearTableStateInPlace(view, live);
         return false;
     }
 
     moveCaretAndClearTableState(view, clickPos, live, options);
-    // For mousedown, consume only if we positioned the cursor.
-    // For contextmenu, never consume so native/Joplin menus can open.
+    // For mousedown, consume once we have positioned the cursor: CodeMirror's own handler
+    // would otherwise repeat the coordinate mapping that just failed, and dispatch its
+    // unusable result. For contextmenu, never consume so native/Joplin menus can open.
     return !options.preserveContextMenu;
 }
 
+/** Handles an outside-table mousedown and closes any live table interaction state. */
+export function handleOutsideMouseDown(view: EditorView, event: MouseEvent): boolean {
+    return handleOutsideTableInteraction(view, event, { preserveContextMenu: false });
+}
+
 export const closeOnOutsideMouseDown = EditorView.domEventHandlers({
-    mousedown: (event, view) => {
-        return handleOutsideTableInteraction(view, event, { preserveContextMenu: false });
-    },
+    mousedown: (event, view) => handleOutsideMouseDown(view, event),
 });
 
 export const outsideInteractionCapturePlugin = ViewPlugin.fromClass(

--- a/src/contentScript/tableRuntime/interaction/outsideTableInteraction.ts
+++ b/src/contentScript/tableRuntime/interaction/outsideTableInteraction.ts
@@ -146,9 +146,10 @@ function handleOutsideTableInteraction(
     }
 
     moveCaretAndClearTableState(view, clickPos, live, options);
-    // For mousedown, consume once we have positioned the cursor: CodeMirror's own handler
-    // would otherwise repeat the coordinate mapping that just failed, and dispatch its
-    // unusable result. For contextmenu, never consume so native/Joplin menus can open.
+    // Consume mousedown after positioning the caret. Otherwise CodeMirror runs its own
+    // coordinate lookup; on the height-map fallback path, that lookup can reproduce the
+    // invalid position we recovered from (see: https://github.com/bwat47/joplin-rich-tables/issues/212).
+    // Never consume contextmenu so native/Joplin menus open.
     return !options.preserveContextMenu;
 }
 


### PR DESCRIPTION
works around: https://github.com/bwat47/joplin-rich-tables/issues/212

related issue with the extra markdown editor settings plugin: https://github.com/personalizedrefrigerator/joplin-plugin-extra-editor-settings/issues/53

`posAtCoords` is typed as always returning a number for the imprecise overload, but it returns `undefined` when another plugin's decorations defeat its DOM scan — reproducible over the 1px hidden HTML comments the "Extra markdown editor settings" plugin draws with `display: none` children. EditorSelection accepts such a value, because its own check only rejects a range past the end of the document, so `undefined` reaches the state fields and throws from `doc.lineAt` in whichever one reads the selection anchor. The exception escaped our mousedown handler before it could tear down the table state, leaving the cell active and the caret stuck inside the table.

Validate the mapped position before dispatching it, and fall back to the height map when it is unusable: `lineBlockAtHeight` never touches the DOM, so it survives the decorations that defeat `posAtCoords` and yields a document position by construction. It resolves the clicked line rather than the column, which is enough to move the caret out of the table.

Consuming the mousedown once the caret is placed also keeps CodeMirror's own handler from repeating the failed mapping and dispatching its unusable result.