### PR TITLE
feat: add zebra striping option

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,9 @@ The below table editing commands can be assigned keyboard shortcuts, the default
 
 ### Settings
 
+- Enable zebra striping
+    - Shade alternating table body rows using the current Joplin theme.
+
 - Show move row/column buttons
     - Display move row and move column actions in the floating table toolbar.
 

--- a/docs/Architecture/Table-Display.md
+++ b/docs/Architecture/Table-Display.md
@@ -90,6 +90,12 @@ See [ADR-004](../ADR/004-global-source-mode.md) for the rationale behind global 
 
 `Ctrl+F` forces raw Markdown mode so native search highlighting works on hidden table text.
 
+## Appearance
+
+Zebra striping is an opt-in startup setting. When enabled, `tableStyles.ts` marks the editor root and shades even
+`tbody` rows with Joplin's table background colour. The direct-child selector applies only to widget-owned rows and
+does not affect HTML tables rendered inside cell Markdown.
+
 ## Host Scroll Modes
 
 Joplin hosts the editor two ways, and internal and external scrolling are mutually exclusive:

--- a/docs/Architecture/Table-Display.md
+++ b/docs/Architecture/Table-Display.md
@@ -94,7 +94,9 @@ See [ADR-004](../ADR/004-global-source-mode.md) for the rationale behind global 
 
 Zebra striping is an opt-in startup setting. When enabled, `tableStyles.ts` marks the editor root and shades even
 `tbody` rows with Joplin's table background colour. The direct-child selector applies only to widget-owned rows and
-does not affect HTML tables rendered inside cell Markdown.
+does not affect HTML tables rendered inside cell Markdown. Selected cells are excluded from the stripe: the stripe
+selector outweighs the selection fill, and `selectionTint.ts` solves its tint against a known ground, so a stripe
+standing in for that ground would band a selected rectangle row by row.
 
 ## Host Scroll Modes
 

--- a/src/__tests__/contentScriptMessageHandler.test.ts
+++ b/src/__tests__/contentScriptMessageHandler.test.ts
@@ -100,6 +100,7 @@ describe('contentScriptMessageHandler', () => {
     it('reads the host editor config', async () => {
         globalValues.mockResolvedValueOnce([true, true]);
         values.mockResolvedValueOnce({
+            'tableAppearance.zebraStriping': true,
             'floatingToolbar.showMoveButtons': false,
             'floatingToolbar.showClearButtons': true,
             'floatingToolbar.showAlignmentButtons': false,
@@ -112,6 +113,7 @@ describe('contentScriptMessageHandler', () => {
 
         expect(globalValues).toHaveBeenCalledWith(['editor.autoMatchingBraces', 'spellChecker.enabled']);
         expect(values).toHaveBeenCalledWith([
+            'tableAppearance.zebraStriping',
             'floatingToolbar.showMoveButtons',
             'floatingToolbar.showClearButtons',
             'floatingToolbar.showAlignmentButtons',
@@ -121,6 +123,9 @@ describe('contentScriptMessageHandler', () => {
             nestedEditor: {
                 autoMatchingBraces: true,
                 spellcheck: true,
+            },
+            tableAppearance: {
+                zebraStriping: true,
             },
             toolbar: {
                 showMoveButtons: false,

--- a/src/__tests__/hostEditorConfigBridge.test.ts
+++ b/src/__tests__/hostEditorConfigBridge.test.ts
@@ -3,6 +3,7 @@ import type { HostEditorConfigDeps } from '../contentScriptBridge/hostEditorConf
 import {
     AUTO_MATCHING_BRACES_SETTING_KEY,
     SPELLCHECK_ENABLED_SETTING_KEY,
+    TABLE_APPEARANCE_ZEBRA_STRIPING_SETTING_KEY,
     defaultHostEditorConfig,
     isHostEditorConfig,
     readHostEditorConfig,
@@ -37,6 +38,7 @@ describe('hostEditorConfigBridge', () => {
     it('reads and normalizes the combined host editor config', async () => {
         globalValuesMock.mockResolvedValue([true, true]);
         valuesMock.mockResolvedValue({
+            [TABLE_APPEARANCE_ZEBRA_STRIPING_SETTING_KEY]: true,
             [TOOLBAR_SHOW_MOVE_BUTTONS_SETTING_KEY]: false,
             [TOOLBAR_SHOW_CLEAR_BUTTONS_SETTING_KEY]: true,
             [TOOLBAR_SHOW_ALIGNMENT_BUTTONS_SETTING_KEY]: false,
@@ -50,6 +52,7 @@ describe('hostEditorConfigBridge', () => {
             SPELLCHECK_ENABLED_SETTING_KEY,
         ]);
         expect(valuesMock).toHaveBeenCalledWith([
+            TABLE_APPEARANCE_ZEBRA_STRIPING_SETTING_KEY,
             TOOLBAR_SHOW_MOVE_BUTTONS_SETTING_KEY,
             TOOLBAR_SHOW_CLEAR_BUTTONS_SETTING_KEY,
             TOOLBAR_SHOW_ALIGNMENT_BUTTONS_SETTING_KEY,
@@ -59,6 +62,9 @@ describe('hostEditorConfigBridge', () => {
             nestedEditor: {
                 autoMatchingBraces: true,
                 spellcheck: true,
+            },
+            tableAppearance: {
+                zebraStriping: true,
             },
             toolbar: {
                 showMoveButtons: false,
@@ -81,6 +87,9 @@ describe('hostEditorConfigBridge', () => {
                 autoMatchingBraces: false,
                 spellcheck: false,
             },
+            tableAppearance: {
+                zebraStriping: false,
+            },
             toolbar: {
                 showMoveButtons: false,
                 showClearButtons: true,
@@ -93,6 +102,7 @@ describe('hostEditorConfigBridge', () => {
     it('defaults only the nested editor config when global settings fail', async () => {
         globalValuesMock.mockRejectedValue(new Error('global boom'));
         valuesMock.mockResolvedValue({
+            [TABLE_APPEARANCE_ZEBRA_STRIPING_SETTING_KEY]: true,
             [TOOLBAR_SHOW_MOVE_BUTTONS_SETTING_KEY]: false,
             [TOOLBAR_SHOW_CLEAR_BUTTONS_SETTING_KEY]: false,
             [TOOLBAR_SHOW_ALIGNMENT_BUTTONS_SETTING_KEY]: false,
@@ -101,6 +111,9 @@ describe('hostEditorConfigBridge', () => {
 
         await expect(readHostEditorConfig(deps)).resolves.toEqual({
             nestedEditor: defaultHostEditorConfig().nestedEditor,
+            tableAppearance: {
+                zebraStriping: true,
+            },
             toolbar: {
                 showMoveButtons: false,
                 showClearButtons: false,
@@ -110,7 +123,7 @@ describe('hostEditorConfigBridge', () => {
         });
     });
 
-    it('defaults only the toolbar config when plugin settings fail', async () => {
+    it('defaults plugin config when plugin settings fail', async () => {
         globalValuesMock.mockResolvedValue([true, true]);
         valuesMock.mockRejectedValue(new Error('plugin boom'));
 
@@ -119,6 +132,7 @@ describe('hostEditorConfigBridge', () => {
                 autoMatchingBraces: true,
                 spellcheck: true,
             },
+            tableAppearance: defaultHostEditorConfig().tableAppearance,
             toolbar: defaultHostEditorConfig().toolbar,
         });
     });
@@ -173,6 +187,17 @@ describe('hostEditorConfigBridge', () => {
                 isHostEditorConfig({
                     ...config,
                     toolbar: { ...config.toolbar, showMoveButtons: 'true' },
+                })
+            ).toBe(false);
+        });
+
+        it('rejects a config with a non-boolean table appearance field', () => {
+            const config = defaultHostEditorConfig();
+
+            expect(
+                isHostEditorConfig({
+                    ...config,
+                    tableAppearance: { zebraStriping: 'true' },
                 })
             ).toBe(false);
         });

--- a/src/contentScript/__tests__/hostEditorConfig.test.ts
+++ b/src/contentScript/__tests__/hostEditorConfig.test.ts
@@ -19,6 +19,9 @@ describe('hostEditorConfig', () => {
             autoMatchingBraces: true,
             spellcheck: true,
         },
+        tableAppearance: {
+            zebraStriping: true,
+        },
         toolbar: {
             showMoveButtons: false,
             showClearButtons: true,

--- a/src/contentScript/__tests__/nestedEditorLifecycle.test.ts
+++ b/src/contentScript/__tests__/nestedEditorLifecycle.test.ts
@@ -48,6 +48,9 @@ const DEFAULT_FEATURE_SETTINGS = {
 } satisfies HostEditorConfig['nestedEditor'];
 const TEST_HOST_CONFIG = {
     nestedEditor: DEFAULT_FEATURE_SETTINGS,
+    tableAppearance: {
+        zebraStriping: false,
+    },
     toolbar: {
         showMoveButtons: true,
         showClearButtons: true,

--- a/src/contentScript/__tests__/nestedEditorUndoRegression.test.ts
+++ b/src/contentScript/__tests__/nestedEditorUndoRegression.test.ts
@@ -54,6 +54,9 @@ const TEST_HOST_CONFIG = {
         autoMatchingBraces: true,
         spellcheck: false,
     },
+    tableAppearance: {
+        zebraStriping: false,
+    },
     toolbar: {
         showMoveButtons: true,
         showClearButtons: true,

--- a/src/contentScript/__tests__/tableStyles.test.ts
+++ b/src/contentScript/__tests__/tableStyles.test.ts
@@ -31,8 +31,15 @@ function mountView(zebraStriping: boolean, extraExtensions: Extension = []): Edi
     return view;
 }
 
-/** Appends a single-column widget table, one body row per entry, and returns its cells. */
-function appendTable(view: EditorView, rows: { selected?: boolean }[]): NodeListOf<HTMLTableCellElement> {
+/**
+ * Renders a single-column widget table, one body row per entry, and returns the background each
+ * row's cell resolves to.
+ *
+ * These backgrounds name theme variables whose colours come from the host, and jsdom does not
+ * substitute custom properties, so the tests below compare rows against each other rather than
+ * against any particular colour.
+ */
+function renderRowBackgrounds(view: EditorView, rows: { selected?: boolean }[]): string[] {
     const table = document.createElement('table');
     table.className = CLASS_TABLE_WIDGET_TABLE;
     const tbody = document.createElement('tbody');
@@ -51,7 +58,7 @@ function appendTable(view: EditorView, rows: { selected?: boolean }[]): NodeList
     table.appendChild(tbody);
     view.contentDOM.appendChild(table);
 
-    return table.querySelectorAll('td');
+    return Array.from(table.querySelectorAll('td'), (cell) => getComputedStyle(cell).backgroundColor);
 }
 
 afterEach(() => {
@@ -74,18 +81,32 @@ describe('tableStyles', () => {
         expect(view.dom.hasAttribute(ATTR_ZEBRA_STRIPING)).toBe(true);
     });
 
-    it('shades only even body rows when enabled', () => {
-        const cells = appendTable(mountView(true), [{}, {}, {}]);
+    it('leaves every body row alike when disabled', () => {
+        const [first, second, third] = renderRowBackgrounds(mountView(false), [{}, {}, {}]);
 
-        expect(getComputedStyle(cells[0]).backgroundColor).not.toBe('var(--rt-stripe-bg)');
-        expect(getComputedStyle(cells[1]).backgroundColor).toBe('var(--rt-stripe-bg)');
-        expect(getComputedStyle(cells[2]).backgroundColor).not.toBe('var(--rt-stripe-bg)');
+        expect(second).toBe(first);
+        expect(third).toBe(first);
     });
 
-    it('leaves a selected cell on the selection ground rather than a stripe', () => {
-        const cells = appendTable(mountView(true, cellSelectionVisuals), [{}, { selected: true }, {}, {}]);
+    it('shades only even body rows when enabled', () => {
+        const rows = [{}, {}, {}, {}];
+        const plain = renderRowBackgrounds(mountView(false), rows);
+        const striped = renderRowBackgrounds(mountView(true), rows);
 
-        expect(getComputedStyle(cells[1]).backgroundColor).toBe('var(--rt-selection-ground-bg)');
-        expect(getComputedStyle(cells[3]).backgroundColor).toBe('var(--rt-stripe-bg)');
+        const shaded = striped.map((background, index) => background !== plain[index]);
+
+        expect(shaded).toEqual([false, true, false, true]);
+    });
+
+    it('paints a selected cell alike whether or not its row is striped', () => {
+        const [plain, selectedEven, selectedOdd, striped] = renderRowBackgrounds(
+            mountView(true, cellSelectionVisuals),
+            [{}, { selected: true }, { selected: true }, {}]
+        );
+
+        expect(selectedEven).toBe(selectedOdd);
+        expect(selectedEven).not.toBe(striped);
+        // The exclusion that keeps the two alike must not have stopped striping altogether.
+        expect(striped).not.toBe(plain);
     });
 });

--- a/src/contentScript/__tests__/tableStyles.test.ts
+++ b/src/contentScript/__tests__/tableStyles.test.ts
@@ -1,15 +1,17 @@
 /** @vitest-environment jsdom */
 
+import type { Extension } from '@codemirror/state';
 import { EditorView } from '@codemirror/view';
 import { afterEach, describe, expect, it } from 'vitest';
 import { defaultHostEditorConfig } from '../../contentScriptBridge/hostEditorConfigBridge';
 import { hostEditorConfigFacet } from '../services/hostEditorConfig';
-import { CLASS_TABLE_WIDGET_TABLE } from '../tableWidget/domHelpers';
+import { cellSelectionVisuals } from '../tableWidget/cellSelectionVisuals';
+import { CLASS_CELL_SELECTED, CLASS_TABLE_WIDGET_TABLE } from '../tableWidget/domHelpers';
 import { ATTR_ZEBRA_STRIPING, tableStyles } from '../tableWidget/tableStyles';
 
 const mountedViews: EditorView[] = [];
 
-function mountView(zebraStriping: boolean): EditorView {
+function mountView(zebraStriping: boolean, extraExtensions: Extension = []): EditorView {
     const parent = document.createElement('div');
     document.body.appendChild(parent);
     const defaults = defaultHostEditorConfig();
@@ -21,11 +23,35 @@ function mountView(zebraStriping: boolean): EditorView {
                 tableAppearance: { zebraStriping },
             }),
             tableStyles,
+            extraExtensions,
         ],
     });
     mountedViews.push(view);
 
     return view;
+}
+
+/** Appends a single-column widget table, one body row per entry, and returns its cells. */
+function appendTable(view: EditorView, rows: { selected?: boolean }[]): NodeListOf<HTMLTableCellElement> {
+    const table = document.createElement('table');
+    table.className = CLASS_TABLE_WIDGET_TABLE;
+    const tbody = document.createElement('tbody');
+
+    for (const [index, row] of rows.entries()) {
+        const tr = document.createElement('tr');
+        const td = document.createElement('td');
+        if (row.selected) {
+            td.classList.add(CLASS_CELL_SELECTED);
+        }
+        td.textContent = String(index + 1);
+        tr.appendChild(td);
+        tbody.appendChild(tr);
+    }
+
+    table.appendChild(tbody);
+    view.contentDOM.appendChild(table);
+
+    return table.querySelectorAll('td');
 }
 
 afterEach(() => {
@@ -49,15 +75,17 @@ describe('tableStyles', () => {
     });
 
     it('shades only even body rows when enabled', () => {
-        const view = mountView(true);
-        const table = document.createElement('table');
-        table.className = CLASS_TABLE_WIDGET_TABLE;
-        table.innerHTML = '<tbody><tr><td>1</td></tr><tr><td>2</td></tr><tr><td>3</td></tr></tbody>';
-        view.contentDOM.appendChild(table);
-        const cells = table.querySelectorAll('td');
+        const cells = appendTable(mountView(true), [{}, {}, {}]);
 
         expect(getComputedStyle(cells[0]).backgroundColor).not.toBe('var(--rt-stripe-bg)');
         expect(getComputedStyle(cells[1]).backgroundColor).toBe('var(--rt-stripe-bg)');
         expect(getComputedStyle(cells[2]).backgroundColor).not.toBe('var(--rt-stripe-bg)');
+    });
+
+    it('leaves a selected cell on the selection ground rather than a stripe', () => {
+        const cells = appendTable(mountView(true, cellSelectionVisuals), [{}, { selected: true }, {}, {}]);
+
+        expect(getComputedStyle(cells[1]).backgroundColor).toBe('var(--rt-selection-ground-bg)');
+        expect(getComputedStyle(cells[3]).backgroundColor).toBe('var(--rt-stripe-bg)');
     });
 });

--- a/src/contentScript/__tests__/tableStyles.test.ts
+++ b/src/contentScript/__tests__/tableStyles.test.ts
@@ -1,0 +1,63 @@
+/** @vitest-environment jsdom */
+
+import { EditorView } from '@codemirror/view';
+import { afterEach, describe, expect, it } from 'vitest';
+import { defaultHostEditorConfig } from '../../contentScriptBridge/hostEditorConfigBridge';
+import { hostEditorConfigFacet } from '../services/hostEditorConfig';
+import { CLASS_TABLE_WIDGET_TABLE } from '../tableWidget/domHelpers';
+import { ATTR_ZEBRA_STRIPING, tableStyles } from '../tableWidget/tableStyles';
+
+const mountedViews: EditorView[] = [];
+
+function mountView(zebraStriping: boolean): EditorView {
+    const parent = document.createElement('div');
+    document.body.appendChild(parent);
+    const defaults = defaultHostEditorConfig();
+    const view = new EditorView({
+        parent,
+        extensions: [
+            hostEditorConfigFacet.of({
+                ...defaults,
+                tableAppearance: { zebraStriping },
+            }),
+            tableStyles,
+        ],
+    });
+    mountedViews.push(view);
+
+    return view;
+}
+
+afterEach(() => {
+    while (mountedViews.length > 0) {
+        mountedViews.pop()?.destroy();
+    }
+    document.body.replaceChildren();
+});
+
+describe('tableStyles', () => {
+    it('does not mark the editor for zebra striping by default', () => {
+        const view = mountView(false);
+
+        expect(view.dom.hasAttribute(ATTR_ZEBRA_STRIPING)).toBe(false);
+    });
+
+    it('marks the editor when zebra striping is enabled', () => {
+        const view = mountView(true);
+
+        expect(view.dom.hasAttribute(ATTR_ZEBRA_STRIPING)).toBe(true);
+    });
+
+    it('shades only even body rows when enabled', () => {
+        const view = mountView(true);
+        const table = document.createElement('table');
+        table.className = CLASS_TABLE_WIDGET_TABLE;
+        table.innerHTML = '<tbody><tr><td>1</td></tr><tr><td>2</td></tr><tr><td>3</td></tr></tbody>';
+        view.contentDOM.appendChild(table);
+        const cells = table.querySelectorAll('td');
+
+        expect(getComputedStyle(cells[0]).backgroundColor).not.toBe('var(--rt-stripe-bg)');
+        expect(getComputedStyle(cells[1]).backgroundColor).toBe('var(--rt-stripe-bg)');
+        expect(getComputedStyle(cells[2]).backgroundColor).not.toBe('var(--rt-stripe-bg)');
+    });
+});

--- a/src/contentScript/tableWidget/richTableThemeVars.ts
+++ b/src/contentScript/tableWidget/richTableThemeVars.ts
@@ -85,6 +85,7 @@ function tintProperties(mode: keyof typeof JOPLIN_SELECTION_COLORS): Record<stri
  * --rt-mark-color          ==highlight== text
  * --rt-link-color          anchor text
  * --rt-header-bg           <th> background
+ * --rt-stripe-bg           alternating body-row background
  * --rt-toolbar-bg          floating toolbar background
  * --rt-toolbar-color       floating toolbar text
  * --rt-toolbar-shadow-near floating toolbar's compact shadow-layer color
@@ -110,6 +111,7 @@ export const richTableThemeVars = EditorView.baseTheme({
         '--rt-mark-color': 'var(--joplin-mark-highlight-color, black)',
         '--rt-link-color': 'var(--joplin-url-color, #155BDA)',
         '--rt-header-bg': 'var(--joplin-table-background-color, rgb(247, 247, 247))',
+        '--rt-stripe-bg': 'var(--joplin-table-background-color, rgb(247, 247, 247))',
         '--rt-toolbar-bg': 'var(--joplin-background-color)',
         '--rt-toolbar-color': 'var(--joplin-color)',
         '--rt-toolbar-shadow-near': 'rgba(0, 0, 0, 0.07)',

--- a/src/contentScript/tableWidget/richTableThemeVars.ts
+++ b/src/contentScript/tableWidget/richTableThemeVars.ts
@@ -104,7 +104,7 @@ function tintProperties(mode: keyof typeof JOPLIN_SELECTION_COLORS): Record<stri
  */
 export const richTableThemeVars = EditorView.baseTheme({
     '&': {
-        '--rt-border-color': 'var(--joplin-divider-color, #dddddd)',
+        '--rt-border-color': 'var(--joplin-code-border-color, #dddddd)',
         '--rt-code-bg': 'var(--joplin-code-background-color, rgb(243, 243, 243))',
         '--rt-code-color': 'var(--joplin-code-color, rgb(0, 0, 0))',
         '--rt-mark-bg': 'var(--joplin-mark-highlight-background-color, #F7D26E)',

--- a/src/contentScript/tableWidget/tableStyles.ts
+++ b/src/contentScript/tableWidget/tableStyles.ts
@@ -1,4 +1,6 @@
+import type { Extension } from '@codemirror/state';
 import { EditorView } from '@codemirror/view';
+import { hostEditorConfigFacet } from '../services/hostEditorConfig';
 import {
     CLASS_CELL_ACTIVE,
     CLASS_CELL_CONTENT,
@@ -14,6 +16,13 @@ import { CLASS_TABLE_WIDGET_TABLE, getWidgetSelector } from './domHelpers';
  * `selectionTint.ts` redraws a gridline at exactly this width.
  */
 export const CELL_BORDER_WIDTH = '1px';
+export const ATTR_ZEBRA_STRIPING = 'data-rt-zebra-striping';
+
+const zebraStripingAttribute = EditorView.editorAttributes.compute(
+    [hostEditorConfigFacet],
+    (state): Record<string, string> =>
+        state.facet(hostEditorConfigFacet).tableAppearance.zebraStriping ? { [ATTR_ZEBRA_STRIPING]: '' } : {}
+);
 
 /**
  * Base styles for the table widget, split by responsibility:
@@ -24,7 +33,7 @@ export const CELL_BORDER_WIDTH = '1px';
  *   4. Rendered content styling (markdown output inside cells)
  *   5. Joplin artifact cleanup
  */
-export const tableStyles = EditorView.baseTheme({
+const tableTheme = EditorView.baseTheme({
     // -------------------------------------------------------------------------
     // 1. Widget container and table layout
     // -------------------------------------------------------------------------
@@ -195,6 +204,9 @@ export const tableStyles = EditorView.baseTheme({
         backgroundColor: 'var(--rt-header-bg)',
         fontWeight: 'bold',
     },
+    [`&[${ATTR_ZEBRA_STRIPING}] .${CLASS_TABLE_WIDGET_TABLE} > tbody > tr:nth-child(even) > td`]: {
+        backgroundColor: 'var(--rt-stripe-bg)',
+    },
     // Media constraints - prevent massive videos/images from breaking the table.
     // Scoped to CLASS_CELL_CONTENT to avoid affecting CodeMirror's internal <img class="cm-widgetBuffer"> elements.
     [`.${CLASS_TABLE_WIDGET_TABLE} .${CLASS_CELL_CONTENT} img, .${CLASS_TABLE_WIDGET_TABLE} .${CLASS_CELL_CONTENT} video`]:
@@ -242,3 +254,5 @@ export const tableStyles = EditorView.baseTheme({
         height: 'auto',
     },
 });
+
+export const tableStyles: Extension = [zebraStripingAttribute, tableTheme];

--- a/src/contentScript/tableWidget/tableStyles.ts
+++ b/src/contentScript/tableWidget/tableStyles.ts
@@ -7,7 +7,7 @@ import {
     CLASS_CELL_EDITOR,
     CLASS_CELL_EDITOR_HIDDEN,
 } from '../shared/tableDomClasses';
-import { CLASS_TABLE_WIDGET_TABLE, getWidgetSelector } from './domHelpers';
+import { CLASS_CELL_SELECTED, CLASS_TABLE_WIDGET_TABLE, getWidgetSelector } from './domHelpers';
 
 /**
  * Width of the gridline between cells.
@@ -204,9 +204,16 @@ const tableTheme = EditorView.baseTheme({
         backgroundColor: 'var(--rt-header-bg)',
         fontWeight: 'bold',
     },
-    [`&[${ATTR_ZEBRA_STRIPING}] .${CLASS_TABLE_WIDGET_TABLE} > tbody > tr:nth-child(even) > td`]: {
-        backgroundColor: 'var(--rt-stripe-bg)',
-    },
+    // Direct children only, so a stripe never reaches an HTML table rendered inside a cell.
+    //
+    // Selected cells are excluded rather than left to lose on specificity: this selector outweighs
+    // the one `selectionTint.ts` paints a cell selection with, and the tint laid over that cell is
+    // pre-solved against `--rt-selection-ground-bg`.  A stripe standing in for the ground would
+    // composite to a different colour, banding a selected rectangle row by row.
+    [`&[${ATTR_ZEBRA_STRIPING}] .${CLASS_TABLE_WIDGET_TABLE} > tbody > tr:nth-child(even) > td:not(.${CLASS_CELL_SELECTED})`]:
+        {
+            backgroundColor: 'var(--rt-stripe-bg)',
+        },
     // Media constraints - prevent massive videos/images from breaking the table.
     // Scoped to CLASS_CELL_CONTENT to avoid affecting CodeMirror's internal <img class="cm-widgetBuffer"> elements.
     [`.${CLASS_TABLE_WIDGET_TABLE} .${CLASS_CELL_CONTENT} img, .${CLASS_TABLE_WIDGET_TABLE} .${CLASS_CELL_CONTENT} video`]:

--- a/src/contentScriptBridge/hostEditorConfigBridge.ts
+++ b/src/contentScriptBridge/hostEditorConfigBridge.ts
@@ -2,6 +2,7 @@ import { logger } from '../logger';
 
 export const AUTO_MATCHING_BRACES_SETTING_KEY = 'editor.autoMatchingBraces';
 export const SPELLCHECK_ENABLED_SETTING_KEY = 'spellChecker.enabled';
+export const TABLE_APPEARANCE_ZEBRA_STRIPING_SETTING_KEY = 'tableAppearance.zebraStriping';
 export const TOOLBAR_SHOW_MOVE_BUTTONS_SETTING_KEY = 'floatingToolbar.showMoveButtons';
 export const TOOLBAR_SHOW_CLEAR_BUTTONS_SETTING_KEY = 'floatingToolbar.showClearButtons';
 export const TOOLBAR_SHOW_ALIGNMENT_BUTTONS_SETTING_KEY = 'floatingToolbar.showAlignmentButtons';
@@ -12,6 +13,9 @@ export interface HostEditorConfig {
         autoMatchingBraces: boolean;
         spellcheck: boolean;
     };
+    tableAppearance: {
+        zebraStriping: boolean;
+    };
     toolbar: {
         showMoveButtons: boolean;
         showClearButtons: boolean;
@@ -21,6 +25,7 @@ export interface HostEditorConfig {
 }
 
 export type NestedEditorHostConfig = HostEditorConfig['nestedEditor'];
+type TableAppearanceHostConfig = HostEditorConfig['tableAppearance'];
 export type ToolbarHostConfig = HostEditorConfig['toolbar'];
 
 export interface GetHostEditorConfigMessage {
@@ -39,6 +44,9 @@ export function defaultHostEditorConfig(): HostEditorConfig {
         nestedEditor: {
             autoMatchingBraces: false,
             spellcheck: false,
+        },
+        tableAppearance: {
+            zebraStriping: false,
         },
         toolbar: {
             showMoveButtons: true,
@@ -78,6 +86,7 @@ export function isHostEditorConfig(value: unknown): value is HostEditorConfig {
 
     return (
         isBooleanShape(candidate.nestedEditor, defaults.nestedEditor) &&
+        isBooleanShape(candidate.tableAppearance, defaults.tableAppearance) &&
         isBooleanShape(candidate.toolbar, defaults.toolbar)
     );
 }
@@ -108,11 +117,17 @@ async function readNestedEditorConfig(deps: HostEditorConfigDeps): Promise<Neste
     }
 }
 
-async function readToolbarConfig(deps: HostEditorConfigDeps): Promise<ToolbarHostConfig> {
-    const defaults = defaultHostEditorConfig().toolbar;
+interface PluginHostConfig {
+    tableAppearance: TableAppearanceHostConfig;
+    toolbar: ToolbarHostConfig;
+}
+
+async function readPluginConfig(deps: HostEditorConfigDeps): Promise<PluginHostConfig> {
+    const defaults = defaultHostEditorConfig();
 
     try {
         const values = await deps.settings.values([
+            TABLE_APPEARANCE_ZEBRA_STRIPING_SETTING_KEY,
             TOOLBAR_SHOW_MOVE_BUTTONS_SETTING_KEY,
             TOOLBAR_SHOW_CLEAR_BUTTONS_SETTING_KEY,
             TOOLBAR_SHOW_ALIGNMENT_BUTTONS_SETTING_KEY,
@@ -120,38 +135,50 @@ async function readToolbarConfig(deps: HostEditorConfigDeps): Promise<ToolbarHos
         ]);
 
         return {
-            showMoveButtons: readBooleanSetting(
-                values,
-                TOOLBAR_SHOW_MOVE_BUTTONS_SETTING_KEY,
-                defaults.showMoveButtons
-            ),
-            showClearButtons: readBooleanSetting(
-                values,
-                TOOLBAR_SHOW_CLEAR_BUTTONS_SETTING_KEY,
-                defaults.showClearButtons
-            ),
-            showAlignmentButtons: readBooleanSetting(
-                values,
-                TOOLBAR_SHOW_ALIGNMENT_BUTTONS_SETTING_KEY,
-                defaults.showAlignmentButtons
-            ),
-            showDeleteTableButton: readBooleanSetting(
-                values,
-                TOOLBAR_SHOW_DELETE_TABLE_BUTTON_SETTING_KEY,
-                defaults.showDeleteTableButton
-            ),
+            tableAppearance: {
+                zebraStriping: readBooleanSetting(
+                    values,
+                    TABLE_APPEARANCE_ZEBRA_STRIPING_SETTING_KEY,
+                    defaults.tableAppearance.zebraStriping
+                ),
+            },
+            toolbar: {
+                showMoveButtons: readBooleanSetting(
+                    values,
+                    TOOLBAR_SHOW_MOVE_BUTTONS_SETTING_KEY,
+                    defaults.toolbar.showMoveButtons
+                ),
+                showClearButtons: readBooleanSetting(
+                    values,
+                    TOOLBAR_SHOW_CLEAR_BUTTONS_SETTING_KEY,
+                    defaults.toolbar.showClearButtons
+                ),
+                showAlignmentButtons: readBooleanSetting(
+                    values,
+                    TOOLBAR_SHOW_ALIGNMENT_BUTTONS_SETTING_KEY,
+                    defaults.toolbar.showAlignmentButtons
+                ),
+                showDeleteTableButton: readBooleanSetting(
+                    values,
+                    TOOLBAR_SHOW_DELETE_TABLE_BUTTON_SETTING_KEY,
+                    defaults.toolbar.showDeleteTableButton
+                ),
+            },
         };
     } catch (error) {
-        logger.warn('Failed to read toolbar host config, using defaults', error);
-        return defaults;
+        logger.warn('Failed to read plugin host config, using defaults', error);
+        return {
+            tableAppearance: defaults.tableAppearance,
+            toolbar: defaults.toolbar,
+        };
     }
 }
 
 export async function readHostEditorConfig(deps: HostEditorConfigDeps): Promise<HostEditorConfig> {
-    const [nestedEditor, toolbar] = await Promise.all([readNestedEditorConfig(deps), readToolbarConfig(deps)]);
+    const [nestedEditor, pluginConfig] = await Promise.all([readNestedEditorConfig(deps), readPluginConfig(deps)]);
 
     return {
         nestedEditor,
-        toolbar,
+        ...pluginConfig,
     };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,7 +53,8 @@ joplin.plugins.register({
                 public: true,
                 section: SETTINGS_SECTION,
                 label: 'Enable zebra striping',
-                description: 'Shade alternating table body rows using the current Joplin theme.',
+                description:
+                    'Shade alternating table body rows using the current Joplin theme (if supported by the current Joplin theme).',
             },
             [TOOLBAR_SHOW_MOVE_BUTTONS_SETTING_KEY]: {
                 value: true,

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { ContentScriptType, MenuItemLocation, SettingItemType, ToastType, Toolba
 import { logger } from './logger';
 import { createContentScriptMessageHandler } from './contentScriptBridge/contentScriptMessageHandler';
 import {
+    TABLE_APPEARANCE_ZEBRA_STRIPING_SETTING_KEY,
     TOOLBAR_SHOW_ALIGNMENT_BUTTONS_SETTING_KEY,
     TOOLBAR_SHOW_CLEAR_BUTTONS_SETTING_KEY,
     TOOLBAR_SHOW_DELETE_TABLE_BUTTON_SETTING_KEY,
@@ -42,10 +43,18 @@ joplin.plugins.register({
         await joplin.settings.registerSection(SETTINGS_SECTION, {
             label: 'Rich Tables',
             iconName: 'fas fa-table',
-            description: 'Configure the Rich Tables floating toolbar.',
+            description: 'Configure Rich Tables appearance and floating toolbar.',
         });
 
         await joplin.settings.registerSettings({
+            [TABLE_APPEARANCE_ZEBRA_STRIPING_SETTING_KEY]: {
+                value: false,
+                type: SettingItemType.Bool,
+                public: true,
+                section: SETTINGS_SECTION,
+                label: 'Enable zebra striping',
+                description: 'Shade alternating table body rows using the current Joplin theme.',
+            },
             [TOOLBAR_SHOW_MOVE_BUTTONS_SETTING_KEY]: {
                 value: true,
                 type: SettingItemType.Bool,


### PR DESCRIPTION
Enables zebra striping, when using a Joplin theme that shows zebra striping for tables in the markdown viewer.