### PR TITLE
fix: pad table boundaries for host-command insertions

### DIFF
--- a/docs/Architecture/Table-Parsing.md
+++ b/docs/Architecture/Table-Parsing.md
@@ -66,8 +66,10 @@ every value derived from it.
 
 `TableContext` is passive derived state and never rewrites the document. Canonicalization occurs only at existing cell
 entry, paste, or structural-operation boundaries. Existing adjacent pipe-free text is normalized as a row. Separately,
-transaction-aware boundary maintenance detects text typed or pasted into a previously blank line below a rendered
-table and restores spacing in the same transaction, keeping that new text outside the table.
+transaction-aware boundary maintenance detects text written into a previously blank line beside a rendered table and
+restores spacing in the same transaction, keeping that new text outside the table. It inspects every document change
+except composition, deletion, and undo/redo, because host commands such as Joplin's `insertText` - the path other
+plugins insert through - dispatch without a user event to match on.
 
 ## Active Cells and Structural Operations
 

--- a/src/contentScript/__tests__/tableBoundaryMaintenance.test.ts
+++ b/src/contentScript/__tests__/tableBoundaryMaintenance.test.ts
@@ -38,12 +38,17 @@ function createState(doc: string, options: { effects?: StateEffect<unknown>[] } 
     return options.effects?.length ? state.update({ effects: options.effects }).state : state;
 }
 
-/** Applies `text` at `pos` the way the editor reports typed or pasted input. */
-function input(state: EditorState, pos: number, text: string, userEvent = 'input.type'): Transaction {
+/**
+ * Applies `text` at `pos`.
+ *
+ * `userEvent` is left off to mirror a host command such as Joplin's `insertText`, which
+ * dispatches without one.
+ */
+function input(state: EditorState, pos: number, text: string, userEvent?: string): Transaction {
     return state.update({
         changes: { from: pos, insert: text },
         selection: { anchor: pos + text.length },
-        userEvent,
+        ...(userEvent ? { userEvent } : {}),
     });
 }
 
@@ -55,7 +60,7 @@ function blankLinePos(doc: string, followingText: string): number {
 describe('table boundary maintenance', () => {
     it('restores the blank line when text is typed above a table', () => {
         const doc = `intro\n\n${TABLE}\n`;
-        const transaction = input(createState(doc), blankLinePos(doc, TABLE), 'x');
+        const transaction = input(createState(doc), blankLinePos(doc, TABLE), 'x', 'input.type');
 
         expect(transaction.state.doc.toString()).toBe(`intro\nx\n\n${TABLE}\n`);
     });
@@ -63,6 +68,10 @@ describe('table boundary maintenance', () => {
     it.each([
         { label: 'typed', userEvent: 'input.type' },
         { label: 'pasted', userEvent: 'input.paste' },
+        { label: 'dropped', userEvent: 'input.drop' },
+        // Joplin's `insertText`/`replaceSelection` commands, which other plugins insert
+        // through, dispatch without a user event.
+        { label: 'inserted by a host command', userEvent: undefined },
     ])('restores the blank line when text is $label below a table', ({ userEvent }) => {
         const doc = `\n${TABLE}\n\nafter`;
         const transaction = input(createState(doc), blankLinePos(doc, 'after'), 'x', userEvent);
@@ -75,7 +84,7 @@ describe('table boundary maintenance', () => {
     it('keeps the caret with the typed text', () => {
         const doc = `intro\n\n${TABLE}\n`;
         const pos = blankLinePos(doc, TABLE);
-        const transaction = input(createState(doc), pos, 'xy');
+        const transaction = input(createState(doc), pos, 'xy', 'input.type');
 
         expect(transaction.state.selection.main.head).toBe(pos + 'xy'.length);
         expect(transaction.state.doc.lineAt(transaction.state.selection.main.head).text).toBe('xy');
@@ -155,7 +164,7 @@ describe('table boundary maintenance', () => {
 
     it('takes back the typed text and the padding in one undo', () => {
         const doc = `intro\n\n${TABLE}\n`;
-        const state = input(createState(doc), blankLinePos(doc, TABLE), 'x').state;
+        const state = input(createState(doc), blankLinePos(doc, TABLE), 'x', 'input.type').state;
 
         let undone = state;
         undo({ state, dispatch: (transaction) => (undone = transaction.state) });
@@ -174,5 +183,27 @@ describe('table boundary maintenance', () => {
         const text = transaction.state.doc.toString();
 
         expect(text).toBe(`intro\n\n${TABLE}\n\n${TABLE}\n`);
+    });
+
+    it.each([
+        { label: 'undo', userEvent: 'undo' },
+        { label: 'redo', userEvent: 'redo' },
+    ])('leaves a $label transaction alone', ({ userEvent }) => {
+        const doc = `intro\n\n${TABLE}\n`;
+        const transaction = input(createState(doc), blankLinePos(doc, TABLE), 'x', userEvent);
+
+        expect(transaction.state.doc.toString()).toBe(`intro\nx\n${TABLE}\n`);
+    });
+
+    it('leaves a full document replacement alone', () => {
+        const doc = `intro\n\n${TABLE}\n`;
+        const replacement = `intro\nx\n${TABLE}\n`;
+        const state = createState(doc);
+        const transaction = state.update({
+            changes: { from: 0, to: state.doc.length, insert: replacement },
+            selection: { anchor: 0 },
+        });
+
+        expect(transaction.state.doc.toString()).toBe(replacement);
     });
 });

--- a/src/contentScript/tableRuntime/tableBoundaryMaintenance.ts
+++ b/src/contentScript/tableRuntime/tableBoundaryMaintenance.ts
@@ -24,18 +24,34 @@ interface BoundaryPadding {
 const BOUNDARY_PADDING_NEWLINE = '\n';
 
 /**
- * Transactions this filter inspects: user input that is not already a plugin rewrite.
+ * User events whose transactions must never be padded.
  *
  * Composition is excluded because rewriting the document mid-composition breaks IME and
  * soft-keyboard input; if composition fills the boundary, cell entry normalization repairs it later.
- * Deletions are excluded too - they are protected by `mainEditorTableEntry` instead, and
- * undo must be able to reach the document as the user last left it.
+ * Deletions are protected by `mainEditorTableEntry` instead, and undo must be able to reach the
+ * document as the user last left it.
+ */
+const EXCLUDED_USER_EVENTS = ['input.type.compose', 'delete', 'undo', 'redo'] as const;
+
+/**
+ * Transactions this filter inspects: document changes that are neither an excluded event nor a
+ * plugin rewrite.
+ *
+ * The excluded events are named individually rather than the wanted ones because a host command
+ * can write into the note with no user event at all: Joplin's `insertText` and `replaceSelection`
+ * commands - the ones other plugins insert text through - dispatch `state.replaceSelection` with an
+ * undefined `userEvent`, which CodeMirror drops rather than annotating. Matching on `input` would
+ * skip every such insertion, leaving a table unseparated from the text written against it.
+ *
+ * Widening the gate this way lets rewrites from the plugin's own transaction filters through as
+ * well, since those rebuild a transaction without its annotations. That is safe because padding is
+ * decided against the post-change document, so a rewrite that already spaced its table is left
+ * alone.
  */
 function isBoundaryMaintenanceCandidate(transaction: Transaction): boolean {
     return (
         transaction.docChanged &&
-        transaction.isUserEvent('input') &&
-        !transaction.isUserEvent('input.type.compose') &&
+        !EXCLUDED_USER_EVENTS.some((event) => transaction.isUserEvent(event)) &&
         !transaction.annotation(syncAnnotation) &&
         !transaction.annotation(normalizeBeforeEditAnnotation) &&
         hasPlainRenderedTableCaret(transaction.startState)
@@ -144,7 +160,7 @@ function buildPaddedTransaction(transaction: Transaction, padding: BoundaryPaddi
 }
 
 /**
- * Restores the blank line a table needs when typing or pasting fills it in.
+ * Restores the blank line a table needs when typing, pasting, or a host command fills it in.
  *
  * The separation a table keeps from its neighbours is protected against deletion by
  * `mainEditorTableEntry` and repaired on cell entry by `tableCanonicalForm`; this closes the


### PR DESCRIPTION
Boundary maintenance only inspected transactions carrying an `input` user event. Joplin's `insertText` and `replaceSelection` commands - the path other plugins write into the note through, including paste-as-markdown - dispatch `state.replaceSelection` with an undefined `userEvent`, which CodeMirror drops instead of annotating. Text inserted that way filled a table's separating blank line without the filter ever looking at it.

Gate on a list of excluded events (composition, deletion, undo, redo) rather than an `input` allowlist, so annotation-less document changes are inspected too. Padding is still decided against the post-change document, so rewrites that already spaced their table are left alone.