### PR TITLE
fix: preserve separate tables on paste

### DIFF
--- a/src/contentScript/__tests__/cellSelectionClipboard.test.ts
+++ b/src/contentScript/__tests__/cellSelectionClipboard.test.ts
@@ -140,6 +140,12 @@ describe('cellSelectionClipboard', () => {
         });
     });
 
+    it('declines clipboard text holding more than one table', () => {
+        const twoTables = ['| P1 |', '| --- |', '| Q1 |', '', '| R1 |', '| --- |', '| S1 |'].join('\n');
+
+        expect(parseMarkdownTableClipboard(twoTables)).toBeNull();
+    });
+
     it('uses the selection top-left cell as the paste anchor', () => {
         let state = createMarkdownState(doc, [cellSelectionField]);
         state = state.update({
@@ -546,6 +552,42 @@ describe('cellSelectionClipboard', () => {
         expect(rewrite?.selection).toEqual(
             selection({ section: 'body', row: 0, col: 1 }, { section: 'body', row: 1, col: 2 })
         );
+    });
+
+    it('fills the selection with a multi-table clipboard instead of merging the tables', () => {
+        let state = createMarkdownState(doc, [cellSelectionField]);
+        state = state.update({
+            effects: setCellSelectionEffect.of(
+                selection({ section: 'body', row: 0, col: 1 }, { section: 'body', row: 0, col: 1 })
+            ),
+        }).state;
+
+        const target = resolveTableClipboardTarget(state, { nestedEditorOpen: false });
+        const twoTables = ['| P1 |', '| --- |', '| Q1 |', '', '| R1 |', '| --- |', '| S1 |'].join('\n');
+        const rewrite = buildMultiCellPasteRewrite(state, target!, twoTables);
+
+        const filledCell = String.raw`\| P1 \|<br>\| --- \|<br>\| Q1 \|<br><br>\| R1 \|<br>\| --- \|<br>\| S1 \|`;
+
+        expect(rewrite?.tableText).toBe(
+            [
+                String.raw`| H\|1 | H2 | H3 |`,
+                '| :--- | ---: | --- |',
+                `| a | ${filledCell} |  |`,
+                '| x | <br> | z |',
+            ].join('\n')
+        );
+    });
+
+    it('leaves a multi-table clipboard to the nested editor when an active cell owns the paste', () => {
+        const state = createMarkdownState(doc);
+        const target = {
+            tableFrom: 0,
+            anchor: { section: 'body', row: 0, col: 1 } as const,
+            source: 'activeCell' as const,
+        };
+        const twoTables = ['| P1 |', '| --- |', '| Q1 |', '', '| R1 |', '| --- |', '| S1 |'].join('\n');
+
+        expect(buildMultiCellPasteRewrite(state, target, twoTables)).toBeNull();
     });
 
     it('sanitizes line breaks and pipes out of filled clipboard text', () => {

--- a/src/contentScript/__tests__/mainEditorGuard.test.ts
+++ b/src/contentScript/__tests__/mainEditorGuard.test.ts
@@ -276,6 +276,27 @@ describe('createMainEditorActiveCellGuard', () => {
         expect(tr.effects.some((effect) => effect.is(activateInsertedTableEffect))).toBe(false);
     });
 
+    it('leaves multiple blank-line-separated tables unchanged in the plain root editor', () => {
+        const state = createState({ doc: '', nestedOpen: false });
+        const pasteText = [
+            '| h2 | h2 |',
+            '| --- | --- |',
+            '| t1 | t2 |',
+            '',
+            '| col1 | col2 |',
+            '| --- | --- |',
+            '| t3 | t4 |',
+        ].join('\n');
+
+        const tr = state.update({
+            changes: { from: 0, to: 0, insert: pasteText },
+            userEvent: 'input.paste',
+        });
+
+        expect(tr.state.doc.toString()).toBe(pasteText);
+        expect(tr.effects.some((effect) => effect.is(activateInsertedTableEffect))).toBe(false);
+    });
+
     it('rewrites plain root markdown-table paste in an empty document with surrounding newlines', () => {
         const state = createState({ doc: '', nestedOpen: false });
         const pasteText = ['|H1|H2|', '|---|---|', '|a|b|'].join('\n');

--- a/src/contentScript/__tests__/pasteTableNormalizer.test.ts
+++ b/src/contentScript/__tests__/pasteTableNormalizer.test.ts
@@ -15,6 +15,18 @@ describe('pasteTableNormalizer', () => {
             expect(parseSinglePastedTable(`\n\n${NON_CANONICAL_TABLE}\n\n`)?.serialize()).toBe(CANONICAL_TABLE);
         });
 
+        it('rejects multiple tables separated by blank lines', () => {
+            const secondTable = ['| H2 |', '| --- |', '| b |'].join('\n');
+
+            expect(parseSinglePastedTable(`${CANONICAL_TABLE}\n\n${secondTable}`)).toBeNull();
+        });
+
+        it('rejects a table containing an internal whitespace-only line', () => {
+            const splitTable = ['| H1 | H2 |', '| --- | --- |', '| a | b |', '   ', '| c | d |'].join('\n');
+
+            expect(parseSinglePastedTable(splitTable)).toBeNull();
+        });
+
         it('rejects table plus trailing text', () => {
             expect(parseSinglePastedTable(`${CANONICAL_TABLE}\ntrailing text`)).toBeNull();
         });

--- a/src/contentScript/__tests__/pasteTableNormalizer.test.ts
+++ b/src/contentScript/__tests__/pasteTableNormalizer.test.ts
@@ -1,49 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import { createMarkdownState } from './testMarkdownState';
-import { buildRootTablePasteRewrite, parseSinglePastedTable } from '../tableRuntime/operations/pasteTableNormalizer';
+import { buildRootTablePasteRewrite } from '../tableRuntime/operations/pasteTableNormalizer';
 
 const NON_CANONICAL_TABLE = ['|H1|H2|', '|---|---|', '|a|b|'].join('\n');
 const CANONICAL_TABLE = ['| H1 | H2 |', '| --- | --- |', '| a | b |'].join('\n');
 
 describe('pasteTableNormalizer', () => {
-    describe('parseSinglePastedTable', () => {
-        it('accepts a valid table', () => {
-            expect(parseSinglePastedTable(CANONICAL_TABLE)?.serialize()).toBe(CANONICAL_TABLE);
-        });
-
-        it('accepts a valid table with outer blank lines', () => {
-            expect(parseSinglePastedTable(`\n\n${NON_CANONICAL_TABLE}\n\n`)?.serialize()).toBe(CANONICAL_TABLE);
-        });
-
-        it('rejects multiple tables separated by blank lines', () => {
-            const secondTable = ['| H2 |', '| --- |', '| b |'].join('\n');
-
-            expect(parseSinglePastedTable(`${CANONICAL_TABLE}\n\n${secondTable}`)).toBeNull();
-        });
-
-        it('rejects a table containing an internal whitespace-only line', () => {
-            const splitTable = ['| H1 | H2 |', '| --- | --- |', '| a | b |', '   ', '| c | d |'].join('\n');
-
-            expect(parseSinglePastedTable(splitTable)).toBeNull();
-        });
-
-        it('rejects table plus trailing text', () => {
-            expect(parseSinglePastedTable(`${CANONICAL_TABLE}\ntrailing text`)).toBeNull();
-        });
-
-        it('rejects leading text plus table', () => {
-            expect(parseSinglePastedTable(`leading text\n${CANONICAL_TABLE}`)).toBeNull();
-        });
-
-        it('rejects non-table text', () => {
-            expect(parseSinglePastedTable('plain text')).toBeNull();
-        });
-
-        it('rejects empty text', () => {
-            expect(parseSinglePastedTable('\n \n')).toBeNull();
-        });
-    });
-
     describe('buildRootTablePasteRewrite', () => {
         it('allows insert at empty document start', () => {
             const state = createMarkdownState('');
@@ -126,6 +88,13 @@ describe('pasteTableNormalizer', () => {
 
             expect(nextDoc).toBe(['before', 'abc', '', ...CANONICAL_TABLE.split('\n'), '', 'after'].join('\n'));
             expect(rewrite?.tableFrom).toBe(from + 2);
+        });
+
+        it('declines a clipboard holding more than one table', () => {
+            const state = createMarkdownState('');
+            const twoTables = [CANONICAL_TABLE, '', ['| H3 |', '| --- |', '| c |'].join('\n')].join('\n');
+
+            expect(buildRootTablePasteRewrite(state, 0, 0, twoTables)).toBeNull();
         });
 
         it('returns an absolute table start in the post-change document', () => {

--- a/src/contentScript/__tests__/singleTableBlock.test.ts
+++ b/src/contentScript/__tests__/singleTableBlock.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { parseSingleTableBlock } from '../tableModel/singleTableBlock';
+
+const NON_CANONICAL_TABLE = ['|H1|H2|', '|---|---|', '|a|b|'].join('\n');
+const CANONICAL_TABLE = ['| H1 | H2 |', '| --- | --- |', '| a | b |'].join('\n');
+
+describe('parseSingleTableBlock', () => {
+    it('accepts a valid table', () => {
+        expect(parseSingleTableBlock(CANONICAL_TABLE)?.serialize()).toBe(CANONICAL_TABLE);
+    });
+
+    it('accepts a valid table with outer blank lines', () => {
+        expect(parseSingleTableBlock(`\n\n${NON_CANONICAL_TABLE}\n\n`)?.serialize()).toBe(CANONICAL_TABLE);
+    });
+
+    it('accepts a table with CRLF line endings', () => {
+        expect(parseSingleTableBlock(NON_CANONICAL_TABLE.split('\n').join('\r\n'))?.serialize()).toBe(CANONICAL_TABLE);
+    });
+
+    it('rejects multiple tables separated by blank lines', () => {
+        const secondTable = ['| H2 |', '| --- |', '| b |'].join('\n');
+
+        expect(parseSingleTableBlock(`${CANONICAL_TABLE}\n\n${secondTable}`)).toBeNull();
+    });
+
+    it('rejects multiple tables separated by a CRLF blank line', () => {
+        const secondTable = ['| H2 |', '| --- |', '| b |'].join('\n');
+
+        expect(parseSingleTableBlock(`${CANONICAL_TABLE}\r\n\r\n${secondTable}`)).toBeNull();
+    });
+
+    it('rejects a table containing an internal whitespace-only line', () => {
+        const splitTable = ['| H1 | H2 |', '| --- | --- |', '| a | b |', '   ', '| c | d |'].join('\n');
+
+        expect(parseSingleTableBlock(splitTable)).toBeNull();
+    });
+
+    it('rejects table plus trailing text', () => {
+        expect(parseSingleTableBlock(`${CANONICAL_TABLE}\ntrailing text`)).toBeNull();
+    });
+
+    it('rejects leading text plus table', () => {
+        expect(parseSingleTableBlock(`leading text\n${CANONICAL_TABLE}`)).toBeNull();
+    });
+
+    it('rejects non-table text', () => {
+        expect(parseSingleTableBlock('plain text')).toBeNull();
+    });
+
+    it('rejects empty text', () => {
+        expect(parseSingleTableBlock('\n \n')).toBeNull();
+    });
+});

--- a/src/contentScript/tableModel/singleTableBlock.ts
+++ b/src/contentScript/tableModel/singleTableBlock.ts
@@ -1,0 +1,62 @@
+/**
+ * Decides whether clipboard text is exactly one Markdown table block.
+ *
+ * `MarkdownTable.parse()` drops blank lines before parsing, so text holding two tables
+ * separated by a blank line parses as one table whose second header and separator row
+ * become body rows. Every clipboard path needs the Markdown rule instead: a table block
+ * ends at the first blank line, and nothing but table rows may sit inside it.
+ */
+import { MarkdownTable } from './MarkdownTable';
+
+/** The separator row is the one block line that is not a table row. */
+const SEPARATOR_ROW_LINE_COUNT = 1;
+
+function normalizeClipboardLineEndings(text: string): string {
+    return text.replace(/\r\n?/g, '\n');
+}
+
+function isBlankLine(line: string): boolean {
+    return line.trim().length === 0;
+}
+
+function trimOuterBlankLines(lines: string[]): string[] {
+    let start = 0;
+    let end = lines.length;
+
+    while (start < end && isBlankLine(lines[start])) {
+        start++;
+    }
+
+    while (end > start && isBlankLine(lines[end - 1])) {
+        end--;
+    }
+
+    return lines.slice(start, end);
+}
+
+/**
+ * Parses `text` only when it is a single table block, ignoring blank lines around it.
+ * Returns null for anything else: multiple tables, a table split by a blank line, or a
+ * table with text lines before or after it.
+ */
+export function parseSingleTableBlock(text: string): MarkdownTable | null {
+    const lines = trimOuterBlankLines(normalizeClipboardLineEndings(text).split('\n'));
+    if (lines.length === 0) {
+        return null;
+    }
+
+    // An interior blank line means the text spans more than one block.
+    if (lines.some(isBlankLine)) {
+        return null;
+    }
+
+    const blockText = lines.join('\n');
+    const table = MarkdownTable.parse(blockText);
+    if (!table) {
+        return null;
+    }
+
+    // `rowCount` counts the header plus body rows, so a block made only of table rows is
+    // exactly that many lines plus the separator row.
+    return lines.length === table.rowCount + SEPARATOR_ROW_LINE_COUNT ? table : null;
+}

--- a/src/contentScript/tableRuntime/operations/pasteTableNormalizer.ts
+++ b/src/contentScript/tableRuntime/operations/pasteTableNormalizer.ts
@@ -1,5 +1,5 @@
 import type { EditorState } from '@codemirror/state';
-import { MarkdownTable } from '../../tableModel/MarkdownTable';
+import { parseSingleTableBlock } from '../../tableModel/singleTableBlock';
 import { buildIsolatedRootTableInsertRewrite, buildRootTableInsertRewrite } from './rootTableInsertRewrite';
 
 export interface RootTablePasteRewrite {
@@ -15,53 +15,13 @@ export interface RootTablePasteRewrite {
     tableFrom: number;
 }
 
-function normalizeClipboardLineEndings(text: string): string {
-    return text.replace(/\r\n?/g, '\n');
-}
-
-function trimOuterBlankLines(text: string): string {
-    const lines = text.split('\n');
-
-    while (lines.length > 0 && lines[0].trim().length === 0) {
-        lines.shift();
-    }
-
-    while (lines.length > 0 && lines[lines.length - 1].trim().length === 0) {
-        lines.pop();
-    }
-
-    return lines.join('\n');
-}
-
-export function parseSinglePastedTable(text: string): MarkdownTable | null {
-    const normalizedText = normalizeClipboardLineEndings(text);
-    const trimmedText = trimOuterBlankLines(normalizedText);
-    if (trimmedText.length === 0) {
-        return null;
-    }
-
-    const lines = trimmedText.split('\n');
-    if (lines.some((line) => line.trim().length === 0)) {
-        return null;
-    }
-
-    const table = MarkdownTable.parse(trimmedText);
-    if (!table) {
-        return null;
-    }
-
-    const expectedLineCount = table.rowCount + 1;
-
-    return lines.length === expectedLineCount ? table : null;
-}
-
 export function buildRootTablePasteRewrite(
     state: EditorState,
     from: number,
     to: number,
     clipboardText: string
 ): RootTablePasteRewrite | null {
-    const table = parseSinglePastedTable(clipboardText);
+    const table = parseSingleTableBlock(clipboardText);
     if (!table) {
         return null;
     }

--- a/src/contentScript/tableRuntime/operations/pasteTableNormalizer.ts
+++ b/src/contentScript/tableRuntime/operations/pasteTableNormalizer.ts
@@ -40,15 +40,19 @@ export function parseSinglePastedTable(text: string): MarkdownTable | null {
         return null;
     }
 
+    const lines = trimmedText.split('\n');
+    if (lines.some((line) => line.trim().length === 0)) {
+        return null;
+    }
+
     const table = MarkdownTable.parse(trimmedText);
     if (!table) {
         return null;
     }
 
-    const nonEmptyLineCount = trimmedText.split('\n').filter((line) => line.trim().length > 0).length;
     const expectedLineCount = table.rowCount + 1;
 
-    return nonEmptyLineCount === expectedLineCount ? table : null;
+    return lines.length === expectedLineCount ? table : null;
 }
 
 export function buildRootTablePasteRewrite(

--- a/src/contentScript/tableRuntime/selection/cellSelectionClipboard.ts
+++ b/src/contentScript/tableRuntime/selection/cellSelectionClipboard.ts
@@ -1,6 +1,7 @@
 import { Annotation, EditorSelection, type EditorState, type TransactionSpec } from '@codemirror/state';
 import { EditorView, ViewPlugin } from '@codemirror/view';
 import { ClipboardTableFragment, MarkdownTable, type TableAlignment } from '../../tableModel/MarkdownTable';
+import { parseSingleTableBlock } from '../../tableModel/singleTableBlock';
 import { clearActiveCellEffect } from '../../tableState/activeCellState';
 import {
     cellSelectionTransitionAnnotation,
@@ -108,8 +109,13 @@ export function copySelectionAsMarkdown(state: EditorState, selection: CellSelec
     }).serialize();
 }
 
+/**
+ * Reads clipboard text as a table fragment, but only when it holds exactly one table.
+ * Anything else falls back to the plain-text path so a multi-table clipboard is never
+ * folded into one fragment.
+ */
 export function parseMarkdownTableClipboard(text: string): ClipboardTableFragment | null {
-    const table = MarkdownTable.parse(text);
+    const table = parseSingleTableBlock(text);
     if (!table) {
         return null;
     }


### PR DESCRIPTION
## Summary

- reject pasted table text with internal blank-line boundaries from the single-table normalization path
- preserve blank-line-separated Markdown tables as distinct pasted blocks
- add parser and editor-guard regression coverage
- refactor the code so that the single table paste and the in-table multi-cell paste use a shared gate for deciding whether clipboard text is exactly one Markdown table block.

## Behavior

- Clipboard content containing only a single table still pastes correctly using the `parseSinglePastedTable` path
- Clipboard content containing multiple tables with empty lines between them now paste as separate tables
- Clipboard content containing a single table fragment still pastes correctly inside a table via the multi-cell paste path
- Clipboard content containing more than one table now pastes as plain text inside a table

## Verification

- npm test (938 tests passed)
- npm run lint
- Prettier check on changed files
- npm run dist