### PR TITLE
feat: place the caret where a click lands in a rendered cell

### DIFF
--- a/docs/Architecture/Interaction-and-Navigation.md
+++ b/docs/Architecture/Interaction-and-Navigation.md
@@ -95,44 +95,31 @@ bolded word lands between the same two letters once the syntax is visible.
 The rendering service returns HTML without character offsets. Placement therefore combines DOM hit testing with
 CodeMirror's Markdown syntax tree:
 
-1. `tableWidget/cellCaretHit.ts` reads the DOM caret before the rendered content is replaced. It flattens text,
-   counts `<br>` as a newline, and skips MathML.
+1. `tableWidget/cellCaretHit.ts` reads the DOM caret before the rendered content is replaced.
 2. `tableRuntime/interaction/cellTextProjection.ts` projects visible source spans into text with a map back to
-   nested-editor offsets. It removes formatting delimiters, link destinations/titles, images, and HTML syntax.
-   Autolink text and inline-code contents remain visible. Pipe and line-break offsets use the existing cell codec.
-3. `clickCursorPlacement.ts` maps matching rendered/projected text directly. Literal text shown before asynchronous
-   rendering also maps directly. These paths do not use the alignment length or comparison limits.
-4. When rendering transforms the text, `shared/textAlignment.ts` aligns against the projection only. Hidden source
-   cannot become an anchor. Entities are omitted from the projection, so their decoded output uses neighboring
-   anchors. Unknown renderer extensions remain approximate; insufficient matches decline placement.
+   nested-editor offsets, so hidden Markdown cannot become an anchor.
+3. `tableRuntime/interaction/clickCursorPlacement.ts` maps matching rendered/projected text directly.
+4. When rendering transforms the text, `shared/textAlignment.ts` aligns rendered text against the projection under a
+   bounded budget. Unknown renderer extensions remain approximate; insufficient matches decline placement.
 
-The offset or range travels through the open-cell request to the nested editor. Rendered content is focusable with
-`tabIndex=-1`, so focusing it does not reset the range through the outer editor's focus handler.
+The offset or range travels through the open-cell request to the nested editor.
 
 Every press inside a widget is routed by `tableWidgetPressPlugin` in `tableWidget/tableWidgetInteractions.ts`, which
 returns one of three dispositions: left native, claimed from CodeMirror with the browser default intact, or consumed
-outright. A press on rendered text needs `claim`, which `EditorView.domEventHandlers` cannot express — a handler
-returning true has its event default-prevented too — so presses are dispatched from a capture listener and only clicks
-remain registered as handlers.
+outright. It runs in the capture phase because `EditorView.domEventHandlers` cannot express the middle one.
 
-While a drag stays in its cell, the browser owns selection. Pointerup reads both endpoints from the same rendered-text
-index and maps them through one projection/alignment, preserving direction. A range is mapped from the characters it
-covers rather than as two carets, so the source span runs from the first covered character to just past the last:
-Markdown syntax is included where the selection spans it and excluded at both ends otherwise. An end then grows past
-trailing syntax when the range already holds the matching leading syntax, and likewise at the start, so a range never
-keeps one marker of a pair without the other; syntax with no partner, such as an entity or an image, is never drawn in.
-A range covering every rendered character takes the whole cell text, syntax included. Unresolved hits preserve the
-established selection fallback.
+While a drag stays in its cell, the browser owns selection. Pointerup maps both endpoints through one
+projection/alignment, preserving direction. A range is mapped from the characters it covers rather than as two carets,
+so Markdown syntax is included where the selection spans it and excluded at both ends otherwise, with paired markers
+kept balanced. Unresolved hits preserve the established selection fallback.
 
 Crossing into another cell after the movement threshold promotes the gesture to rectangular selection, clears native
 text selection, and suppresses it until release or cancellation. Returning to the anchor keeps rectangular mode; it
 does not restore the earlier text range. Active-editor drags retain their existing boundary margin and behavior.
 
-Only another cell promotes a drag. Leaving the table promotes nothing — every other cell is inside it, so an exit is
-overshoot rather than intent — and the gesture stays a text selection. An endpoint that landed outside the cell is
-clamped to the end the drag left by, so dragging out of the table selects to the end of the cell; at least one endpoint
-must still resolve inside it. Once a rectangle is being dragged, a pointer outside the table tracks the nearest cell as
-before.
+Only another cell promotes a drag; leaving the table keeps the gesture a text selection, with an endpoint outside the
+cell clamped to the end the drag left by. Once a rectangle is being dragged, a pointer outside the table tracks the
+nearest cell as before.
 
 ## Pointer, Links, and Scrolling
 
@@ -140,9 +127,8 @@ before.
 - Mouse dragging within an inactive cell selects rendered text; dragging into another cell selects a rectangle.
   Touch and pen input retain native scrolling and tap behavior.
 - A long press on mobile selects rendered text without opening the cell. `TableWidget.ignoreEvent` disowns the `copy`
-  that follows, so the browser copies what was selected; CodeMirror would otherwise answer it from its own document
-  selection, which is empty there and falls back to the caret's whole source line. A whole-table selection keeps its
-  Markdown copy: its endpoints are not inside a cell.
+  that follows, so the browser copies what was selected rather than CodeMirror's own document selection. A
+  whole-table selection keeps its Markdown copy: its endpoints are not inside a cell.
 - Drags near an edge auto-scroll the table or host scroll container. See
   [Table-Display.md](./Table-Display.md#host-scroll-modes).
 - Links delegate to the content-script link opener and then to the main plugin.

--- a/docs/Architecture/Interaction-and-Navigation.md
+++ b/docs/Architecture/Interaction-and-Navigation.md
@@ -139,6 +139,10 @@ before.
 - Clicking activates a cell or updates the current cell selection, placing the caret where the click landed.
 - Mouse dragging within an inactive cell selects rendered text; dragging into another cell selects a rectangle.
   Touch and pen input retain native scrolling and tap behavior.
+- A long press on mobile selects rendered text without opening the cell. `TableWidget.ignoreEvent` disowns the `copy`
+  that follows, so the browser copies what was selected; CodeMirror would otherwise answer it from its own document
+  selection, which is empty there and falls back to the caret's whole source line. A whole-table selection keeps its
+  Markdown copy: its endpoints are not inside a cell.
 - Drags near an edge auto-scroll the table or host scroll container. See
   [Table-Display.md](./Table-Display.md#host-scroll-modes).
 - Links delegate to the content-script link opener and then to the main plugin.

--- a/docs/Architecture/Interaction-and-Navigation.md
+++ b/docs/Architecture/Interaction-and-Navigation.md
@@ -108,12 +108,14 @@ Every press inside a widget is routed by `tableWidgetPressPlugin` in `tableWidge
 returns one of three dispositions: left native, claimed from CodeMirror with the browser default intact, or consumed
 outright. It runs in the capture phase because `EditorView.domEventHandlers` cannot express the middle one.
 
-While a drag stays in its cell, the browser owns selection. Pointerup maps both endpoints through one
-projection/alignment, preserving direction. A range is mapped from the characters it covers rather than as two carets,
+A press on a rendered cell is consumed, and the gesture draws the DOM selection itself from the caret each pointer
+move hit-tests. The browser latches its own selection drag at mousedown, and nothing cancels it afterwards: left
+native, its auto-scroll keeps running once the gesture has become a cell rectangle, carrying the editor past the
+table. Pointerup maps both endpoints through one projection/alignment, preserving direction. A range is mapped from the characters it covers rather than as two carets,
 so Markdown syntax is included where the selection spans it and excluded at both ends otherwise, with paired markers
 kept balanced. Unresolved hits preserve the established selection fallback.
 
-Crossing into another cell after the movement threshold promotes the gesture to rectangular selection, clears native
+Crossing into another cell after the movement threshold promotes the gesture to rectangular selection, clears rendered
 text selection, and suppresses it until release or cancellation. Returning to the anchor keeps rectangular mode; it
 does not restore the earlier text range. Active-editor drags retain their existing boundary margin and behavior.
 

--- a/docs/Architecture/Interaction-and-Navigation.md
+++ b/docs/Architecture/Interaction-and-Navigation.md
@@ -99,8 +99,10 @@ CodeMirror's Markdown syntax tree:
 2. `tableRuntime/interaction/cellTextProjection.ts` projects visible source spans into text with a map back to
    nested-editor offsets, so hidden Markdown cannot become an anchor.
 3. `tableRuntime/interaction/clickCursorPlacement.ts` maps matching rendered/projected text directly.
-4. When rendering transforms the text, `shared/textAlignment.ts` aligns rendered text against the projection under a
-   bounded budget. Unknown renderer extensions remain approximate; insufficient matches decline placement.
+4. When rendering transforms the text, `shared/textAlignment.ts` aligns rendered text against the projection with one
+   forward scan that resynchronises within a small window. Unknown renderer extensions remain approximate; a hidden run
+   wider than that window strands the rest of the cell, which collapses the matched ratio, and insufficient matches
+   decline placement.
 
 The offset or range travels through the open-cell request to the nested editor.
 

--- a/docs/Architecture/Interaction-and-Navigation.md
+++ b/docs/Architecture/Interaction-and-Navigation.md
@@ -113,9 +113,11 @@ focusable with `tabIndex=-1`, so focusing it does not reset the range through th
 While a drag stays in its cell, the browser owns selection. Pointerup reads both endpoints from the same rendered-text
 index and maps them through one projection/alignment, preserving direction. A range is mapped from the characters it
 covers rather than as two carets, so the source span runs from the first covered character to just past the last:
-Markdown syntax is included where the selection spans it and excluded at both ends otherwise. A range covering every
-rendered character takes the whole cell text, syntax included. Unresolved hits preserve the established selection
-fallback.
+Markdown syntax is included where the selection spans it and excluded at both ends otherwise. An end then grows past
+trailing syntax when the range already holds the matching leading syntax, and likewise at the start, so a range never
+keeps one marker of a pair without the other; syntax with no partner, such as an entity or an image, is never drawn in.
+A range covering every rendered character takes the whole cell text, syntax included. Unresolved hits preserve the
+established selection fallback.
 
 Crossing into another cell after the movement threshold promotes the gesture to rectangular selection, clears native
 text selection, and suppresses it until release or cancellation. Returning to the anchor keeps rectangular mode; it

--- a/docs/Architecture/Interaction-and-Navigation.md
+++ b/docs/Architecture/Interaction-and-Navigation.md
@@ -87,9 +87,32 @@ the same cell-selection tint; their extent distinguishes them.
 
 Moving the main-editor caret outside the selected table clears table-owned selection state.
 
+## Click-to-Caret Placement
+
+A click on a rendered cell opens it with the caret at the clicked point in the Markdown source, so clicking inside a
+bolded word lands between the same two letters once the syntax is visible.
+
+The rendering service returns HTML without character offsets. Placement therefore combines DOM hit testing with
+CodeMirror's Markdown syntax tree:
+
+1. `tableWidget/cellCaretHit.ts` reads the DOM caret before the rendered content is replaced. It flattens text,
+   counts `<br>` as a newline, and skips MathML.
+2. `tableRuntime/interaction/cellTextProjection.ts` projects visible source spans into text with a map back to
+   nested-editor offsets. It removes formatting delimiters, link destinations/titles, images, and HTML syntax.
+   Autolink text and inline-code contents remain visible. Pipe and line-break offsets use the existing cell codec.
+3. `clickCursorPlacement.ts` maps matching rendered/projected text directly. Literal text shown before asynchronous
+   rendering also maps directly. These paths do not use the alignment length or comparison limits.
+4. When rendering transforms the text, `shared/textAlignment.ts` aligns against the projection only. Hidden source
+   cannot become an anchor. Entities are omitted from the projection, so their decoded output uses neighboring
+   anchors. Unknown renderer extensions remain approximate; insufficient matches decline placement.
+
+The offset travels through the open-cell request to the nested editor. Pointerdown records the hit; pointerup applies
+it only after confirming a click. Drag selection discards it. Unresolved hits preserve the established selection
+fallback. Start/end hits retain the source-boundary policy, including surrounding Markdown delimiters.
+
 ## Pointer, Links, and Scrolling
 
-- Clicking activates a cell or updates the current cell selection.
+- Clicking activates a cell or updates the current cell selection, placing the caret where the click landed.
 - Mouse dragging selects a cell rectangle; touch and pen input retain native scrolling and tap behavior.
 - Drags near an edge auto-scroll the table or host scroll container. See
   [Table-Display.md](./Table-Display.md#host-scroll-modes).

--- a/docs/Architecture/Interaction-and-Navigation.md
+++ b/docs/Architecture/Interaction-and-Navigation.md
@@ -111,9 +111,11 @@ presses out of CodeMirror's default mouse handling without cancelling native bro
 focusable with `tabIndex=-1`, so focusing it does not reset the range through the outer editor's focus handler.
 
 While a drag stays in its cell, the browser owns selection. Pointerup reads both endpoints from the same rendered-text
-index and maps them through one projection/alignment, preserving direction. Both endpoints use the existing caret
-boundary policy: selecting an entire formatted word includes its Markdown delimiters. Unresolved hits preserve the
-established selection fallback.
+index and maps them through one projection/alignment, preserving direction. A range is mapped from the characters it
+covers rather than as two carets, so the source span runs from the first covered character to just past the last:
+Markdown syntax is included where the selection spans it and excluded at both ends otherwise. A range covering every
+rendered character takes the whole cell text, syntax included. Unresolved hits preserve the established selection
+fallback.
 
 Crossing into another cell after the movement threshold promotes the gesture to rectangular selection, clears native
 text selection, and suppresses it until release or cancellation. Returning to the anchor keeps rectangular mode; it

--- a/docs/Architecture/Interaction-and-Navigation.md
+++ b/docs/Architecture/Interaction-and-Navigation.md
@@ -111,7 +111,7 @@ The offset or range travels through the open-cell request to the nested editor. 
 
 Every press inside a widget is routed by `tableWidgetPressPlugin` in `tableWidget/tableWidgetInteractions.ts`, which
 returns one of three dispositions: left native, claimed from CodeMirror with the browser default intact, or consumed
-outright. A press on rendered text needs the middle one, which `EditorView.domEventHandlers` cannot express — a handler
+outright. A press on rendered text needs `claim`, which `EditorView.domEventHandlers` cannot express — a handler
 returning true has its event default-prevented too — so presses are dispatched from a capture listener and only clicks
 remain registered as handlers.
 

--- a/docs/Architecture/Interaction-and-Navigation.md
+++ b/docs/Architecture/Interaction-and-Navigation.md
@@ -106,14 +106,24 @@ CodeMirror's Markdown syntax tree:
    cannot become an anchor. Entities are omitted from the projection, so their decoded output uses neighboring
    anchors. Unknown renderer extensions remain approximate; insufficient matches decline placement.
 
-The offset travels through the open-cell request to the nested editor. Pointerdown records the hit; pointerup applies
-it only after confirming a click. Drag selection discards it. Unresolved hits preserve the established selection
-fallback. Start/end hits retain the source-boundary policy, including surrounding Markdown delimiters.
+The offset or range travels through the open-cell request to the nested editor. A capture listener keeps rendered-cell
+presses out of CodeMirror's default mouse handling without cancelling native browser selection. Rendered content is
+focusable with `tabIndex=-1`, so focusing it does not reset the range through the outer editor's focus handler.
+
+While a drag stays in its cell, the browser owns selection. Pointerup reads both endpoints from the same rendered-text
+index and maps them through one projection/alignment, preserving direction. Both endpoints use the existing caret
+boundary policy: selecting an entire formatted word includes its Markdown delimiters. Unresolved hits preserve the
+established selection fallback.
+
+Crossing into another cell after the movement threshold promotes the gesture to rectangular selection, clears native
+text selection, and suppresses it until release or cancellation. Returning to the anchor keeps rectangular mode; it
+does not restore the earlier text range. Active-editor drags retain their existing boundary margin and behavior.
 
 ## Pointer, Links, and Scrolling
 
 - Clicking activates a cell or updates the current cell selection, placing the caret where the click landed.
-- Mouse dragging selects a cell rectangle; touch and pen input retain native scrolling and tap behavior.
+- Mouse dragging within an inactive cell selects rendered text; dragging into another cell selects a rectangle.
+  Touch and pen input retain native scrolling and tap behavior.
 - Drags near an edge auto-scroll the table or host scroll container. See
   [Table-Display.md](./Table-Display.md#host-scroll-modes).
 - Links delegate to the content-script link opener and then to the main plugin.

--- a/docs/Architecture/Interaction-and-Navigation.md
+++ b/docs/Architecture/Interaction-and-Navigation.md
@@ -106,9 +106,14 @@ CodeMirror's Markdown syntax tree:
    cannot become an anchor. Entities are omitted from the projection, so their decoded output uses neighboring
    anchors. Unknown renderer extensions remain approximate; insufficient matches decline placement.
 
-The offset or range travels through the open-cell request to the nested editor. A capture listener keeps rendered-cell
-presses out of CodeMirror's default mouse handling without cancelling native browser selection. Rendered content is
-focusable with `tabIndex=-1`, so focusing it does not reset the range through the outer editor's focus handler.
+The offset or range travels through the open-cell request to the nested editor. Rendered content is focusable with
+`tabIndex=-1`, so focusing it does not reset the range through the outer editor's focus handler.
+
+Every press inside a widget is routed by `tableWidgetPressPlugin` in `tableWidget/tableWidgetInteractions.ts`, which
+returns one of three dispositions: left native, claimed from CodeMirror with the browser default intact, or consumed
+outright. A press on rendered text needs the middle one, which `EditorView.domEventHandlers` cannot express — a handler
+returning true has its event default-prevented too — so presses are dispatched from a capture listener and only clicks
+remain registered as handlers.
 
 While a drag stays in its cell, the browser owns selection. Pointerup reads both endpoints from the same rendered-text
 index and maps them through one projection/alignment, preserving direction. A range is mapped from the characters it

--- a/docs/Architecture/Interaction-and-Navigation.md
+++ b/docs/Architecture/Interaction-and-Navigation.md
@@ -104,9 +104,10 @@ CodeMirror's Markdown syntax tree:
 
 The offset or range travels through the open-cell request to the nested editor.
 
-Every press inside a widget is routed by `tableWidgetPressPlugin` in `tableWidget/tableWidgetInteractions.ts`, which
-returns one of three dispositions: left native, claimed from CodeMirror with the browser default intact, or consumed
-outright. It runs in the capture phase because `EditorView.domEventHandlers` cannot express the middle one.
+Every press inside a widget is routed by `handleWidgetPress` in `tableWidget/tableWidgetInteractions.ts`, registered
+for `pointerdown` and `mousedown` alongside the click handler. It reports whether it took the press. CodeMirror stops
+running handlers for an event once one returns true and appends its own built-ins after every plugin's, so a press the
+router takes reaches neither those nor `closeOnOutsideMouseDown`.
 
 A press on a rendered cell is consumed, and the gesture draws the DOM selection itself from the caret each pointer
 move hit-tests. The browser latches its own selection drag at mousedown, and nothing cancels it afterwards: left

--- a/docs/Architecture/Interaction-and-Navigation.md
+++ b/docs/Architecture/Interaction-and-Navigation.md
@@ -123,6 +123,12 @@ Crossing into another cell after the movement threshold promotes the gesture to 
 text selection, and suppresses it until release or cancellation. Returning to the anchor keeps rectangular mode; it
 does not restore the earlier text range. Active-editor drags retain their existing boundary margin and behavior.
 
+Only another cell promotes a drag. Leaving the table promotes nothing — every other cell is inside it, so an exit is
+overshoot rather than intent — and the gesture stays a text selection. An endpoint that landed outside the cell is
+clamped to the end the drag left by, so dragging out of the table selects to the end of the cell; at least one endpoint
+must still resolve inside it. Once a rectangle is being dragged, a pointer outside the table tracks the nearest cell as
+before.
+
 ## Pointer, Links, and Scrolling
 
 - Clicking activates a cell or updates the current cell selection, placing the caret where the click landed.

--- a/docs/Architecture/Table-Display.md
+++ b/docs/Architecture/Table-Display.md
@@ -101,8 +101,7 @@ standing in for that ground would band a selected rectangle row by row.
 
 Text dragged out inside a rendered cell keeps the browser's own selection highlight until the cell opens.
 `renderedTextSelectionTheme.ts` paints it in Joplin's selection colour, carved out of the widget-wide `::selection`
-reset in `wholeTableSelectionVisuals.ts`: its selectors skip tables the main editor has selected whole and the open
-cell, whose selections those modules and the nested editor already draw.
+reset in `wholeTableSelectionVisuals.ts`.
 
 ## Host Scroll Modes
 

--- a/docs/Architecture/Table-Display.md
+++ b/docs/Architecture/Table-Display.md
@@ -99,6 +99,11 @@ does not affect HTML tables rendered inside cell Markdown. Selected cells are ex
 selector outweighs the selection fill, and `selectionTint.ts` solves its tint against a known ground, so a stripe
 standing in for that ground would band a selected rectangle row by row.
 
+Text dragged out inside a rendered cell keeps the browser's own selection highlight until the cell opens.
+`renderedTextSelectionTheme.ts` paints it in Joplin's selection colour, carved out of the widget-wide `::selection`
+reset in `wholeTableSelectionVisuals.ts`: its selectors skip tables the main editor has selected whole and the open
+cell, whose selections those modules and the nested editor already draw.
+
 ## Host Scroll Modes
 
 Joplin hosts the editor two ways, and internal and external scrolling are mutually exclusive:

--- a/src/contentScript/__tests__/cellTextNormalization.test.ts
+++ b/src/contentScript/__tests__/cellTextNormalization.test.ts
@@ -69,6 +69,25 @@ describe('rootToLocalOffsets', () => {
     /** The offsets a plain scan of `rootText` would need, character by character. */
     const displayOffsets = (rootText: string): number[] => Array.from(rootToLocalOffsets(rootText));
 
+    it('maps the only offset in an empty cell to zero', () => {
+        expect(displayOffsets('')).toEqual([0]);
+    });
+
+    it('maps consecutive substitutions through the end of the cell', () => {
+        expect(displayOffsets(String.raw`<br>\|<br>`)).toEqual([0, 0, 0, 0, 1, 1, 2, 2, 2, 2, 3]);
+    });
+
+    it.each([
+        { root: String.raw`a\\|b`, offsets: [0, 1, 2, 2, 3, 4] },
+        { root: String.raw`a\\\|b`, offsets: [0, 1, 2, 3, 3, 4, 5] },
+    ])('preserves backslashes before the final pipe escape in $root', ({ root, offsets }) => {
+        expect(displayOffsets(root)).toEqual(offsets);
+    });
+
+    it('counts emoji as UTF-16 code units on both sides of a substitution', () => {
+        expect(displayOffsets('😀<br>😀')).toEqual([0, 1, 2, 2, 2, 2, 3, 4, 5]);
+    });
+
     it('maps stored text one to one where nothing is spelled out', () => {
         expect(displayOffsets('abc')).toEqual([0, 1, 2, 3]);
     });

--- a/src/contentScript/__tests__/cellTextNormalization.test.ts
+++ b/src/contentScript/__tests__/cellTextNormalization.test.ts
@@ -69,25 +69,6 @@ describe('rootToLocalOffsets', () => {
     /** The offsets a plain scan of `rootText` would need, character by character. */
     const displayOffsets = (rootText: string): number[] => Array.from(rootToLocalOffsets(rootText));
 
-    it('maps the only offset in an empty cell to zero', () => {
-        expect(displayOffsets('')).toEqual([0]);
-    });
-
-    it('maps consecutive substitutions through the end of the cell', () => {
-        expect(displayOffsets(String.raw`<br>\|<br>`)).toEqual([0, 0, 0, 0, 1, 1, 2, 2, 2, 2, 3]);
-    });
-
-    it.each([
-        { root: String.raw`a\\|b`, offsets: [0, 1, 2, 2, 3, 4] },
-        { root: String.raw`a\\\|b`, offsets: [0, 1, 2, 3, 3, 4, 5] },
-    ])('preserves backslashes before the final pipe escape in $root', ({ root, offsets }) => {
-        expect(displayOffsets(root)).toEqual(offsets);
-    });
-
-    it('counts emoji as UTF-16 code units on both sides of a substitution', () => {
-        expect(displayOffsets('😀<br>😀')).toEqual([0, 1, 2, 2, 2, 2, 3, 4, 5]);
-    });
-
     it('maps stored text one to one where nothing is spelled out', () => {
         expect(displayOffsets('abc')).toEqual([0, 1, 2, 3]);
     });
@@ -113,5 +94,37 @@ describe('rootToLocalOffsets', () => {
         const rootText = String.raw`a<br>b`;
 
         expect(rootToLocalOffsets(rootText)[rootText.length]).toBe(unsanitizeRootText(rootText).length);
+    });
+
+    it('maps the only offset in an empty cell to zero', () => {
+        expect(displayOffsets('')).toEqual([0]);
+    });
+
+    it('maps consecutive substitutions through the end of the cell', () => {
+        expect(displayOffsets(String.raw`<br>\|<br>`)).toEqual([0, 0, 0, 0, 1, 1, 2, 2, 2, 2, 3]);
+    });
+
+    it.each([
+        { root: String.raw`a\\|b`, offsets: [0, 1, 2, 2, 3, 4] },
+        { root: String.raw`a\\\|b`, offsets: [0, 1, 2, 3, 3, 4, 5] },
+    ])('preserves backslashes before the final pipe escape in $root', ({ root, offsets }) => {
+        expect(displayOffsets(root)).toEqual(offsets);
+    });
+
+    it('counts emoji as UTF-16 code units on both sides of a substitution', () => {
+        expect(displayOffsets('😀<br>😀')).toEqual([0, 1, 2, 2, 2, 2, 3, 4, 5]);
+    });
+
+    it.each([
+        { root: 'a<br', offsets: [0, 1, 2, 3, 4] },
+        { root: 'a\\', offsets: [0, 1, 2] },
+    ])('leaves a spelling the cell breaks off partway through as text in $root', ({ root, offsets }) => {
+        expect(displayOffsets(root)).toEqual(offsets);
+        expect(unsanitizeRootText(root)).toBe(root);
+    });
+
+    it('matches a stored spelling exactly, so an uppercase break tag stays text', () => {
+        expect(displayOffsets('a<BR>b')).toEqual([0, 1, 2, 3, 4, 5, 6]);
+        expect(unsanitizeRootText('a<BR>b')).toBe('a<BR>b');
     });
 });

--- a/src/contentScript/__tests__/cellTextNormalization.test.ts
+++ b/src/contentScript/__tests__/cellTextNormalization.test.ts
@@ -3,6 +3,7 @@ import {
     convertNewlinesToBr,
     escapeUnescapedPipes,
     normalizeBrTags,
+    rootToLocalOffsets,
     sanitizeLocalText,
     unsanitizeRootText,
 } from '../shared/cellTextNormalization';
@@ -56,5 +57,42 @@ describe('sanitizeLocalText / unsanitizeRootText', () => {
 
     it('converts root markdown-safe cell text back to local display text', () => {
         expect(unsanitizeRootText(String.raw`a<br>b\|c`)).toBe('a\nb|c');
+    });
+
+    it('escapes a backslash run down to the pipe it ends with', () => {
+        // The two spellings the offset map has to agree with `unsanitizeRootText` about.
+        expect(unsanitizeRootText(String.raw`a\\|b`)).toBe(String.raw`a\|b`);
+    });
+});
+
+describe('rootToLocalOffsets', () => {
+    /** The offsets a plain scan of `rootText` would need, character by character. */
+    const displayOffsets = (rootText: string): number[] => Array.from(rootToLocalOffsets(rootText));
+
+    it('maps stored text one to one where nothing is spelled out', () => {
+        expect(displayOffsets('abc')).toEqual([0, 1, 2, 3]);
+    });
+
+    it('lands every offset in the same place the display text puts it', () => {
+        const rootText = String.raw`a<br>b\|c`;
+
+        // `a\nb|c`: the offsets after each stored spelling shift by what it saves.
+        expect(displayOffsets(rootText)).toEqual([0, 1, 1, 1, 1, 2, 3, 3, 4, 5]);
+        expect(unsanitizeRootText(rootText)).toHaveLength(5);
+    });
+
+    it('gives the start of what a spelling displays as for offsets inside it', () => {
+        // The middle of `<br>` has nowhere else to be: it is one newline in the nested editor.
+        const offsets = rootToLocalOffsets('<br>x');
+
+        expect(offsets[1]).toBe(0);
+        expect(offsets[3]).toBe(0);
+        expect(offsets[4]).toBe(1);
+    });
+
+    it('ends one past the display text, so a range can reach the end of the cell', () => {
+        const rootText = String.raw`a<br>b`;
+
+        expect(rootToLocalOffsets(rootText)[rootText.length]).toBe(unsanitizeRootText(rootText).length);
     });
 });

--- a/src/contentScript/__tests__/clickCursorPlacement.test.ts
+++ b/src/contentScript/__tests__/clickCursorPlacement.test.ts
@@ -242,7 +242,7 @@ function offsetsOf(pos: InitialCursorPos, expected: string): LocalSelection {
         throw new Error(`Expected ${expected}, got ${pos}`);
     }
 
-    return pos.localSelection;
+    return pos;
 }
 
 function placement(doc: string, coords: CellCoords, hit: RenderedCaretHit | null): string {
@@ -442,7 +442,8 @@ describe('syntax-aware click placement', () => {
         const doc = ['', '| H1 |', '| --- |', `| **${word}** |`, ''].join('\n');
         const { state, resolvedCell } = resolveCell(doc, { section: 'body', row: 0, col: 0 });
         expect(resolveClickCursorPos(state, resolvedCell, { renderedText: word, renderedOffset: 1200 })).toEqual({
-            localSelection: { anchor: 1202, head: 1202 },
+            anchor: 1202,
+            head: 1202,
         });
     });
 
@@ -468,7 +469,7 @@ describe('syntax-aware click placement', () => {
         } as unknown as MouseEvent;
         expect(handleWidgetPress(view, event)).toBe(true);
         const request = getPendingOpenCellRequest(view.state);
-        expect(request?.initialCursorPos).toEqual({ localSelection: { anchor: 9, head: 9 } });
+        expect(request?.initialCursorPos).toEqual({ anchor: 9, head: 9 });
         expect(resolveInitialLocalSelection({ anchor: 0, head: 0 }, '**markdown**', request?.initialCursorPos)).toEqual(
             { anchor: 9, head: 9 }
         );
@@ -483,7 +484,7 @@ describe('rendered range mapping', () => {
         const { state, resolvedCell } = resolveCell(doc, cell);
         expect(
             resolveRenderedSelection(state, resolvedCell, { renderedText: 'hello & world', anchor: 11, head: 2 })
-        ).toEqual({ localSelection: { anchor: 19, head: 4 } });
+        ).toEqual({ anchor: 19, head: 4 });
     });
 
     it('leaves the delimiters of a fully selected formatted word outside both ends', () => {

--- a/src/contentScript/__tests__/clickCursorPlacement.test.ts
+++ b/src/contentScript/__tests__/clickCursorPlacement.test.ts
@@ -1,9 +1,10 @@
 /** @vitest-environment jsdom */
-import { describe, it, expect, vi } from 'vitest';
+import { afterEach, describe, it, expect, vi } from 'vitest';
 import { CLASS_CELL_CONTENT } from '../shared/tableDomClasses';
 import {
     indexRenderedText,
     flatOffsetFromDomPosition,
+    readRenderedSelectionHit,
     type RenderedCaretHit,
     type RenderedSelectionHit,
 } from '../tableWidget/cellCaretHit';
@@ -87,6 +88,78 @@ describe('flatOffsetFromDomPosition', () => {
         const index = indexRenderedText(contentElement('text'));
 
         expect(flatOffsetFromDomPosition(index, document.createElement('div'), 0)).toBeNull();
+    });
+});
+
+/** A cell in the document, so a selection can genuinely run past it into the page. */
+function mountedCell(html: string): HTMLElement {
+    const cell = document.createElement('td');
+    cell.appendChild(contentElement(html));
+    const row = document.createElement('tr');
+    row.appendChild(cell);
+    const body = document.createElement('tbody');
+    body.appendChild(row);
+    const table = document.createElement('table');
+    table.appendChild(body);
+    document.body.appendChild(table);
+    return cell;
+}
+
+/** Text outside the table, placed either side of it in document order. */
+function pageText(data: string, where: 'before' | 'after'): Text {
+    const paragraph = document.createElement('p');
+    paragraph.textContent = data;
+    document.body[where === 'before' ? 'prepend' : 'append'](paragraph);
+    return paragraph.firstChild as Text;
+}
+
+function select(anchorNode: Node, anchorOffset: number, focusNode: Node, focusOffset: number): void {
+    const selection = document.getSelection();
+    if (!selection) {
+        throw new Error('Expected the test document to have a selection');
+    }
+    selection.setBaseAndExtent(anchorNode, anchorOffset, focusNode, focusOffset);
+}
+
+describe('readRenderedSelectionHit', () => {
+    afterEach(() => {
+        document.getSelection()?.removeAllRanges();
+        document.body.replaceChildren();
+    });
+
+    it('clamps an endpoint the drag carried out of the cell to the end it left by', () => {
+        const cell = mountedCell('see <strong>the</strong> docs');
+        select(textNode(cell, 'the'), 1, pageText('below the table', 'after'), 5);
+
+        expect(readRenderedSelectionHit(cell)).toEqual({ renderedText: 'see the docs', anchor: 5, head: 12 });
+    });
+
+    it('clamps a backward drag out of the cell to its start, keeping the direction', () => {
+        const cell = mountedCell('see <strong>the</strong> docs');
+        select(textNode(cell, 'the'), 1, pageText('above the table', 'before'), 5);
+
+        expect(readRenderedSelectionHit(cell)).toEqual({ renderedText: 'see the docs', anchor: 5, head: 0 });
+    });
+
+    it('declines a selection with neither endpoint in the cell', () => {
+        const cell = mountedCell('see <strong>the</strong> docs');
+        select(pageText('above the table', 'before'), 0, pageText('below the table', 'after'), 5);
+
+        expect(readRenderedSelectionHit(cell)).toBeNull();
+    });
+
+    it('declines an endpoint inside a formula, whose text is not its source', () => {
+        const cell = mountedCell('a <math><mi>x</mi></math> b');
+        select(textNode(cell, 'a '), 0, textNode(cell, 'x'), 1);
+
+        expect(readRenderedSelectionHit(cell)).toBeNull();
+    });
+
+    it('declines a collapsed selection, which is a caret rather than a range', () => {
+        const cell = mountedCell('see <strong>the</strong> docs');
+        select(textNode(cell, 'the'), 1, textNode(cell, 'the'), 1);
+
+        expect(readRenderedSelectionHit(cell)).toBeNull();
     });
 });
 

--- a/src/contentScript/__tests__/clickCursorPlacement.test.ts
+++ b/src/contentScript/__tests__/clickCursorPlacement.test.ts
@@ -437,7 +437,7 @@ describe('syntax-aware click placement', () => {
         expect(placement(doc, { section: 'body', row: 0, col: 0 }, { renderedText, renderedOffset })).toBe(expected);
     });
 
-    it('directly maps long formatted cells beyond the alignment budget', () => {
+    it('directly maps long formatted cells beyond the alignment length limit', () => {
         const word = 'a'.repeat(1500);
         const doc = ['', '| H1 |', '| --- |', `| **${word}** |`, ''].join('\n');
         const { state, resolvedCell } = resolveCell(doc, { section: 'body', row: 0, col: 0 });

--- a/src/contentScript/__tests__/clickCursorPlacement.test.ts
+++ b/src/contentScript/__tests__/clickCursorPlacement.test.ts
@@ -1,7 +1,12 @@
 /** @vitest-environment jsdom */
 import { describe, it, expect, vi } from 'vitest';
 import { CLASS_CELL_CONTENT } from '../shared/tableDomClasses';
-import { indexRenderedText, flatOffsetFromDomPosition, type RenderedCaretHit } from '../tableWidget/cellCaretHit';
+import {
+    indexRenderedText,
+    flatOffsetFromDomPosition,
+    type RenderedCaretHit,
+    type RenderedSelectionHit,
+} from '../tableWidget/cellCaretHit';
 import { resolveClickCursorPos, resolveRenderedSelection } from '../tableRuntime/interaction/clickCursorPlacement';
 import { createResolvedActiveCell, type ResolvedActiveCell } from '../tableRuntime/activeCell/resolvedActiveCell';
 import { resolveTableContextAtPos } from '../tableRuntime/tableResolution';
@@ -119,6 +124,27 @@ function placement(doc: string, coords: CellCoords, hit: RenderedCaretHit | null
         throw new Error(`Expected an offset placement, got ${pos}`);
     }
     return `${cellText.slice(0, pos.localOffset)}|${cellText.slice(pos.localOffset)}`;
+}
+
+/** As {@link placement}, with the mapped range bracketed rather than a caret marked. */
+function rangePlacement(doc: string, coords: CellCoords, hit: RenderedSelectionHit): string {
+    const { state, resolvedCell } = resolveCell(doc, coords);
+    const cellText = unsanitizeRootText(state.doc.sliceString(resolvedCell.editableFrom, resolvedCell.editableTo));
+    const pos = resolveRenderedSelection(state, resolvedCell, hit);
+    if (pos === undefined) {
+        return '<mirrored>';
+    }
+    if (typeof pos !== 'object' || !('localSelection' in pos)) {
+        throw new Error(`Expected a range placement, got ${JSON.stringify(pos)}`);
+    }
+    const { anchor, head } = pos.localSelection;
+    const [from, to] = anchor <= head ? [anchor, head] : [head, anchor];
+    return `${cellText.slice(0, from)}[${cellText.slice(from, to)}]${cellText.slice(to)}`;
+}
+
+/** A one-cell table whose only body cell holds `source`. */
+function cellDoc(source: string): string {
+    return ['', '| H1 |', '| --- |', `| ${source} |`, ''].join('\n');
 }
 
 describe('resolveClickCursorPos', () => {
@@ -320,11 +346,55 @@ describe('syntax-aware click placement', () => {
 });
 
 describe('rendered range mapping', () => {
+    const cell: CellCoords = { section: 'body', row: 0, col: 0 };
+
     it('maps a backward range through the alignment fallback', () => {
         const doc = ['', '| H1 |', '| --- |', '| **hello** &amp; world |', ''].join('\n');
-        const { state, resolvedCell } = resolveCell(doc, { section: 'body', row: 0, col: 0 });
+        const { state, resolvedCell } = resolveCell(doc, cell);
         expect(
             resolveRenderedSelection(state, resolvedCell, { renderedText: 'hello & world', anchor: 11, head: 2 })
         ).toEqual({ localSelection: { anchor: 19, head: 4 } });
+    });
+
+    it('leaves the delimiters of a fully selected formatted word outside both ends', () => {
+        expect(
+            rangePlacement(cellDoc('test **bold text** aaa'), cell, {
+                renderedText: 'test bold text aaa',
+                anchor: 5,
+                head: 14,
+            })
+        ).toBe('test **[bold text]** aaa');
+    });
+
+    it('maps the same range the same way when it was dragged backwards', () => {
+        expect(
+            rangePlacement(cellDoc('test **bold text** aaa'), cell, {
+                renderedText: 'test bold text aaa',
+                anchor: 14,
+                head: 5,
+            })
+        ).toBe('test **[bold text]** aaa');
+    });
+
+    it('takes the syntax a range spans over rather than the syntax around it', () => {
+        expect(
+            rangePlacement(cellDoc('test **bold text** aaa'), cell, {
+                renderedText: 'test bold text aaa',
+                anchor: 2,
+                head: 12,
+            })
+        ).toBe('te[st **bold te]xt** aaa');
+    });
+
+    it('selects a link’s label without its target', () => {
+        expect(
+            rangePlacement(cellDoc('a [link](http://x) b'), cell, { renderedText: 'a link b', anchor: 2, head: 6 })
+        ).toBe('a [[link]](http://x) b');
+    });
+
+    it('takes the whole cell text when the range covers every rendered character', () => {
+        expect(rangePlacement(cellDoc('**bold**'), cell, { renderedText: 'bold', anchor: 0, head: 4 })).toBe(
+            '[**bold**]'
+        );
     });
 });

--- a/src/contentScript/__tests__/clickCursorPlacement.test.ts
+++ b/src/contentScript/__tests__/clickCursorPlacement.test.ts
@@ -5,6 +5,8 @@ import {
     indexRenderedText,
     flatOffsetFromDomPosition,
     readRenderedSelectionHit,
+    setRenderedTextSelection,
+    type RenderedCaretDomHit,
     type RenderedCaretHit,
     type RenderedSelectionHit,
 } from '../tableWidget/cellCaretHit';
@@ -121,6 +123,43 @@ function select(anchorNode: Node, anchorOffset: number, focusNode: Node, focusOf
     }
     selection.setBaseAndExtent(anchorNode, anchorOffset, focusNode, focusOffset);
 }
+
+/**
+ * A hit as `readRenderedCaretHit` reports one. Painting reads only the DOM endpoint, so the
+ * flattened half carries no weight here.
+ */
+function domHit(node: Node, offset: number): RenderedCaretDomHit {
+    return { renderedText: '', renderedOffset: 0, node, offset };
+}
+
+describe('setRenderedTextSelection', () => {
+    afterEach(() => {
+        document.getSelection()?.removeAllRanges();
+        document.body.replaceChildren();
+    });
+
+    it('paints the range between the two endpoints the hit test read', () => {
+        const cell = mountedCell('one<strong>two</strong><br>three');
+        const content = cell.firstElementChild as HTMLElement;
+        const plain = content.firstChild!;
+        const bold = content.querySelector('strong')!.firstChild!;
+
+        setRenderedTextSelection(cell, domHit(plain, 2), domHit(bold, 3));
+
+        expect(document.getSelection()!.toString()).toBe('etwo');
+    });
+
+    it('declines an endpoint the cell no longer contains', () => {
+        const cell = mountedCell('old text');
+        const content = cell.firstElementChild as HTMLElement;
+        const stale = content.firstChild!;
+        content.replaceChildren(document.createTextNode('new text'));
+
+        setRenderedTextSelection(cell, domHit(stale, 1), domHit(content.firstChild!, 4));
+
+        expect(document.getSelection()!.rangeCount).toBe(0);
+    });
+});
 
 describe('readRenderedSelectionHit', () => {
     afterEach(() => {

--- a/src/contentScript/__tests__/clickCursorPlacement.test.ts
+++ b/src/contentScript/__tests__/clickCursorPlacement.test.ts
@@ -4,7 +4,7 @@ import { CLASS_CELL_CONTENT } from '../shared/tableDomClasses';
 import {
     indexRenderedText,
     flatOffsetFromDomPosition,
-    readRenderedSelectionHit,
+    readRenderedCaretHit,
     setRenderedTextSelection,
     type RenderedCaretDomHit,
     type RenderedCaretHit,
@@ -94,7 +94,7 @@ describe('flatOffsetFromDomPosition', () => {
     });
 });
 
-/** A cell in the document, so a selection can genuinely run past it into the page. */
+/** A cell in the document, so hit tests and painting have a tree to resolve against. */
 function mountedCell(html: string): HTMLElement {
     const cell = document.createElement('td');
     cell.appendChild(contentElement(html));
@@ -106,22 +106,6 @@ function mountedCell(html: string): HTMLElement {
     table.appendChild(body);
     document.body.appendChild(table);
     return cell;
-}
-
-/** Text outside the table, placed either side of it in document order. */
-function pageText(data: string, where: 'before' | 'after'): Text {
-    const paragraph = document.createElement('p');
-    paragraph.textContent = data;
-    document.body[where === 'before' ? 'prepend' : 'append'](paragraph);
-    return paragraph.firstChild as Text;
-}
-
-function select(anchorNode: Node, anchorOffset: number, focusNode: Node, focusOffset: number): void {
-    const selection = document.getSelection();
-    if (!selection) {
-        throw new Error('Expected the test document to have a selection');
-    }
-    selection.setBaseAndExtent(anchorNode, anchorOffset, focusNode, focusOffset);
 }
 
 /**
@@ -161,45 +145,71 @@ describe('setRenderedTextSelection', () => {
     });
 });
 
-describe('readRenderedSelectionHit', () => {
+/** Places the content box of `cell` so a press can be aimed inside or outside it. */
+function placeContent(cell: HTMLElement, rect: { left: number; top: number; right: number; bottom: number }): void {
+    const content = cell.firstElementChild as HTMLElement;
+    vi.spyOn(content, 'getBoundingClientRect').mockReturnValue({
+        ...rect,
+        width: rect.right - rect.left,
+        height: rect.bottom - rect.top,
+        x: rect.left,
+        y: rect.top,
+        toJSON: () => ({}),
+    } as DOMRect);
+}
+
+/** The caret the browser reports for any point, as Chromium and the Joplin webviews spell it. */
+function stubCaretFromPoint(node: Node | null, offset = 0): void {
+    Object.defineProperty(document, 'caretRangeFromPoint', {
+        configurable: true,
+        value: () => {
+            if (!node) {
+                return null;
+            }
+            const range = document.createRange();
+            range.setStart(node, offset);
+            range.collapse(true);
+            return range;
+        },
+    });
+}
+
+describe('readRenderedCaretHit', () => {
     afterEach(() => {
-        document.getSelection()?.removeAllRanges();
+        Reflect.deleteProperty(document, 'caretRangeFromPoint');
         document.body.replaceChildren();
     });
 
-    it('clamps an endpoint the drag carried out of the cell to the end it left by', () => {
+    it('reads the caret the browser reports inside the content', () => {
         const cell = mountedCell('see <strong>the</strong> docs');
-        select(textNode(cell, 'the'), 1, pageText('below the table', 'after'), 5);
+        placeContent(cell, { left: 0, top: 0, right: 100, bottom: 20 });
+        stubCaretFromPoint(textNode(cell, 'the'), 1);
 
-        expect(readRenderedSelectionHit(cell)).toEqual({ renderedText: 'see the docs', anchor: 5, head: 12 });
+        expect(readRenderedCaretHit(cell, 40, 10)).toMatchObject({ renderedText: 'see the docs', renderedOffset: 5 });
     });
 
-    it('clamps a backward drag out of the cell to its start, keeping the direction', () => {
+    it('clamps a press past the content in reading order to the end of its text', () => {
         const cell = mountedCell('see <strong>the</strong> docs');
-        select(textNode(cell, 'the'), 1, pageText('above the table', 'before'), 5);
+        placeContent(cell, { left: 0, top: 0, right: 100, bottom: 20 });
+        stubCaretFromPoint(null);
 
-        expect(readRenderedSelectionHit(cell)).toEqual({ renderedText: 'see the docs', anchor: 5, head: 0 });
+        expect(readRenderedCaretHit(cell, 40, 60)).toMatchObject({ renderedOffset: 12 });
     });
 
-    it('declines a selection with neither endpoint in the cell', () => {
+    it('clamps a press before the content to its start', () => {
         const cell = mountedCell('see <strong>the</strong> docs');
-        select(pageText('above the table', 'before'), 0, pageText('below the table', 'after'), 5);
+        placeContent(cell, { left: 0, top: 40, right: 100, bottom: 60 });
+        stubCaretFromPoint(null);
 
-        expect(readRenderedSelectionHit(cell)).toBeNull();
+        expect(readRenderedCaretHit(cell, 40, 10)).toMatchObject({ renderedOffset: 0 });
     });
 
-    it('declines an endpoint inside a formula, whose text is not its source', () => {
+    it('declines a press inside a formula, whose text is not its source', () => {
         const cell = mountedCell('a <math><mi>x</mi></math> b');
-        select(textNode(cell, 'a '), 0, textNode(cell, 'x'), 1);
+        placeContent(cell, { left: 0, top: 0, right: 100, bottom: 20 });
+        stubCaretFromPoint(textNode(cell, 'x'), 1);
 
-        expect(readRenderedSelectionHit(cell)).toBeNull();
-    });
-
-    it('declines a collapsed selection, which is a caret rather than a range', () => {
-        const cell = mountedCell('see <strong>the</strong> docs');
-        select(textNode(cell, 'the'), 1, textNode(cell, 'the'), 1);
-
-        expect(readRenderedSelectionHit(cell)).toBeNull();
+        expect(readRenderedCaretHit(cell, 40, 10)).toBeNull();
     });
 });
 

--- a/src/contentScript/__tests__/clickCursorPlacement.test.ts
+++ b/src/contentScript/__tests__/clickCursorPlacement.test.ts
@@ -1,0 +1,320 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect, vi } from 'vitest';
+import { CLASS_CELL_CONTENT } from '../shared/tableDomClasses';
+import { indexRenderedText, flatOffsetFromDomPosition, type RenderedCaretHit } from '../tableWidget/cellCaretHit';
+import { resolveClickCursorPos } from '../tableRuntime/interaction/clickCursorPlacement';
+import { createResolvedActiveCell, type ResolvedActiveCell } from '../tableRuntime/activeCell/resolvedActiveCell';
+import { resolveTableContextAtPos } from '../tableRuntime/tableResolution';
+import { isCellTextOffset } from '../shared/cursorPlacement';
+import type { CellCoords } from '../tableModel/types';
+import { unsanitizeRootText } from '../shared/cellTextNormalization';
+import { handleTableInteraction } from '../tableWidget/tableWidgetInteractions';
+import { getPendingOpenCellRequest } from '../tableRuntime/openCellRequest';
+import { resolveInitialLocalSelection } from '../nestedEditor/nestedEditorSelection';
+import { createInteractiveTableHarness } from './interactiveTableTestHarness';
+import { createMarkdownState } from './testMarkdownState';
+
+function contentElement(html: string): HTMLElement {
+    const content = document.createElement('div');
+    content.className = CLASS_CELL_CONTENT;
+    content.innerHTML = html;
+    return content;
+}
+
+/** Locates a text node by its content, so tests can name a caret without walking the tree. */
+function textNode(root: HTMLElement, data: string): Text {
+    const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+    let node = walker.nextNode();
+    while (node) {
+        if ((node as Text).data === data) {
+            return node as Text;
+        }
+        node = walker.nextNode();
+    }
+    throw new Error(`No text node with data ${JSON.stringify(data)}`);
+}
+
+describe('indexRenderedText', () => {
+    it('flattens nested inline markup into the text a reader sees', () => {
+        expect(indexRenderedText(contentElement('see <strong>the</strong> <code>docs</code>')).text).toBe(
+            'see the docs'
+        );
+    });
+
+    it('counts a line break as the single newline it stands for in the cell text', () => {
+        // A cell newline survives its GFM row as `<br>`, and the nested editor shows it as `\n`.
+        expect(indexRenderedText(contentElement('one<br>two')).text).toBe('one\ntwo');
+    });
+
+    it('skips MathML, whose text transcribes the formula rather than its source', () => {
+        const index = indexRenderedText(contentElement('a <math><mi>x</mi></math> b'));
+        expect(index.text).toBe('a  b');
+    });
+
+    it('contributes nothing for an image', () => {
+        expect(indexRenderedText(contentElement('a<img src="x.png" alt="pic">b')).text).toBe('ab');
+    });
+});
+
+describe('flatOffsetFromDomPosition', () => {
+    it('offsets into a text node from where its own text begins', () => {
+        const content = contentElement('see <strong>the</strong> docs');
+        const index = indexRenderedText(content);
+
+        expect(flatOffsetFromDomPosition(index, textNode(content, 'the'), 2)).toBe(6);
+    });
+
+    it('resolves a caret in an element to the start of the child it precedes', () => {
+        const content = contentElement('see <strong>the</strong> docs');
+        const index = indexRenderedText(content);
+
+        expect(flatOffsetFromDomPosition(index, content, 1)).toBe(4);
+    });
+
+    it('resolves a caret past an element’s last child to the end of its text', () => {
+        const content = contentElement('see <strong>the</strong> docs');
+        const index = indexRenderedText(content);
+
+        expect(flatOffsetFromDomPosition(index, content, content.childNodes.length)).toBe('see the docs'.length);
+    });
+
+    it('declines a node it never indexed', () => {
+        const index = indexRenderedText(contentElement('text'));
+
+        expect(flatOffsetFromDomPosition(index, document.createElement('div'), 0)).toBeNull();
+    });
+});
+
+const CANONICAL_DOC = ['', '| H1 | H2 |', '| --- | --- |', '| **markdown** | b |', ''].join('\n');
+
+function resolveCell(
+    doc: string,
+    coords: CellCoords
+): { state: ReturnType<typeof createMarkdownState>; resolvedCell: ResolvedActiveCell } {
+    const state = createMarkdownState(doc);
+    const ctx = resolveTableContextAtPos(state, doc.indexOf('|'));
+    if (!ctx) {
+        throw new Error('Expected a table context');
+    }
+    const resolvedCell = createResolvedActiveCell({ ctx, coords });
+    if (!resolvedCell) {
+        throw new Error('Expected a resolved cell');
+    }
+    return { state, resolvedCell };
+}
+
+/**
+ * The placement split into the cell's local text - the text the nested editor opens on,
+ * with `<br>` back as a newline and pipes unescaped - so failures read as text and the
+ * coordinate system the offset is expressed in stays visible.
+ */
+function placement(doc: string, coords: CellCoords, hit: RenderedCaretHit | null): string {
+    const { state, resolvedCell } = resolveCell(doc, coords);
+    const cellText = unsanitizeRootText(state.doc.sliceString(resolvedCell.editableFrom, resolvedCell.editableTo));
+    const pos = resolveClickCursorPos(state, resolvedCell, hit);
+    if (pos === undefined) {
+        return '<mirrored>';
+    }
+    if (!isCellTextOffset(pos)) {
+        throw new Error(`Expected an offset placement, got ${pos}`);
+    }
+    return `${cellText.slice(0, pos.localOffset)}|${cellText.slice(pos.localOffset)}`;
+}
+
+describe('resolveClickCursorPos', () => {
+    const boldCell: CellCoords = { section: 'body', row: 0, col: 0 };
+
+    it('places the caret at the clicked point inside the cell’s Markdown source', () => {
+        // The reported case: clicking between "w" and "n" of a bolded "markdown".
+        expect(placement(CANONICAL_DOC, boldCell, { renderedText: 'markdown', renderedOffset: 7 })).toBe(
+            '**markdow|n**'
+        );
+    });
+
+    it('places the caret in a plain cell one-to-one', () => {
+        expect(
+            placement(CANONICAL_DOC, { section: 'body', row: 0, col: 1 }, { renderedText: 'b', renderedOffset: 1 })
+        ).toBe('b|');
+    });
+
+    it('places repeated text on the correct side of an emphasis boundary', () => {
+        const doc = ['', '| H1 |', '| --- |', '| a**aa** |', ''].join('\n');
+
+        expect(placement(doc, { section: 'body', row: 0, col: 0 }, { renderedText: 'aaa', renderedOffset: 1 })).toBe(
+            'a**|aa**'
+        );
+    });
+
+    it('places a caret across a line break, which the source stores as <br>', () => {
+        const doc = ['', '| H1 |', '| --- |', '| one<br>two |', ''].join('\n');
+
+        expect(
+            placement(doc, { section: 'body', row: 0, col: 0 }, { renderedText: 'one\ntwo', renderedOffset: 5 })
+        ).toBe('one\nt|wo');
+    });
+
+    it('places a caret past a pipe, which the source stores escaped', () => {
+        const doc = ['', '| H1 |', '| --- |', '| a \\| b |', ''].join('\n');
+
+        expect(placement(doc, { section: 'body', row: 0, col: 0 }, { renderedText: 'a | b', renderedOffset: 4 })).toBe(
+            'a | |b'
+        );
+    });
+
+    it('excludes raw-HTML tags when aligning their visible text', () => {
+        const doc = ['', '| H1 |', '| --- |', '| <code>code</code> |', ''].join('\n');
+
+        expect(placement(doc, { section: 'body', row: 0, col: 0 }, { renderedText: 'code', renderedOffset: 2 })).toBe(
+            '<code>co|de</code>'
+        );
+    });
+
+    it('excludes raw-HTML attributes when aligning identical visible text', () => {
+        const doc = ['', '| H1 |', '| --- |', '| <span title="hello">hello</span> |', ''].join('\n');
+
+        expect(placement(doc, { section: 'body', row: 0, col: 0 }, { renderedText: 'hello', renderedOffset: 2 })).toBe(
+            '<span title="hello">he|llo</span>'
+        );
+    });
+
+    it('excludes HTML comments when aligning later visible text', () => {
+        const doc = ['', '| H1 |', '| --- |', '| <!--hello-->hello |', ''].join('\n');
+
+        expect(placement(doc, { section: 'body', row: 0, col: 0 }, { renderedText: 'hello', renderedOffset: 2 })).toBe(
+            '<!--hello-->he|llo'
+        );
+    });
+
+    it('excludes HTML processing instructions when aligning later visible text', () => {
+        const doc = ['', '| H1 |', '| --- |', '| <?pi hello?>hello |', ''].join('\n');
+
+        expect(placement(doc, { section: 'body', row: 0, col: 0 }, { renderedText: 'hello', renderedOffset: 2 })).toBe(
+            '<?pi hello?>he|llo'
+        );
+    });
+
+    it('keeps tag-shaped inline code and autolinks available to alignment', () => {
+        const inlineCodeDoc = ['', '| H1 |', '| --- |', '| `<code>code</code>` |', ''].join('\n');
+        const autolinkDoc = ['', '| H1 |', '| --- |', '| <https://example.com> |', ''].join('\n');
+
+        expect(
+            placement(
+                inlineCodeDoc,
+                { section: 'body', row: 0, col: 0 },
+                {
+                    renderedText: '<code>code</code>',
+                    renderedOffset: 8,
+                }
+            )
+        ).toBe('`<code>co|de</code>`');
+        expect(
+            placement(
+                autolinkDoc,
+                { section: 'body', row: 0, col: 0 },
+                {
+                    renderedText: 'https://example.com',
+                    renderedOffset: 8,
+                }
+            )
+        ).toBe('<https://|example.com>');
+    });
+
+    it('maps excluded HTML ranges through an earlier escaped pipe', () => {
+        const doc = ['', '| H1 |', '| --- |', '| a \\| <code>code</code> |', ''].join('\n');
+
+        expect(
+            placement(doc, { section: 'body', row: 0, col: 0 }, { renderedText: 'a | code', renderedOffset: 6 })
+        ).toBe('a | <code>co|de</code>');
+    });
+
+    it('maps excluded HTML ranges through an earlier line break', () => {
+        const doc = ['', '| H1 |', '| --- |', '| one<br><code>code</code> |', ''].join('\n');
+
+        expect(
+            placement(doc, { section: 'body', row: 0, col: 0 }, { renderedText: 'one\ncode', renderedOffset: 6 })
+        ).toBe('one\n<code>co|de</code>');
+    });
+
+    it('mirrors the main selection when the press produced no caret', () => {
+        expect(placement(CANONICAL_DOC, boldCell, null)).toBe('<mirrored>');
+    });
+
+    it('mirrors the main selection when too little of the rendered text aligns', () => {
+        // A cell rendered as something unrecognisable has no anchors worth placing from.
+        expect(placement(CANONICAL_DOC, boldCell, { renderedText: 'qqqqqqqq', renderedOffset: 4 })).toBe('<mirrored>');
+    });
+
+    it('mirrors the main selection when non-empty source renders no indexable text', () => {
+        const doc = ['', '| H1 |', '| --- |', '| ![alt](resource) |', ''].join('\n');
+
+        expect(placement(doc, { section: 'body', row: 0, col: 0 }, { renderedText: '', renderedOffset: 0 })).toBe(
+            '<mirrored>'
+        );
+    });
+
+    it('places the only possible caret in a genuinely empty cell', () => {
+        const doc = ['', '| H1 |', '| --- |', '|  |', ''].join('\n');
+
+        expect(placement(doc, { section: 'body', row: 0, col: 0 }, { renderedText: '', renderedOffset: 0 })).toBe('|');
+    });
+
+    it('clamps a caret past the end of the cell text', () => {
+        expect(placement(CANONICAL_DOC, boldCell, { renderedText: 'markdown', renderedOffset: 99 })).toBe(
+            '**markdown**|'
+        );
+    });
+});
+
+describe('syntax-aware click placement', () => {
+    it.each([
+        ['[a](url "a b") **b**', 'a b', 1, '[a](url "a b")| **b**'],
+        ['![hello world](img)hello **world**', 'hello world', 3, '![hello world](img)hel|lo **world**'],
+        ['[a](url "a b") **b** &amp; c', 'a b & c', 2, '[a](url "a b") **|b** &amp; c'],
+        ['[**hello**](hello "hello")', 'hello', 2, '[**he|llo**](hello "hello")'],
+        ['[a](destination "many spaces") b', 'a b', 2, '[a](destination "many spaces") |b'],
+        ['~~strike~~ and `code`', 'strike and code', 12, '~~strike~~ and `c|ode`'],
+        ['a \\| [**hello**](url "hello")', 'a | hello', 6, 'a | [**he|llo**](url "hello")'],
+        ['one<br>[hello](url "hello")', 'one\nhello', 6, 'one\n[he|llo](url "hello")'],
+        ['**raw**', '**raw**', 4, '**ra|w**'],
+    ])('maps %s through visible source spans', (source, renderedText, renderedOffset, expected) => {
+        const doc = ['', '| H1 |', '| --- |', `| ${source} |`, ''].join('\n');
+        expect(placement(doc, { section: 'body', row: 0, col: 0 }, { renderedText, renderedOffset })).toBe(expected);
+    });
+
+    it('directly maps long formatted cells beyond the alignment budget', () => {
+        const word = 'a'.repeat(1500);
+        const doc = ['', '| H1 |', '| --- |', `| **${word}** |`, ''].join('\n');
+        const { state, resolvedCell } = resolveCell(doc, { section: 'body', row: 0, col: 0 });
+        expect(resolveClickCursorPos(state, resolvedCell, { renderedText: word, renderedOffset: 1200 })).toEqual({
+            localOffset: 1202,
+        });
+    });
+
+    it('carries a DOM caret through mouse entry into the initial nested selection', () => {
+        const { view, cells } = createInteractiveTableHarness({ doc: CANONICAL_DOC.trim() });
+        const content = contentElement('<strong>markdown</strong>');
+        cells.body0.querySelector = () => content;
+        const range = document.createRange();
+        range.setStart(textNode(content, 'markdown'), 7);
+        Object.defineProperty(cells.body0, 'ownerDocument', {
+            value: {
+                caretRangeFromPoint: vi.fn(() => range),
+            },
+        });
+        const event = {
+            type: 'mousedown',
+            button: 0,
+            clientX: 20,
+            clientY: 10,
+            target: cells.body0,
+            preventDefault: vi.fn(),
+            stopPropagation: vi.fn(),
+        } as unknown as MouseEvent;
+        expect(handleTableInteraction(view, event)).toBe(true);
+        const request = getPendingOpenCellRequest(view.state);
+        expect(request?.initialCursorPos).toEqual({ localOffset: 9 });
+        expect(resolveInitialLocalSelection({ anchor: 0, head: 0 }, '**markdown**', request?.initialCursorPos)).toEqual(
+            { anchor: 9, head: 9 }
+        );
+    });
+});

--- a/src/contentScript/__tests__/clickCursorPlacement.test.ts
+++ b/src/contentScript/__tests__/clickCursorPlacement.test.ts
@@ -2,7 +2,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { CLASS_CELL_CONTENT } from '../shared/tableDomClasses';
 import { indexRenderedText, flatOffsetFromDomPosition, type RenderedCaretHit } from '../tableWidget/cellCaretHit';
-import { resolveClickCursorPos } from '../tableRuntime/interaction/clickCursorPlacement';
+import { resolveClickCursorPos, resolveRenderedSelection } from '../tableRuntime/interaction/clickCursorPlacement';
 import { createResolvedActiveCell, type ResolvedActiveCell } from '../tableRuntime/activeCell/resolvedActiveCell';
 import { resolveTableContextAtPos } from '../tableRuntime/tableResolution';
 import { isCellTextOffset } from '../shared/cursorPlacement';
@@ -316,5 +316,15 @@ describe('syntax-aware click placement', () => {
         expect(resolveInitialLocalSelection({ anchor: 0, head: 0 }, '**markdown**', request?.initialCursorPos)).toEqual(
             { anchor: 9, head: 9 }
         );
+    });
+});
+
+describe('rendered range mapping', () => {
+    it('maps a backward range through the alignment fallback', () => {
+        const doc = ['', '| H1 |', '| --- |', '| **hello** &amp; world |', ''].join('\n');
+        const { state, resolvedCell } = resolveCell(doc, { section: 'body', row: 0, col: 0 });
+        expect(
+            resolveRenderedSelection(state, resolvedCell, { renderedText: 'hello & world', anchor: 11, head: 2 })
+        ).toEqual({ localSelection: { anchor: 19, head: 4 } });
     });
 });

--- a/src/contentScript/__tests__/clickCursorPlacement.test.ts
+++ b/src/contentScript/__tests__/clickCursorPlacement.test.ts
@@ -11,7 +11,8 @@ import {
 import { resolveClickCursorPos, resolveRenderedSelection } from '../tableRuntime/interaction/clickCursorPlacement';
 import { createResolvedActiveCell, type ResolvedActiveCell } from '../tableRuntime/activeCell/resolvedActiveCell';
 import { resolveTableContextAtPos } from '../tableRuntime/tableResolution';
-import { isCellTextOffset } from '../shared/cursorPlacement';
+import type { InitialCursorPos } from '../shared/cursorPlacement';
+import type { LocalSelection } from '../editorBridge/cellTextCodec';
 import type { CellCoords } from '../tableModel/types';
 import { unsanitizeRootText } from '../shared/cellTextNormalization';
 import { handleWidgetPress } from '../tableWidget/tableWidgetInteractions';
@@ -186,6 +187,15 @@ function resolveCell(
  * with `<br>` back as a newline and pipes unescaped - so failures read as text and the
  * coordinate system the offset is expressed in stays visible.
  */
+/** The cell-text offsets a placement carries, rejecting the named edges the helpers never expect. */
+function offsetsOf(pos: InitialCursorPos, expected: string): LocalSelection {
+    if (typeof pos !== 'object') {
+        throw new Error(`Expected ${expected}, got ${pos}`);
+    }
+
+    return pos.localSelection;
+}
+
 function placement(doc: string, coords: CellCoords, hit: RenderedCaretHit | null): string {
     const { state, resolvedCell } = resolveCell(doc, coords);
     const cellText = unsanitizeRootText(state.doc.sliceString(resolvedCell.editableFrom, resolvedCell.editableTo));
@@ -193,10 +203,11 @@ function placement(doc: string, coords: CellCoords, hit: RenderedCaretHit | null
     if (pos === undefined) {
         return '<mirrored>';
     }
-    if (!isCellTextOffset(pos)) {
-        throw new Error(`Expected an offset placement, got ${pos}`);
+    const caret = offsetsOf(pos, 'a caret placement');
+    if (caret.anchor !== caret.head) {
+        throw new Error(`Expected a collapsed placement, got ${JSON.stringify(caret)}`);
     }
-    return `${cellText.slice(0, pos.localOffset)}|${cellText.slice(pos.localOffset)}`;
+    return `${cellText.slice(0, caret.anchor)}|${cellText.slice(caret.anchor)}`;
 }
 
 /** As {@link placement}, with the mapped range bracketed rather than a caret marked. */
@@ -207,10 +218,7 @@ function rangePlacement(doc: string, coords: CellCoords, hit: RenderedSelectionH
     if (pos === undefined) {
         return '<mirrored>';
     }
-    if (typeof pos !== 'object' || !('localSelection' in pos)) {
-        throw new Error(`Expected a range placement, got ${JSON.stringify(pos)}`);
-    }
-    const { anchor, head } = pos.localSelection;
+    const { anchor, head } = offsetsOf(pos, 'a range placement');
     const [from, to] = anchor <= head ? [anchor, head] : [head, anchor];
     return `${cellText.slice(0, from)}[${cellText.slice(from, to)}]${cellText.slice(to)}`;
 }
@@ -385,7 +393,7 @@ describe('syntax-aware click placement', () => {
         const doc = ['', '| H1 |', '| --- |', `| **${word}** |`, ''].join('\n');
         const { state, resolvedCell } = resolveCell(doc, { section: 'body', row: 0, col: 0 });
         expect(resolveClickCursorPos(state, resolvedCell, { renderedText: word, renderedOffset: 1200 })).toEqual({
-            localOffset: 1202,
+            localSelection: { anchor: 1202, head: 1202 },
         });
     });
 
@@ -411,7 +419,7 @@ describe('syntax-aware click placement', () => {
         } as unknown as MouseEvent;
         expect(handleWidgetPress(view, event)).toBe('consume');
         const request = getPendingOpenCellRequest(view.state);
-        expect(request?.initialCursorPos).toEqual({ localOffset: 9 });
+        expect(request?.initialCursorPos).toEqual({ localSelection: { anchor: 9, head: 9 } });
         expect(resolveInitialLocalSelection({ anchor: 0, head: 0 }, '**markdown**', request?.initialCursorPos)).toEqual(
             { anchor: 9, head: 9 }
         );

--- a/src/contentScript/__tests__/clickCursorPlacement.test.ts
+++ b/src/contentScript/__tests__/clickCursorPlacement.test.ts
@@ -14,7 +14,7 @@ import { resolveTableContextAtPos } from '../tableRuntime/tableResolution';
 import { isCellTextOffset } from '../shared/cursorPlacement';
 import type { CellCoords } from '../tableModel/types';
 import { unsanitizeRootText } from '../shared/cellTextNormalization';
-import { handleTableInteraction } from '../tableWidget/tableWidgetInteractions';
+import { handleWidgetPress } from '../tableWidget/tableWidgetInteractions';
 import { getPendingOpenCellRequest } from '../tableRuntime/openCellRequest';
 import { resolveInitialLocalSelection } from '../nestedEditor/nestedEditorSelection';
 import { createInteractiveTableHarness } from './interactiveTableTestHarness';
@@ -409,7 +409,7 @@ describe('syntax-aware click placement', () => {
             preventDefault: vi.fn(),
             stopPropagation: vi.fn(),
         } as unknown as MouseEvent;
-        expect(handleTableInteraction(view, event)).toBe(true);
+        expect(handleWidgetPress(view, event)).toBe('consume');
         const request = getPendingOpenCellRequest(view.state);
         expect(request?.initialCursorPos).toEqual({ localOffset: 9 });
         expect(resolveInitialLocalSelection({ anchor: 0, head: 0 }, '**markdown**', request?.initialCursorPos)).toEqual(

--- a/src/contentScript/__tests__/clickCursorPlacement.test.ts
+++ b/src/contentScript/__tests__/clickCursorPlacement.test.ts
@@ -456,7 +456,7 @@ describe('syntax-aware click placement', () => {
             preventDefault: vi.fn(),
             stopPropagation: vi.fn(),
         } as unknown as MouseEvent;
-        expect(handleWidgetPress(view, event)).toBe('consume');
+        expect(handleWidgetPress(view, event)).toBe(true);
         const request = getPendingOpenCellRequest(view.state);
         expect(request?.initialCursorPos).toEqual({ localSelection: { anchor: 9, head: 9 } });
         expect(resolveInitialLocalSelection({ anchor: 0, head: 0 }, '**markdown**', request?.initialCursorPos)).toEqual(

--- a/src/contentScript/__tests__/clickCursorPlacement.test.ts
+++ b/src/contentScript/__tests__/clickCursorPlacement.test.ts
@@ -392,6 +392,47 @@ describe('rendered range mapping', () => {
         ).toBe('a [[link]](http://x) b');
     });
 
+    it('closes a construct whose opening syntax the range already holds', () => {
+        expect(
+            rangePlacement(cellDoc('foo and **nested markdown** and more'), cell, {
+                renderedText: 'foo and nested markdown and more',
+                anchor: 0,
+                head: 23,
+            })
+        ).toBe('[foo and **nested markdown**] and more');
+    });
+
+    it('opens a construct whose closing syntax the range already holds', () => {
+        expect(
+            rangePlacement(cellDoc('foo and **nested markdown** and more'), cell, {
+                renderedText: 'foo and nested markdown and more',
+                anchor: 8,
+                head: 32,
+            })
+        ).toBe('foo and [**nested markdown** and more]');
+    });
+
+    it('leaves syntax that has no partner outside a range that stops beside it', () => {
+        // The entity renders one character the range did not cover; nothing pairs it inwards.
+        expect(rangePlacement(cellDoc('a &amp; b'), cell, { renderedText: 'a & b', anchor: 0, head: 2 })).toBe(
+            '[a ]&amp; b'
+        );
+    });
+
+    it('closes every construct of a nested pair', () => {
+        expect(
+            rangePlacement(cellDoc('foo ***both*** bar'), cell, { renderedText: 'foo both bar', anchor: 0, head: 8 })
+        ).toBe('[foo ***both***] bar');
+    });
+
+    it('pairs markers through the alignment fallback', () => {
+        // Entities force the fallback, and the range still ends on the far side of the `**`.
+        const source = 'x &amp; y and **bold**<br>more';
+        expect(
+            rangePlacement(cellDoc(source), cell, { renderedText: 'x & y and bold\nmore', anchor: 0, head: 14 })
+        ).toBe('[x &amp; y and **bold**]\nmore');
+    });
+
     it('takes the whole cell text when the range covers every rendered character', () => {
         expect(rangePlacement(cellDoc('**bold**'), cell, { renderedText: 'bold', anchor: 0, head: 4 })).toBe(
             '[**bold**]'

--- a/src/contentScript/__tests__/interactiveOpenCellRequest.test.ts
+++ b/src/contentScript/__tests__/interactiveOpenCellRequest.test.ts
@@ -40,7 +40,7 @@ describe('interactive open-cell requests', () => {
             stopPropagation: vi.fn(),
         } as unknown as MouseEvent;
 
-        expect(handleWidgetPress(view, event)).toBe('consume');
+        expect(handleWidgetPress(view, event)).toBe(true);
         expect(view.state.doc.toString()).toBe(NORMALIZED_DOC);
         expect(getActiveCell(view.state)).toMatchObject({
             section: 'header',

--- a/src/contentScript/__tests__/interactiveOpenCellRequest.test.ts
+++ b/src/contentScript/__tests__/interactiveOpenCellRequest.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { type TransactionSpec } from '@codemirror/state';
 import { activateCellAtPosition } from '../tableRuntime/activeCell/cellActivation';
 import { getActiveCell } from '../tableState/activeCellState';
-import { handleTableInteraction } from '../tableWidget/tableWidgetInteractions';
+import { handleWidgetPress } from '../tableWidget/tableWidgetInteractions';
 import { navigateCell } from '../tableRuntime/navigation/tableNavigation';
 import {
     beginOpenCellRequestEffect,
@@ -40,7 +40,7 @@ describe('interactive open-cell requests', () => {
             stopPropagation: vi.fn(),
         } as unknown as MouseEvent;
 
-        expect(handleTableInteraction(view, event)).toBe(true);
+        expect(handleWidgetPress(view, event)).toBe('consume');
         expect(view.state.doc.toString()).toBe(NORMALIZED_DOC);
         expect(getActiveCell(view.state)).toMatchObject({
             section: 'header',

--- a/src/contentScript/__tests__/interactiveTableTestHarness.ts
+++ b/src/contentScript/__tests__/interactiveTableTestHarness.ts
@@ -13,6 +13,7 @@ export const NON_CANONICAL_DOC = ['|H1|H2|', '|---|---|', '|a|b|'].join('\n');
 interface CellStub {
     dataset: Record<string, string>;
     closest: (selector: string) => unknown;
+    querySelector: (selector: string) => unknown;
 }
 
 export interface MutableTestView {
@@ -84,6 +85,9 @@ export function createInteractiveTableHarness(params?: {
                 }
                 return null;
             },
+            // These cells carry no rendered content wrapper, so a press on one yields no
+            // caret to place from and entry falls back to mirroring the main selection.
+            querySelector: () => null,
         };
 
         return cell as unknown as HTMLElement;

--- a/src/contentScript/__tests__/mouseCellDragSelection.test.ts
+++ b/src/contentScript/__tests__/mouseCellDragSelection.test.ts
@@ -8,7 +8,7 @@ import { activeCellField, getActiveCell, setActiveCellEffect } from '../tableSta
 import { cellSelectionField, getCellSelection, setCellSelectionEffect } from '../tableState/cellSelectionState';
 import { cellDragField, isCellDragInProgress } from '../tableState/cellDragState';
 import { getPendingOpenCellRequest, openCellRequestField } from '../tableRuntime/openCellRequest';
-import { handleWidgetClick, tableWidgetPressPlugin } from '../tableWidget/tableWidgetInteractions';
+import { handleWidgetClick, handleWidgetPress } from '../tableWidget/tableWidgetInteractions';
 import { mouseCellDragSelectionPlugin } from '../tableRuntime/interaction/mouseCellDragSelection';
 import { canHandleTableSelectionKeydown } from '../tableRuntime/selection/cellSelectionShortcutScope';
 import { getCellSelector } from '../tableWidget/domHelpers';
@@ -101,7 +101,6 @@ function mountGestureView(doc = GRID_DOC): MountedGestureView {
             cellDragField,
             openCellRequestField,
             mouseCellDragSelectionPlugin,
-            tableWidgetPressPlugin,
         ]),
     });
     mountedViews.push(view);
@@ -125,8 +124,16 @@ function mountGestureView(doc = GRID_DOC): MountedGestureView {
         body1: findCell(widget, { section: 'body', row: 0, col: 1 }),
     };
 
-    // Presses reach the view through `tableWidgetPressPlugin`, the way production dispatches
-    // them; only clicks are still registered as handlers.
+    // Production registers these through `EditorView.domEventHandlers`, which fires on
+    // `contentDOM`. The widget here is mounted outside it, so the same routing functions are
+    // wired up by hand: returning true stands in for CodeMirror calling `preventDefault`.
+    const dispatchPress = (event: MouseEvent | PointerEvent): void => {
+        if (!event.defaultPrevented && handleWidgetPress(view, event)) {
+            event.preventDefault();
+        }
+    };
+    view.dom.addEventListener('pointerdown', dispatchPress);
+    view.dom.addEventListener('mousedown', dispatchPress);
     view.dom.addEventListener('click', (event) => {
         handleWidgetClick(view, event);
     });

--- a/src/contentScript/__tests__/mouseCellDragSelection.test.ts
+++ b/src/contentScript/__tests__/mouseCellDragSelection.test.ts
@@ -335,6 +335,30 @@ describe('mouse cell drag selection', () => {
         expect(widget.style.userSelect).toBe('');
     });
 
+    it('selects to the end of the cell when the drag leaves the table without crossing a cell', () => {
+        const { view, cells } = mountGestureView(GRID_DOC.replace('a1', '**hello**'));
+        const content = cells.body0.querySelector(`.${CLASS_CELL_CONTENT}`)!;
+        content.innerHTML = '<strong>hello</strong>';
+        const text = content.firstChild!.firstChild!;
+        const below = document.createElement('p');
+        below.textContent = 'below the table';
+        document.body.appendChild(below);
+        elementAtPoint = cells.body0;
+        cells.body0.dispatchEvent(pointerEvent('pointerdown', { button: 0, clientX: 10, clientY: 10 }));
+        document.getSelection()!.setBaseAndExtent(text, 2, below.firstChild!, 5);
+
+        // Nothing of this widget is under the pointer, so the gesture stays a text selection.
+        elementAtPoint = null;
+        document.dispatchEvent(pointerEvent('pointermove', { clientX: 400, clientY: 400 }));
+        expect(isCellDragInProgress(view.state)).toBe(false);
+
+        // `llo` of `**hello**`: the escaped end clamps to the end of the cell's own text.
+        document.dispatchEvent(pointerEvent('pointerup', { clientX: 400, clientY: 400 }));
+        expect(getPendingOpenCellRequest(view.state)?.initialCursorPos).toEqual({
+            localSelection: { anchor: 4, head: 7 },
+        });
+    });
+
     it('re-resolves a provisional press when the table moves before release', () => {
         const { view, cells } = mountGestureView();
         cells.body0.dispatchEvent(pointerEvent('pointerdown', { button: 0, clientX: 10, clientY: 10 }));

--- a/src/contentScript/__tests__/mouseCellDragSelection.test.ts
+++ b/src/contentScript/__tests__/mouseCellDragSelection.test.ts
@@ -38,6 +38,14 @@ interface MountedGestureView {
 const mountedViews: EditorView[] = [];
 let elementAtPoint: Element | null = null;
 let originalElementFromPoint: PropertyDescriptor | undefined;
+let originalCaretRangeFromPoint: PropertyDescriptor | undefined;
+
+function mockCaretHit(node: Node, offset: number): void {
+    const range = document.createRange();
+    range.setStart(node, offset);
+    range.collapse(true);
+    Object.defineProperty(document, 'caretRangeFromPoint', { configurable: true, value: () => range });
+}
 
 const POINTER_RELEASE_TYPES = ['pointerup', 'pointercancel'];
 
@@ -208,6 +216,7 @@ function mountNestedEditorHost(cell: HTMLTableCellElement): HTMLElement {
 beforeEach(() => {
     vi.stubGlobal('ResizeObserver', ResizeObserverMock as unknown as typeof ResizeObserver);
     originalElementFromPoint = Object.getOwnPropertyDescriptor(document, 'elementFromPoint');
+    originalCaretRangeFromPoint = Object.getOwnPropertyDescriptor(document, 'caretRangeFromPoint');
     Object.defineProperty(document, 'elementFromPoint', {
         configurable: true,
         value: vi.fn(() => elementAtPoint),
@@ -223,6 +232,12 @@ afterEach(() => {
     document.body.replaceChildren();
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
+
+    if (originalCaretRangeFromPoint) {
+        Object.defineProperty(document, 'caretRangeFromPoint', originalCaretRangeFromPoint);
+    } else {
+        Reflect.deleteProperty(document, 'caretRangeFromPoint');
+    }
 
     if (originalElementFromPoint) {
         Object.defineProperty(document, 'elementFromPoint', originalElementFromPoint);
@@ -248,7 +263,7 @@ describe('mouse cell drag selection', () => {
         });
 
         cells.body0.dispatchEvent(down);
-        expect(down.defaultPrevented).toBe(false);
+        expect(down.defaultPrevented).toBe(true);
         expect(getActiveCell(view.state)).toBeNull();
         expect(getCellSelection(view.state)).not.toBeNull();
 
@@ -258,7 +273,7 @@ describe('mouse cell drag selection', () => {
             button: 0,
         });
         cells.body0.dispatchEvent(compatibilityMouseDown);
-        expect(compatibilityMouseDown.defaultPrevented).toBe(false);
+        expect(compatibilityMouseDown.defaultPrevented).toBe(true);
         expect(getActiveCell(view.state)).toBeNull();
 
         document.dispatchEvent(
@@ -286,11 +301,12 @@ describe('mouse cell drag selection', () => {
         [0, 5, 0, 9],
         [1, 4, 3, 6],
         [4, 1, 6, 3],
-    ])('preserves native selection %i to %i until release', (anchor, head, localAnchor, localHead) => {
+    ])('draws rendered selection %i to %i and maps it on release', (anchor, head, localAnchor, localHead) => {
         const { view, cells } = mountGestureView(GRID_DOC.replace('a1', '**hello**'));
         const content = cells.body0.querySelector(`.${CLASS_CELL_CONTENT}`)!;
         content.innerHTML = '<strong>hello</strong>';
         const text = content.firstChild!.firstChild!;
+        mockCaretHit(text, anchor);
         const capture = vi.fn();
         cells.body0.setPointerCapture = capture;
         elementAtPoint = cells.body0;
@@ -298,12 +314,13 @@ describe('mouse cell drag selection', () => {
         cells.body0.dispatchEvent(down);
         const mouseDown = new MouseEvent('mousedown', { bubbles: true, cancelable: true, button: 0 });
         cells.body0.dispatchEvent(mouseDown);
-        document.getSelection()!.setBaseAndExtent(text, anchor, text, head);
+        mockCaretHit(text, head);
         const move = pointerEvent('pointermove', { clientX: 80, clientY: 10 });
         document.dispatchEvent(move);
-        expect(down.defaultPrevented).toBe(false);
-        expect(mouseDown.defaultPrevented).toBe(false);
+        expect(down.defaultPrevented).toBe(true);
+        expect(mouseDown.defaultPrevented).toBe(true);
         expect(move.defaultPrevented).toBe(false);
+        expect(document.getSelection()!.toString()).toBe('hello'.slice(Math.min(anchor, head), Math.max(anchor, head)));
         expect(capture).not.toHaveBeenCalled();
         expect(getCellSelection(view.state)).toBeNull();
         expect(getPendingOpenCellRequest(view.state)).toBeNull();
@@ -340,9 +357,10 @@ describe('mouse cell drag selection', () => {
         const below = document.createElement('p');
         below.textContent = 'below the table';
         document.body.appendChild(below);
+        mockCaretHit(text, 2);
         elementAtPoint = cells.body0;
         cells.body0.dispatchEvent(pointerEvent('pointerdown', { button: 0, clientX: 10, clientY: 10 }));
-        document.getSelection()!.setBaseAndExtent(text, 2, below.firstChild!, 5);
+        mockCaretHit(below.firstChild!, 5);
 
         // Nothing of this widget is under the pointer, so the gesture stays a text selection.
         elementAtPoint = null;

--- a/src/contentScript/__tests__/mouseCellDragSelection.test.ts
+++ b/src/contentScript/__tests__/mouseCellDragSelection.test.ts
@@ -318,21 +318,22 @@ describe('mouse cell drag selection', () => {
     });
 
     it('clears native text selection on conversion and keeps cell selection mode on return', () => {
-        const { view, widget, cells } = mountGestureView();
+        const { view, cells } = mountGestureView();
         const text = cells.body0.querySelector(`.${CLASS_CELL_CONTENT}`)!.firstChild!;
         cells.body0.dispatchEvent(pointerEvent('pointerdown', { button: 0, clientX: 10, clientY: 10 }));
         document.getSelection()!.setBaseAndExtent(text, 0, text, 2);
         elementAtPoint = cells.body1;
         document.dispatchEvent(pointerEvent('pointermove', { clientX: 80, clientY: 10 }));
         expect(document.getSelection()!.rangeCount).toBe(0);
-        expect(widget.style.userSelect).toBe('none');
+        // Further text selection is suppressed for as long as this state stands; see
+        // `cellSelectionVisuals.test.ts` for the attribute it puts on the editor.
         expect(isCellDragInProgress(view.state)).toBe(true);
         elementAtPoint = cells.body0;
         document.dispatchEvent(pointerEvent('pointermove', { clientX: 10, clientY: 10 }));
         expect(isCellDragInProgress(view.state)).toBe(true);
         document.dispatchEvent(pointerEvent('pointerup', { clientX: 10, clientY: 10 }));
         expect(getPendingOpenCellRequest(view.state)?.initialCursorPos).toBeUndefined();
-        expect(widget.style.userSelect).toBe('');
+        expect(isCellDragInProgress(view.state)).toBe(false);
     });
 
     it('selects to the end of the cell when the drag leaves the table without crossing a cell', () => {

--- a/src/contentScript/__tests__/mouseCellDragSelection.test.ts
+++ b/src/contentScript/__tests__/mouseCellDragSelection.test.ts
@@ -8,7 +8,7 @@ import { activeCellField, getActiveCell, setActiveCellEffect } from '../tableSta
 import { cellSelectionField, getCellSelection, setCellSelectionEffect } from '../tableState/cellSelectionState';
 import { cellDragField, isCellDragInProgress } from '../tableState/cellDragState';
 import { getPendingOpenCellRequest, openCellRequestField } from '../tableRuntime/openCellRequest';
-import { handleTableInteraction } from '../tableWidget/tableWidgetInteractions';
+import { handleTableInteraction, renderedCellNativeSelectionPlugin } from '../tableWidget/tableWidgetInteractions';
 import { mouseCellDragSelectionPlugin } from '../tableRuntime/interaction/mouseCellDragSelection';
 import { canHandleTableSelectionKeydown } from '../tableRuntime/selection/cellSelectionShortcutScope';
 import { getCellSelector } from '../tableWidget/domHelpers';
@@ -18,7 +18,7 @@ import type { CellCoords } from '../tableModel/types';
 import { markdownRenderServiceFacet } from '../services/markdownRenderer';
 import { createMarkdownState } from './testMarkdownState';
 import { getResolvedActiveCell, resolvedActiveCellField } from '../tableRuntime/activeCell/resolvedActiveCell';
-import { CLASS_CELL_ACTIVE, CLASS_CELL_EDITOR } from '../shared/tableDomClasses';
+import { CLASS_CELL_ACTIVE, CLASS_CELL_EDITOR, CLASS_CELL_CONTENT } from '../shared/tableDomClasses';
 import { parseCellRangesFixture } from './testUtils';
 
 const GRID_DOC = ['| H1 | H2 |', '| --- | --- |', '| a1 | a2 |'].join('\n');
@@ -75,13 +75,13 @@ function findCell(widget: HTMLElement, coords: CellCoords): HTMLTableCellElement
     return cell as HTMLTableCellElement;
 }
 
-function mountGestureView(): MountedGestureView {
+function mountGestureView(doc = GRID_DOC): MountedGestureView {
     const parent = document.createElement('div');
     document.body.appendChild(parent);
 
     const view = new EditorView({
         parent,
-        state: createMarkdownState(GRID_DOC, [
+        state: createMarkdownState(doc, [
             markdownRenderServiceFacet.of({
                 getCached: vi.fn(() => undefined),
                 render: vi.fn(async () => ''),
@@ -93,6 +93,7 @@ function mountGestureView(): MountedGestureView {
             cellDragField,
             openCellRequestField,
             mouseCellDragSelectionPlugin,
+            renderedCellNativeSelectionPlugin,
         ]),
     });
     mountedViews.push(view);
@@ -101,12 +102,12 @@ function mountGestureView(): MountedGestureView {
 
     // The widget is built the way production builds it, so these tests fail if the cell
     // attribute contract the gesture hit-tests against ever changes.
-    const table = MarkdownTable.parse(GRID_DOC);
-    const cellRanges = parseCellRangesFixture(GRID_DOC);
+    const table = MarkdownTable.parse(doc);
+    const cellRanges = parseCellRangesFixture(doc);
     if (!table) {
         throw new Error('Expected the test table to parse');
     }
-    const widget = new TableWidget(table, cellRanges, GRID_DOC, 0).toDOM(view);
+    const widget = new TableWidget(table, cellRanges, doc, 0).toDOM(view);
     view.dom.appendChild(widget);
 
     const cells = {
@@ -251,7 +252,7 @@ describe('mouse cell drag selection', () => {
         });
 
         cells.body0.dispatchEvent(down);
-        expect(down.defaultPrevented).toBe(true);
+        expect(down.defaultPrevented).toBe(false);
         expect(getActiveCell(view.state)).toBeNull();
         expect(getCellSelection(view.state)).not.toBeNull();
 
@@ -261,7 +262,7 @@ describe('mouse cell drag selection', () => {
             button: 0,
         });
         cells.body0.dispatchEvent(compatibilityMouseDown);
-        expect(compatibilityMouseDown.defaultPrevented).toBe(true);
+        expect(compatibilityMouseDown.defaultPrevented).toBe(false);
         expect(getActiveCell(view.state)).toBeNull();
 
         document.dispatchEvent(
@@ -283,6 +284,55 @@ describe('mouse cell drag selection', () => {
             col: 0,
         });
         expect(getCellSelection(view.state)).toBeNull();
+    });
+
+    it.each([
+        [0, 5, 0, 9],
+        [1, 4, 3, 6],
+        [4, 1, 6, 3],
+    ])('preserves native selection %i to %i until release', (anchor, head, localAnchor, localHead) => {
+        const { view, cells } = mountGestureView(GRID_DOC.replace('a1', '**hello**'));
+        const content = cells.body0.querySelector(`.${CLASS_CELL_CONTENT}`)!;
+        content.innerHTML = '<strong>hello</strong>';
+        const text = content.firstChild!.firstChild!;
+        const capture = vi.fn();
+        cells.body0.setPointerCapture = capture;
+        elementAtPoint = cells.body0;
+        const down = pointerEvent('pointerdown', { button: 0, clientX: 10, clientY: 10 });
+        cells.body0.dispatchEvent(down);
+        const mouseDown = new MouseEvent('mousedown', { bubbles: true, cancelable: true, button: 0 });
+        cells.body0.dispatchEvent(mouseDown);
+        document.getSelection()!.setBaseAndExtent(text, anchor, text, head);
+        const move = pointerEvent('pointermove', { clientX: 80, clientY: 10 });
+        document.dispatchEvent(move);
+        expect(down.defaultPrevented).toBe(false);
+        expect(mouseDown.defaultPrevented).toBe(false);
+        expect(move.defaultPrevented).toBe(false);
+        expect(capture).not.toHaveBeenCalled();
+        expect(getCellSelection(view.state)).toBeNull();
+        expect(getPendingOpenCellRequest(view.state)).toBeNull();
+        document.dispatchEvent(pointerEvent('pointerup', { clientX: 80, clientY: 10 }));
+        expect(getPendingOpenCellRequest(view.state)?.initialCursorPos).toEqual({
+            localSelection: { anchor: localAnchor, head: localHead },
+        });
+    });
+
+    it('clears native text selection on conversion and keeps cell selection mode on return', () => {
+        const { view, widget, cells } = mountGestureView();
+        const text = cells.body0.querySelector(`.${CLASS_CELL_CONTENT}`)!.firstChild!;
+        cells.body0.dispatchEvent(pointerEvent('pointerdown', { button: 0, clientX: 10, clientY: 10 }));
+        document.getSelection()!.setBaseAndExtent(text, 0, text, 2);
+        elementAtPoint = cells.body1;
+        document.dispatchEvent(pointerEvent('pointermove', { clientX: 80, clientY: 10 }));
+        expect(document.getSelection()!.rangeCount).toBe(0);
+        expect(widget.style.userSelect).toBe('none');
+        expect(isCellDragInProgress(view.state)).toBe(true);
+        elementAtPoint = cells.body0;
+        document.dispatchEvent(pointerEvent('pointermove', { clientX: 10, clientY: 10 }));
+        expect(isCellDragInProgress(view.state)).toBe(true);
+        document.dispatchEvent(pointerEvent('pointerup', { clientX: 10, clientY: 10 }));
+        expect(getPendingOpenCellRequest(view.state)?.initialCursorPos).toBeUndefined();
+        expect(widget.style.userSelect).toBe('');
     });
 
     it('re-resolves a provisional press when the table moves before release', () => {

--- a/src/contentScript/__tests__/mouseCellDragSelection.test.ts
+++ b/src/contentScript/__tests__/mouseCellDragSelection.test.ts
@@ -333,7 +333,8 @@ describe('mouse cell drag selection', () => {
         expect(getPendingOpenCellRequest(view.state)).toBeNull();
         document.dispatchEvent(pointerEvent('pointerup', { clientX: 80, clientY: 10 }));
         expect(getPendingOpenCellRequest(view.state)?.initialCursorPos).toEqual({
-            localSelection: { anchor: localAnchor, head: localHead },
+            anchor: localAnchor,
+            head: localHead,
         });
     });
 
@@ -376,9 +377,7 @@ describe('mouse cell drag selection', () => {
 
         // `llo` of `**hello**`: the escaped end clamps to the end of the cell's own text.
         document.dispatchEvent(pointerEvent('pointerup', { clientX: 400, clientY: 400 }));
-        expect(getPendingOpenCellRequest(view.state)?.initialCursorPos).toEqual({
-            localSelection: { anchor: 4, head: 7 },
-        });
+        expect(getPendingOpenCellRequest(view.state)?.initialCursorPos).toEqual({ anchor: 4, head: 7 });
     });
 
     it('re-resolves a provisional press when the table moves before release', () => {

--- a/src/contentScript/__tests__/mouseCellDragSelection.test.ts
+++ b/src/contentScript/__tests__/mouseCellDragSelection.test.ts
@@ -8,7 +8,7 @@ import { activeCellField, getActiveCell, setActiveCellEffect } from '../tableSta
 import { cellSelectionField, getCellSelection, setCellSelectionEffect } from '../tableState/cellSelectionState';
 import { cellDragField, isCellDragInProgress } from '../tableState/cellDragState';
 import { getPendingOpenCellRequest, openCellRequestField } from '../tableRuntime/openCellRequest';
-import { handleTableInteraction, renderedCellNativeSelectionPlugin } from '../tableWidget/tableWidgetInteractions';
+import { handleWidgetClick, tableWidgetPressPlugin } from '../tableWidget/tableWidgetInteractions';
 import { mouseCellDragSelectionPlugin } from '../tableRuntime/interaction/mouseCellDragSelection';
 import { canHandleTableSelectionKeydown } from '../tableRuntime/selection/cellSelectionShortcutScope';
 import { getCellSelector } from '../tableWidget/domHelpers';
@@ -93,7 +93,7 @@ function mountGestureView(doc = GRID_DOC): MountedGestureView {
             cellDragField,
             openCellRequestField,
             mouseCellDragSelectionPlugin,
-            renderedCellNativeSelectionPlugin,
+            tableWidgetPressPlugin,
         ]),
     });
     mountedViews.push(view);
@@ -117,14 +117,10 @@ function mountGestureView(doc = GRID_DOC): MountedGestureView {
         body1: findCell(widget, { section: 'body', row: 0, col: 1 }),
     };
 
-    view.dom.addEventListener('pointerdown', (event) => {
-        handleTableInteraction(view, event);
-    });
-    view.dom.addEventListener('mousedown', (event) => {
-        handleTableInteraction(view, event);
-    });
+    // Presses reach the view through `tableWidgetPressPlugin`, the way production dispatches
+    // them; only clicks are still registered as handlers.
     view.dom.addEventListener('click', (event) => {
-        handleTableInteraction(view, event);
+        handleWidgetClick(view, event);
     });
 
     return { view, widget, table: widget.querySelector('table') as HTMLTableElement, cells };

--- a/src/contentScript/__tests__/nestedEditorSelection.test.ts
+++ b/src/contentScript/__tests__/nestedEditorSelection.test.ts
@@ -89,11 +89,10 @@ describe('resolveInitialLocalSelection', () => {
     });
 
     it('clamps both initial selection endpoints while retaining direction', () => {
-        expect(
-            resolveInitialLocalSelection(mirrored, 'hello', {
-                localSelection: { anchor: 8, head: -2 },
-            })
-        ).toEqual({ anchor: 5, head: 0 });
+        expect(resolveInitialLocalSelection(mirrored, 'hello', { anchor: 8, head: -2 })).toEqual({
+            anchor: 5,
+            head: 0,
+        });
     });
 
     it('clamps a requested offset the cell text can no longer hold', () => {

--- a/src/contentScript/__tests__/nestedEditorSelection.test.ts
+++ b/src/contentScript/__tests__/nestedEditorSelection.test.ts
@@ -79,4 +79,18 @@ describe('resolveInitialLocalSelection', () => {
     it('places the caret after a trailing newline for lastLineStart', () => {
         expect(resolveInitialLocalSelection(mirrored, 'first\n', 'lastLineStart')).toEqual({ anchor: 6, head: 6 });
     });
+
+    it('collapses to a requested offset in the cell text', () => {
+        expect(resolveInitialLocalSelection(mirrored, 'hello world', { localOffset: 4 })).toEqual({
+            anchor: 4,
+            head: 4,
+        });
+    });
+
+    it('clamps a requested offset the cell text can no longer hold', () => {
+        // The offset is decided against the cell as it stood; an entry that repairs the table
+        // into canonical form can restripe that cell's padding in the same transaction.
+        expect(resolveInitialLocalSelection(mirrored, 'hi', { localOffset: 9 })).toEqual({ anchor: 2, head: 2 });
+        expect(resolveInitialLocalSelection(mirrored, 'hi', { localOffset: -1 })).toEqual({ anchor: 0, head: 0 });
+    });
 });

--- a/src/contentScript/__tests__/nestedEditorSelection.test.ts
+++ b/src/contentScript/__tests__/nestedEditorSelection.test.ts
@@ -6,6 +6,7 @@ import {
     toAbsoluteSelection,
     toRelativeSelection,
 } from '../nestedEditor/nestedEditorSelection';
+import { cellTextCaret } from '../shared/cursorPlacement';
 
 describe('toAbsoluteSelection', () => {
     it('shifts a cell-relative selection by the editable start', () => {
@@ -81,7 +82,7 @@ describe('resolveInitialLocalSelection', () => {
     });
 
     it('collapses to a requested offset in the cell text', () => {
-        expect(resolveInitialLocalSelection(mirrored, 'hello world', { localOffset: 4 })).toEqual({
+        expect(resolveInitialLocalSelection(mirrored, 'hello world', cellTextCaret(4))).toEqual({
             anchor: 4,
             head: 4,
         });
@@ -98,7 +99,7 @@ describe('resolveInitialLocalSelection', () => {
     it('clamps a requested offset the cell text can no longer hold', () => {
         // The offset is decided against the cell as it stood; an entry that repairs the table
         // into canonical form can restripe that cell's padding in the same transaction.
-        expect(resolveInitialLocalSelection(mirrored, 'hi', { localOffset: 9 })).toEqual({ anchor: 2, head: 2 });
-        expect(resolveInitialLocalSelection(mirrored, 'hi', { localOffset: -1 })).toEqual({ anchor: 0, head: 0 });
+        expect(resolveInitialLocalSelection(mirrored, 'hi', cellTextCaret(9))).toEqual({ anchor: 2, head: 2 });
+        expect(resolveInitialLocalSelection(mirrored, 'hi', cellTextCaret(-1))).toEqual({ anchor: 0, head: 0 });
     });
 });

--- a/src/contentScript/__tests__/nestedEditorSelection.test.ts
+++ b/src/contentScript/__tests__/nestedEditorSelection.test.ts
@@ -87,6 +87,14 @@ describe('resolveInitialLocalSelection', () => {
         });
     });
 
+    it('clamps both initial selection endpoints while retaining direction', () => {
+        expect(
+            resolveInitialLocalSelection(mirrored, 'hello', {
+                localSelection: { anchor: 8, head: -2 },
+            })
+        ).toEqual({ anchor: 5, head: 0 });
+    });
+
     it('clamps a requested offset the cell text can no longer hold', () => {
         // The offset is decided against the cell as it stood; an entry that repairs the table
         // into canonical form can restripe that cell's padding in the same transaction.

--- a/src/contentScript/__tests__/tableWidgetIgnoreEvent.test.ts
+++ b/src/contentScript/__tests__/tableWidgetIgnoreEvent.test.ts
@@ -1,0 +1,97 @@
+/** @vitest-environment jsdom */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { MarkdownTable } from '../tableModel/MarkdownTable';
+import { TableWidget } from '../tableWidget/TableWidget';
+import { CLASS_CELL_CONTENT } from '../shared/tableDomClasses';
+import { CLASS_TABLE_WIDGET } from '../tableWidget/domHelpers';
+import { parseCellRangesFixture } from './testUtils';
+
+const DOC = ['| H1 | H2 |', '| --- | --- |', '| a1 | a2 |'].join('\n');
+
+function createWidget(): TableWidget {
+    const table = MarkdownTable.parse(DOC);
+    if (!table) {
+        throw new Error('Expected the test table to parse');
+    }
+
+    return new TableWidget(table, parseCellRangesFixture(DOC), DOC, 0);
+}
+
+/**
+ * The parts of a rendered table the copy rules care about: content inside a cell, the widget
+ * around it, and a line of the document after it.
+ */
+function mountEditorContent(): { cellText: Text; widget: HTMLElement; afterTable: Text } {
+    document.body.innerHTML = `
+        <div class="cm-content">
+            <div class="${CLASS_TABLE_WIDGET}">
+                <table><tbody><tr><td><div class="${CLASS_CELL_CONTENT}">hello</div></td></tr></tbody></table>
+            </div>
+            <div class="cm-line">after the table</div>
+        </div>`;
+
+    return {
+        cellText: document.querySelector(`.${CLASS_CELL_CONTENT}`)?.firstChild as Text,
+        widget: document.querySelector(`.${CLASS_TABLE_WIDGET}`) as HTMLElement,
+        afterTable: document.querySelector('.cm-line')?.firstChild as Text,
+    };
+}
+
+function copyEventFrom(target: Node): Event {
+    return { type: 'copy', target } as unknown as Event;
+}
+
+function select(anchorNode: Node, anchorOffset: number, focusNode: Node, focusOffset: number): void {
+    document.getSelection()?.setBaseAndExtent(anchorNode, anchorOffset, focusNode, focusOffset);
+}
+
+describe('TableWidget.ignoreEvent', () => {
+    afterEach(() => {
+        document.getSelection()?.removeAllRanges();
+        document.body.replaceChildren();
+    });
+
+    it('disowns a selection change, which belongs to the pending cell gesture', () => {
+        expect(createWidget().ignoreEvent({ type: 'selectionchange' } as Event)).toBe(true);
+    });
+
+    it('disowns a copy of text the browser selected inside a rendered cell', () => {
+        // Otherwise CodeMirror answers the copy from its own document selection, which is
+        // empty during a long press, and copies the caret's whole source line instead.
+        const { cellText } = mountEditorContent();
+        select(cellText, 1, cellText, 4);
+
+        expect(createWidget().ignoreEvent(copyEventFrom(cellText))).toBe(true);
+    });
+
+    it('keeps a copy of a whole-table selection, whose Markdown the main editor owns', () => {
+        const { widget, afterTable } = mountEditorContent();
+        const content = widget.parentElement as HTMLElement;
+        select(content, 0, afterTable, 0);
+
+        expect(createWidget().ignoreEvent(copyEventFrom(content))).toBe(false);
+    });
+
+    it('keeps a copy whose selection only starts in a rendered cell', () => {
+        const { cellText, afterTable } = mountEditorContent();
+        select(cellText, 1, afterTable, 5);
+
+        expect(createWidget().ignoreEvent(copyEventFrom(cellText))).toBe(false);
+    });
+
+    it('keeps a copy with nothing selected, which is the caret the main editor parked', () => {
+        const { cellText } = mountEditorContent();
+        select(cellText, 2, cellText, 2);
+
+        expect(createWidget().ignoreEvent(copyEventFrom(cellText))).toBe(false);
+    });
+
+    it('keeps every other event, including a cut a rendered cell cannot serve', () => {
+        const { cellText } = mountEditorContent();
+        select(cellText, 1, cellText, 4);
+
+        expect(createWidget().ignoreEvent({ type: 'cut', target: cellText } as unknown as Event)).toBe(false);
+        expect(createWidget().ignoreEvent({ type: 'mousedown', target: cellText } as unknown as Event)).toBe(false);
+    });
+});

--- a/src/contentScript/__tests__/tableWidgetInteractions.test.ts
+++ b/src/contentScript/__tests__/tableWidgetInteractions.test.ts
@@ -30,7 +30,7 @@ describe('table widget interactions', () => {
             stopPropagation: vi.fn(),
         } as unknown as MouseEvent;
 
-        expect(handleWidgetPress(view, event)).toBe('consume');
+        expect(handleWidgetPress(view, event)).toBe(true);
         expect(getActiveCell(view.state)).toBeNull();
         expect(getCellSelection(view.state)).toEqual({
             tableFrom: 0,
@@ -57,7 +57,7 @@ describe('table widget interactions', () => {
             stopPropagation: vi.fn(),
         } as unknown as MouseEvent;
 
-        expect(handleWidgetPress(view, event)).toBe('consume');
+        expect(handleWidgetPress(view, event)).toBe(true);
         expect(getCellSelection(view.state)).toBeNull();
         expect(getActiveCell(view.state)).toMatchObject({
             section: 'body',

--- a/src/contentScript/__tests__/tableWidgetInteractions.test.ts
+++ b/src/contentScript/__tests__/tableWidgetInteractions.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import type { EditorView } from '@codemirror/view';
 import { getActiveCell } from '../tableState/activeCellState';
 import { getCellSelection, setCellSelectionEffect } from '../tableState/cellSelectionState';
-import { handleTableInteraction } from '../tableWidget/tableWidgetInteractions';
+import { handleWidgetClick, handleWidgetPress } from '../tableWidget/tableWidgetInteractions';
 import { linkOpenerFacet } from '../services/linkOpener';
 import { buildFootnoteHref } from '../shared/footnoteAnchor';
 import {
@@ -30,7 +30,7 @@ describe('table widget interactions', () => {
             stopPropagation: vi.fn(),
         } as unknown as MouseEvent;
 
-        expect(handleTableInteraction(view, event)).toBe(true);
+        expect(handleWidgetPress(view, event)).toBe('consume');
         expect(getActiveCell(view.state)).toBeNull();
         expect(getCellSelection(view.state)).toEqual({
             tableFrom: 0,
@@ -57,7 +57,7 @@ describe('table widget interactions', () => {
             stopPropagation: vi.fn(),
         } as unknown as MouseEvent;
 
-        expect(handleTableInteraction(view, event)).toBe(true);
+        expect(handleWidgetPress(view, event)).toBe('consume');
         expect(getCellSelection(view.state)).toBeNull();
         expect(getActiveCell(view.state)).toMatchObject({
             section: 'body',
@@ -102,7 +102,7 @@ describe('table widget interactions', () => {
             stopPropagation: vi.fn(),
         } as unknown as MouseEvent;
 
-        expect(handleTableInteraction(view, event)).toBe(true);
+        expect(handleWidgetClick(view, event)).toBe(true);
         expect(open).toHaveBeenCalledWith('https://example.com');
         expect(event.preventDefault).toHaveBeenCalled();
         expect(event.stopPropagation).toHaveBeenCalled();
@@ -155,7 +155,7 @@ describe('table widget interactions', () => {
                 stopPropagation: vi.fn(),
             } as unknown as MouseEvent;
 
-            return { view, handled: handleTableInteraction(view, event) };
+            return { view, handled: handleWidgetClick(view, event) };
         }
 
         it('scrolls to the footnote definition outside fenced code', () => {

--- a/src/contentScript/__tests__/textAlignment.test.ts
+++ b/src/contentScript/__tests__/textAlignment.test.ts
@@ -1,17 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { alignRenderedToSource, mapCaretToSource, type ExcludedSourceRange } from '../shared/textAlignment';
+import { alignRenderedToSource, mapCaretToSource } from '../shared/textAlignment';
 
 /**
  * Maps a caret in rendered text back to its source offset, expressed as the source split
  * at that point so failures read as text rather than as an integer mismatch.
  */
-function place(
-    rendered: string,
-    source: string,
-    caret: number,
-    excludedRanges: readonly ExcludedSourceRange[] = []
-): string {
-    const alignment = alignRenderedToSource(rendered, source, excludedRanges);
+function place(rendered: string, source: string, caret: number): string {
+    const alignment = alignRenderedToSource(rendered, source);
     if (!alignment) {
         throw new Error('expected an alignment');
     }
@@ -49,15 +44,6 @@ describe('alignRenderedToSource', () => {
 
     it('keeps the caret inside inline code', () => {
         expect(place('code', '`code`', 2)).toBe('`co|de`');
-    });
-
-    it('does not use excluded source ranges as alignment anchors', () => {
-        expect(
-            place('code', '<code>code</code>', 2, [
-                { from: 0, to: 6 },
-                { from: 10, to: 17 },
-            ])
-        ).toBe('<code>co|de</code>');
     });
 
     it('still aligns tag-shaped text rendered literally by an inline code span', () => {

--- a/src/contentScript/__tests__/textAlignment.test.ts
+++ b/src/contentScript/__tests__/textAlignment.test.ts
@@ -10,7 +10,7 @@ function place(rendered: string, source: string, caret: number): string {
     if (!alignment) {
         throw new Error('expected an alignment');
     }
-    const offset = mapCaretToSource(alignment, caret, source.length);
+    const offset = mapCaretToSource(alignment.toSource, caret, source.length);
     return `${source.slice(0, offset)}|${source.slice(offset)}`;
 }
 

--- a/src/contentScript/__tests__/textAlignment.test.ts
+++ b/src/contentScript/__tests__/textAlignment.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect } from 'vitest';
+import { alignRenderedToSource, mapCaretToSource, type ExcludedSourceRange } from '../shared/textAlignment';
+
+/**
+ * Maps a caret in rendered text back to its source offset, expressed as the source split
+ * at that point so failures read as text rather than as an integer mismatch.
+ */
+function place(
+    rendered: string,
+    source: string,
+    caret: number,
+    excludedRanges: readonly ExcludedSourceRange[] = []
+): string {
+    const alignment = alignRenderedToSource(rendered, source, excludedRanges);
+    if (!alignment) {
+        throw new Error('expected an alignment');
+    }
+    const offset = mapCaretToSource(alignment, caret, source.length);
+    return `${source.slice(0, offset)}|${source.slice(offset)}`;
+}
+
+function ratio(rendered: string, source: string): number {
+    const alignment = alignRenderedToSource(rendered, source);
+    if (!alignment) {
+        throw new Error('expected an alignment');
+    }
+    return alignment.matchedRatio;
+}
+
+describe('alignRenderedToSource', () => {
+    it('places a caret inside emphasised text at the matching source character', () => {
+        // The reported case: clicking between "w" and "n" of a bolded "markdown".
+        expect(place('markdown', '**markdown**', 7)).toBe('**markdow|n**');
+    });
+
+    it('maps identical text one-to-one', () => {
+        expect(place('plain text', 'plain text', 6)).toBe('plain |text');
+    });
+
+    it('maps all repeated text when a later longest block would strand an earlier character', () => {
+        expect(place('aaa', 'a**aa**', 1)).toBe('a**|aa**');
+        expect(place('aaa', 'a**aa**', 2)).toBe('a**a|a**');
+    });
+
+    it('places a caret in link text rather than in the URL', () => {
+        // "link" occurs twice in the source; only the label is the text that was rendered.
+        expect(place('link', '[link](http://link.com)', 2)).toBe('[li|nk](http://link.com)');
+    });
+
+    it('keeps the caret inside inline code', () => {
+        expect(place('code', '`code`', 2)).toBe('`co|de`');
+    });
+
+    it('does not use excluded source ranges as alignment anchors', () => {
+        expect(
+            place('code', '<code>code</code>', 2, [
+                { from: 0, to: 6 },
+                { from: 10, to: 17 },
+            ])
+        ).toBe('<code>co|de</code>');
+    });
+
+    it('still aligns tag-shaped text rendered literally by an inline code span', () => {
+        expect(place('<code>code</code>', '`<code>code</code>`', 8)).toBe('`<code>co|de</code>`');
+    });
+
+    it('does not mistake an autolink for an HTML tag', () => {
+        expect(place('https://example.com', '<https://example.com>', 8)).toBe('<https://|example.com>');
+    });
+
+    it('binds a caret at a syntax boundary to the character that follows it', () => {
+        // Both sides of the closing `**` are defensible for a caret between "bold" and the
+        // space. Ties resolve towards the following character throughout, so the rule is the
+        // same at an opening boundary, where it puts the caret inside the emphasis instead.
+        expect(place('bold and more', '**bold** and more', 4)).toBe('**bold**| and more');
+        expect(place('abc', 'a**b**c', 1)).toBe('a**|b**c');
+    });
+
+    it('pins a caret past the last rendered character to the end of the source', () => {
+        // Clicking to the right of a short cell means "type here", including past trailing syntax.
+        expect(place('bold', '**bold**', 4)).toBe('**bold**|');
+    });
+
+    it('pins a caret before the first rendered character to the start of the source', () => {
+        expect(place('bold', '**bold**', 0)).toBe('|**bold**');
+    });
+
+    it('aligns across several inline constructs', () => {
+        const source = 'see **the** `docs` for [more](http://x.y)';
+        expect(place('see the docs for more', source, 9)).toBe('see **the** `d|ocs` for [more](http://x.y)');
+    });
+
+    it('recovers after a substitution instead of desynchronising', () => {
+        // "&" is rendered from "&amp;"; everything after it must still align exactly.
+        const source = 'a &amp; bcdef';
+        expect(place('a & bcdef', source, 6)).toBe('a &amp; bc|def');
+    });
+
+    it('treats a newline from a line break like any other character', () => {
+        expect(place('one\ntwo', 'one\ntwo', 5)).toBe('one\nt|wo');
+    });
+
+    it('resolves a caret beside an unmatched run to the nearest anchor', () => {
+        // The emoji is nowhere in the source, so the shortcode it came from is one gap the
+        // caret steps over rather than into. Its two UTF-16 units put "after" at caret 4.
+        expect(place('ab\u{1F600}cd', 'ab:smile:cd', 2)).toBe('ab|:smile:cd');
+        expect(place('ab\u{1F600}cd', 'ab:smile:cd', 4)).toBe('ab:smile:|cd');
+    });
+
+    it('reports full matching when the rendered text is a subsequence of the source', () => {
+        expect(ratio('bold', '**bold**')).toBe(1);
+    });
+
+    it('reports partial matching when the rendered text diverges from the source', () => {
+        expect(ratio('\u{1D465}²', '$x^2$')).toBeLessThan(0.5);
+    });
+
+    it('treats empty rendered text as fully matched', () => {
+        expect(ratio('', '$x^2$')).toBe(1);
+        expect(place('', '$x^2$', 0)).toBe('|$x^2$');
+    });
+
+    it('handles a source that shares nothing with the rendered text', () => {
+        expect(place('xyz', 'abc', 1)).toBe('|abc');
+        expect(ratio('xyz', 'abc')).toBe(0);
+    });
+
+    it('declines to align inputs longer than the supported cell size', () => {
+        expect(alignRenderedToSource('a'.repeat(1001), 'a'.repeat(1001))).toBeNull();
+        expect(alignRenderedToSource('a', 'a'.repeat(1001))).toBeNull();
+    });
+
+    it('aligns a long repeated-character cell within the supported size', () => {
+        // The worst case for a single scan: every character is a candidate for every other.
+        // It still costs about half the comparison budget, so this pins that headroom.
+        expect(alignRenderedToSource('a'.repeat(1000), 'a'.repeat(1000))?.matchedRatio).toBe(1);
+    });
+
+    it('aligns a long prose cell carrying inline markup', () => {
+        const rendered = 'lorem ipsum dolor sit amet '.repeat(33);
+        const source = rendered.replace(/dolor/g, '**dolor**').slice(0, 1000);
+
+        expect(alignRenderedToSource(rendered, source)?.matchedRatio).toBeGreaterThan(0.9);
+    });
+
+    it('declines text whose shape would cost more than the comparison budget', () => {
+        // Nothing longer than one character is common to the two, so every character becomes
+        // its own block and the recursion rescans the rest of the cell for each of them.
+        expect(alignRenderedToSource('a'.repeat(500), 'ab'.repeat(500))).toBeNull();
+    });
+
+    it('declines a cell of short inline code spans rather than stalling the click', () => {
+        // Same shape from real Markdown: `a` `a` `a` ... shares no run longer than one
+        // character with the text it renders to.
+        expect(alignRenderedToSource('a '.repeat(200), '`a` '.repeat(200))).toBeNull();
+    });
+});

--- a/src/contentScript/__tests__/textAlignment.test.ts
+++ b/src/contentScript/__tests__/textAlignment.test.ts
@@ -22,6 +22,9 @@ function ratio(rendered: string, source: string): number {
     return alignment.matchedRatio;
 }
 
+/** Comfortably past `RESYNC_WINDOW`, without this test needing to know its exact value. */
+const RESYNC_WINDOW_LIMIT = 60;
+
 describe('alignRenderedToSource', () => {
     it('places a caret inside emphasised text at the matching source character', () => {
         // The reported case: clicking between "w" and "n" of a bolded "markdown".
@@ -117,8 +120,8 @@ describe('alignRenderedToSource', () => {
     });
 
     it('aligns a long repeated-character cell within the supported size', () => {
-        // The worst case for a single scan: every character is a candidate for every other.
-        // It still costs about half the comparison budget, so this pins that headroom.
+        // Every character is a candidate for every other, which the run check resolves in favour
+        // of staying in step rather than jumping to a later copy.
         expect(alignRenderedToSource('a'.repeat(1000), 'a'.repeat(1000))?.matchedRatio).toBe(1);
     });
 
@@ -129,15 +132,57 @@ describe('alignRenderedToSource', () => {
         expect(alignRenderedToSource(rendered, source)?.matchedRatio).toBeGreaterThan(0.9);
     });
 
-    it('declines text whose shape would cost more than the comparison budget', () => {
-        // Nothing longer than one character is common to the two, so every character becomes
-        // its own block and the recursion rescans the rest of the cell for each of them.
-        expect(alignRenderedToSource('a'.repeat(500), 'ab'.repeat(500))).toBeNull();
+    it('aligns text sharing no run longer than a character, one anchor at a time', () => {
+        // Nothing longer than one character is common to the two, so no candidate ever starts an
+        // agreeing run and every anchor is the nearest bare match.
+        expect(alignRenderedToSource('a'.repeat(500), 'ab'.repeat(500))?.matchedRatio).toBe(1);
     });
 
-    it('declines a cell of short inline code spans rather than stalling the click', () => {
-        // Same shape from real Markdown: `a` `a` `a` ... shares no run longer than one
-        // character with the text it renders to.
-        expect(alignRenderedToSource('a '.repeat(200), '`a` '.repeat(200))).toBeNull();
+    it('aligns a cell of short inline code spans rather than declining the click', () => {
+        // The same shape from real Markdown: `a` `a` `a` ... rendering to `a a a `.
+        expect(place('a a a ', '`a` `a` `a` ', 2)).toBe('`a` `|a` `a` ');
+    });
+
+    it('strands the rest of a cell behind a hidden run wider than the resync window', () => {
+        // The scan cannot see past the window and never backtracks, so nothing after the run
+        // finds an anchor. The collapsed ratio is what keeps the caller from trusting it.
+        const hidden = 'y'.repeat(RESYNC_WINDOW_LIMIT);
+        const alignment = alignRenderedToSource('abcdefghij' + 'klmnopqrst', `abcdefghij${hidden}klmnopqrst`);
+
+        expect(alignment?.matchedRatio).toBeLessThan(0.6);
+    });
+});
+
+/**
+ * Substitutions a renderer actually makes, as (label, rendered, projected source) with the caret
+ * to place and the source split at where it should land.
+ *
+ * These are the shapes that reach alignment at all: the projection has already removed hidden
+ * Markdown, so what is left differs only where rendering rewrote a character. Each was checked
+ * against a longest-matching-block alignment of the same input, which places every caret in
+ * these cells identically.
+ */
+const SUBSTITUTION_CASES: ReadonlyArray<
+    readonly [label: string, rendered: string, source: string, caret: number, expected: string]
+> = [
+    ['em dash', 'a — b and more text', 'a --- b and more text', 8, 'a --- b an|d more text'],
+    ['ellipsis', 'wait… then go on', 'wait... then go on', 6, 'wait... |then go on'],
+    ['smart quotes', '“quoted words” after', '"quoted words" after', 8, '"quoted |words" after'],
+    ['apostrophe', 'it’s a test of things', "it's a test of things", 5, "it's |a test of things"],
+    ['entity', 'Tom & Jerry go home', 'Tom &amp; Jerry go home', 8, 'Tom &amp; Je|rry go home'],
+    ['emoji shortcode', 'nice \u{1F600} work here', 'nice :smile: work here', 9, 'nice :smile: w|ork here'],
+    ['repeated token past a substitution', 'cat — cat — cat', 'cat --- cat --- cat', 12, 'cat --- cat --- |cat'],
+];
+
+describe('alignRenderedToSource across renderer substitutions', () => {
+    it.each(SUBSTITUTION_CASES)('places a caret past a %s', (_label, rendered, source, caret, expected) => {
+        expect(place(rendered, source, caret)).toBe(expected);
+    });
+
+    it('keeps aligning a long cell whose substitutions repeat throughout', () => {
+        const rendered = 'lorem ipsum — dolor sit amet '.repeat(20).slice(0, 600);
+        const source = 'lorem ipsum --- dolor sit amet '.repeat(20).slice(0, 640);
+
+        expect(ratio(rendered, source)).toBeGreaterThan(0.95);
     });
 });

--- a/src/contentScript/nestedEditor/nestedEditorSelection.ts
+++ b/src/contentScript/nestedEditor/nestedEditorSelection.ts
@@ -51,7 +51,7 @@ export function resolveInitialLocalSelection(
     initialCursorPos?: InitialCursorPos
 ): LocalSelection {
     if (typeof initialCursorPos === 'object') {
-        const { anchor, head } = initialCursorPos.localSelection;
+        const { anchor, head } = initialCursorPos;
         return { anchor: clamp(anchor, 0, localText.length), head: clamp(head, 0, localText.length) };
     }
 

--- a/src/contentScript/nestedEditor/nestedEditorSelection.ts
+++ b/src/contentScript/nestedEditor/nestedEditorSelection.ts
@@ -1,6 +1,6 @@
 import type { EditorSelection } from '@codemirror/state';
 import type { LocalSelection } from '../editorBridge/cellTextCodec';
-import type { InitialCursorPos } from '../shared/cursorPlacement';
+import { isCellTextOffset, type InitialCursorPos } from '../shared/cursorPlacement';
 import { clamp } from '../shared/numberUtils';
 
 /** Shifts a cell-relative selection into main-document coordinates. */
@@ -39,12 +39,22 @@ export function areSelectionsEqual(a: LocalSelection, b: LocalSelection): boolea
  *
  * `lastLineStart` splits on the last newline, so a single-line cell collapses to
  * the start and a trailing newline leaves the caret on the empty final line.
+ *
+ * An exact offset is clamped rather than trusted: it is measured against the cell
+ * text as it stood when the placement was decided, and an entry that repairs the
+ * table into canonical form can restripe that cell's padding in the same
+ * transaction.
  */
 export function resolveInitialLocalSelection(
     mirroredSelection: LocalSelection,
     localText: string,
     initialCursorPos?: InitialCursorPos
 ): LocalSelection {
+    if (initialCursorPos !== undefined && isCellTextOffset(initialCursorPos)) {
+        const pos = clamp(initialCursorPos.localOffset, 0, localText.length);
+        return { anchor: pos, head: pos };
+    }
+
     switch (initialCursorPos) {
         case 'start':
             return { anchor: 0, head: 0 };

--- a/src/contentScript/nestedEditor/nestedEditorSelection.ts
+++ b/src/contentScript/nestedEditor/nestedEditorSelection.ts
@@ -42,7 +42,7 @@ export function areSelectionsEqual(a: LocalSelection, b: LocalSelection): boolea
  *
  * Exact offsets are clamped rather than trusted: they are measured against the cell
  * text as it stood when the placement was decided, and an entry that repairs the
- * table into canonical form can restripe that cell's padding in the same
+ * table into canonical form can rewrite that cell's padding in the same
  * transaction.
  */
 export function resolveInitialLocalSelection(

--- a/src/contentScript/nestedEditor/nestedEditorSelection.ts
+++ b/src/contentScript/nestedEditor/nestedEditorSelection.ts
@@ -55,6 +55,13 @@ export function resolveInitialLocalSelection(
         return { anchor: pos, head: pos };
     }
 
+    if (typeof initialCursorPos === 'object' && 'localSelection' in initialCursorPos) {
+        return {
+            anchor: clamp(initialCursorPos.localSelection.anchor, 0, localText.length),
+            head: clamp(initialCursorPos.localSelection.head, 0, localText.length),
+        };
+    }
+
     switch (initialCursorPos) {
         case 'start':
             return { anchor: 0, head: 0 };

--- a/src/contentScript/nestedEditor/nestedEditorSelection.ts
+++ b/src/contentScript/nestedEditor/nestedEditorSelection.ts
@@ -1,6 +1,6 @@
 import type { EditorSelection } from '@codemirror/state';
 import type { LocalSelection } from '../editorBridge/cellTextCodec';
-import { isCellTextOffset, type InitialCursorPos } from '../shared/cursorPlacement';
+import type { InitialCursorPos } from '../shared/cursorPlacement';
 import { clamp } from '../shared/numberUtils';
 
 /** Shifts a cell-relative selection into main-document coordinates. */
@@ -40,7 +40,7 @@ export function areSelectionsEqual(a: LocalSelection, b: LocalSelection): boolea
  * `lastLineStart` splits on the last newline, so a single-line cell collapses to
  * the start and a trailing newline leaves the caret on the empty final line.
  *
- * An exact offset is clamped rather than trusted: it is measured against the cell
+ * Exact offsets are clamped rather than trusted: they are measured against the cell
  * text as it stood when the placement was decided, and an entry that repairs the
  * table into canonical form can restripe that cell's padding in the same
  * transaction.
@@ -50,16 +50,9 @@ export function resolveInitialLocalSelection(
     localText: string,
     initialCursorPos?: InitialCursorPos
 ): LocalSelection {
-    if (initialCursorPos !== undefined && isCellTextOffset(initialCursorPos)) {
-        const pos = clamp(initialCursorPos.localOffset, 0, localText.length);
-        return { anchor: pos, head: pos };
-    }
-
-    if (typeof initialCursorPos === 'object' && 'localSelection' in initialCursorPos) {
-        return {
-            anchor: clamp(initialCursorPos.localSelection.anchor, 0, localText.length),
-            head: clamp(initialCursorPos.localSelection.head, 0, localText.length),
-        };
+    if (typeof initialCursorPos === 'object') {
+        const { anchor, head } = initialCursorPos.localSelection;
+        return { anchor: clamp(anchor, 0, localText.length), head: clamp(head, 0, localText.length) };
     }
 
     switch (initialCursorPos) {

--- a/src/contentScript/shared/cellTextNormalization.ts
+++ b/src/contentScript/shared/cellTextNormalization.ts
@@ -96,9 +96,10 @@ export function unsanitizeRootText(rootText: string): string {
  *
  * Offsets inside a stored spelling all give the start of what it displays as: `<br>` is one
  * newline in the nested editor, so there is nowhere else in the display text for its middle to
- * be. Mapping a range therefore means reading both of its ends out of this array, rather than
- * running the text transform once per end as `editorBridge/cellTextCodec.ts` does for a
- * selection — the same answer, but built once for the whole cell.
+ * be. Mapping a range reads both ends from this array, built once for the whole cell.
+ * Unlike the selection codec, which inserts markers at both endpoints before transforming
+ * the text, this map does not interrupt substitutions. For example, offset 1 in `<br>x`
+ * maps to 0 here but to 1 in the codec, where the marker prevents `<br>` from decoding.
  */
 export function rootToLocalOffsets(rootText: string): Int32Array {
     const offsets = new Int32Array(rootText.length + 1);

--- a/src/contentScript/shared/cellTextNormalization.ts
+++ b/src/contentScript/shared/cellTextNormalization.ts
@@ -50,7 +50,73 @@ export function sanitizeLocalText(localText: string): string {
     return escapeUnescapedPipes(convertNewlinesToBr(normalizeBrTags(localText)));
 }
 
+/**
+ * Stored spellings and the display text each becomes, longest first.
+ *
+ * The single source of truth for reading stored cell text: {@link unsanitizeRootText} produces
+ * the text and {@link rootToLocalOffsets} the offsets that go with it, from one scan apiece over
+ * this table, so the two cannot disagree about where a character went.
+ */
+const STORED_TO_DISPLAY: ReadonlyArray<readonly [stored: string, display: string]> = [
+    ['<br>', '\n'],
+    ['\\|', '|'],
+];
+
+/** The substitution `rootText` spells out at `index`, or null where it spells none. */
+function substitutionAt(rootText: string, index: number): (typeof STORED_TO_DISPLAY)[number] | null {
+    for (const substitution of STORED_TO_DISPLAY) {
+        if (rootText.startsWith(substitution[0], index)) {
+            return substitution;
+        }
+    }
+
+    return null;
+}
+
 /** Converts stored cell text back into display text for the nested editor. */
 export function unsanitizeRootText(rootText: string): string {
-    return rootText.split('<br>').join('\n').split('\\|').join('|');
+    let text = '';
+
+    for (let index = 0; index < rootText.length;) {
+        const substitution = substitutionAt(rootText, index);
+        if (substitution) {
+            text += substitution[1];
+            index += substitution[0].length;
+        } else {
+            text += rootText[index];
+            index++;
+        }
+    }
+
+    return text;
+}
+
+/**
+ * Display offset for every offset in `rootText`, including one past its end.
+ *
+ * Offsets inside a stored spelling all give the start of what it displays as: `<br>` is one
+ * newline in the nested editor, so there is nowhere else in the display text for its middle to
+ * be. Mapping a range therefore means reading both of its ends out of this array, rather than
+ * running the text transform once per end as `editorBridge/cellTextCodec.ts` does for a
+ * selection — the same answer, but built once for the whole cell.
+ */
+export function rootToLocalOffsets(rootText: string): Int32Array {
+    const offsets = new Int32Array(rootText.length + 1);
+    let local = 0;
+
+    for (let index = 0; index < rootText.length;) {
+        const substitution = substitutionAt(rootText, index);
+        if (substitution) {
+            offsets.fill(local, index, index + substitution[0].length);
+            index += substitution[0].length;
+            local += substitution[1].length;
+        } else {
+            offsets[index] = local;
+            index++;
+            local++;
+        }
+    }
+
+    offsets[rootText.length] = local;
+    return offsets;
 }

--- a/src/contentScript/shared/cursorPlacement.ts
+++ b/src/contentScript/shared/cursorPlacement.ts
@@ -1,3 +1,5 @@
+import type { LocalSelection } from '../editorBridge/cellTextCodec';
+
 /**
  * Where the caret should land when a cell is opened programmatically.
  *
@@ -11,10 +13,11 @@
  * - `lastLineStart`: collapse to the start of the final line, so moving up into
  *   a multi-line cell lands on the line nearest the cell the caret came from.
  * - {@link CellTextOffset}: collapse to a specific offset in the cell text.
+ * - {@link CellTextSelection}: select a range in the cell text, preserving direction.
  *
  * Omitting the value mirrors the main editor's own selection into the cell.
  */
-export type InitialCursorPos = 'start' | 'end' | 'lastLineStart' | CellTextOffset;
+export type InitialCursorPos = 'start' | 'end' | 'lastLineStart' | CellTextOffset | CellTextSelection;
 
 /**
  * An exact caret offset in a cell's own text.
@@ -30,5 +33,10 @@ export interface CellTextOffset {
 
 /** Distinguishes an exact offset from the named edges. */
 export function isCellTextOffset(value: InitialCursorPos): value is CellTextOffset {
-    return typeof value === 'object';
+    return typeof value === 'object' && 'localOffset' in value;
+}
+
+/** An initial range in decoded cell text, preserving selection direction. */
+export interface CellTextSelection {
+    localSelection: LocalSelection;
 }

--- a/src/contentScript/shared/cursorPlacement.ts
+++ b/src/contentScript/shared/cursorPlacement.ts
@@ -12,31 +12,28 @@ import type { LocalSelection } from '../editorBridge/cellTextCodec';
  * - `start` / `end`: collapse to the corresponding edge of the cell text.
  * - `lastLineStart`: collapse to the start of the final line, so moving up into
  *   a multi-line cell lands on the line nearest the cell the caret came from.
- * - {@link CellTextOffset}: collapse to a specific offset in the cell text.
- * - {@link CellTextSelection}: select a range in the cell text, preserving direction.
+ * - {@link CellTextSelection}: exact offsets in the cell text, a caret when collapsed.
  *
  * Omitting the value mirrors the main editor's own selection into the cell.
+ *
+ * The named edges are strings and the offsets an object, so a placement is told from an
+ * edge by its type alone; nothing here needs a guard of its own.
  */
-export type InitialCursorPos = 'start' | 'end' | 'lastLineStart' | CellTextOffset | CellTextSelection;
+export type InitialCursorPos = 'start' | 'end' | 'lastLineStart' | CellTextSelection;
 
 /**
- * An exact caret offset in a cell's own text.
+ * Exact offsets in a cell's own text, preserving selection direction.
  *
- * Produced by placements derived from something outside the document - a click on rendered
- * Markdown, whose offset comes from aligning what was drawn against the source. The offset
- * is clamped when applied, because the entry that carries it may rewrite the cell's padding
- * in the same transaction.
+ * Carried by placements derived from something outside the document - a click or drag on
+ * rendered Markdown, whose offsets come from aligning what was drawn against the source.
+ * They are clamped when applied, because the entry that carries them may rewrite the cell's
+ * padding in the same transaction.
  */
-export interface CellTextOffset {
-    localOffset: number;
-}
-
-/** Distinguishes an exact offset from the named edges. */
-export function isCellTextOffset(value: InitialCursorPos): value is CellTextOffset {
-    return typeof value === 'object' && 'localOffset' in value;
-}
-
-/** An initial range in decoded cell text, preserving selection direction. */
 export interface CellTextSelection {
     localSelection: LocalSelection;
+}
+
+/** The placement that opens a cell with its caret at `offset` in the cell text. */
+export function cellTextCaret(offset: number): CellTextSelection {
+    return { localSelection: { anchor: offset, head: offset } };
 }

--- a/src/contentScript/shared/cursorPlacement.ts
+++ b/src/contentScript/shared/cursorPlacement.ts
@@ -2,15 +2,33 @@
  * Where the caret should land when a cell is opened programmatically.
  *
  * The value travels from the code that decides the placement (keyboard
- * navigation, structural mutations) through an open-cell request to the nested
- * editor, which applies it in `resolveInitialLocalSelection`. Each hop is a
- * separate module, so the vocabulary is defined here once instead of being
- * re-declared at every boundary.
+ * navigation, structural mutations, click-to-caret placement) through an
+ * open-cell request to the nested editor, which applies it in
+ * `resolveInitialLocalSelection`. Each hop is a separate module, so the
+ * vocabulary is defined here once instead of being re-declared at every boundary.
  *
  * - `start` / `end`: collapse to the corresponding edge of the cell text.
  * - `lastLineStart`: collapse to the start of the final line, so moving up into
  *   a multi-line cell lands on the line nearest the cell the caret came from.
+ * - {@link CellTextOffset}: collapse to a specific offset in the cell text.
  *
  * Omitting the value mirrors the main editor's own selection into the cell.
  */
-export type InitialCursorPos = 'start' | 'end' | 'lastLineStart';
+export type InitialCursorPos = 'start' | 'end' | 'lastLineStart' | CellTextOffset;
+
+/**
+ * An exact caret offset in a cell's own text.
+ *
+ * Produced by placements derived from something outside the document - a click on rendered
+ * Markdown, whose offset comes from aligning what was drawn against the source. The offset
+ * is clamped when applied, because the entry that carries it may rewrite the cell's padding
+ * in the same transaction.
+ */
+export interface CellTextOffset {
+    localOffset: number;
+}
+
+/** Distinguishes an exact offset from the named edges. */
+export function isCellTextOffset(value: InitialCursorPos): value is CellTextOffset {
+    return typeof value === 'object';
+}

--- a/src/contentScript/shared/cursorPlacement.ts
+++ b/src/contentScript/shared/cursorPlacement.ts
@@ -12,25 +12,17 @@ import type { LocalSelection } from '../editorBridge/cellTextCodec';
  * - `start` / `end`: collapse to the corresponding edge of the cell text.
  * - `lastLineStart`: collapse to the start of the final line, so moving up into
  *   a multi-line cell lands on the line nearest the cell the caret came from.
- * - {@link CellTextSelection}: exact offsets in the cell text, a caret when collapsed.
+ * - a {@link LocalSelection}: exact offsets in the cell text, preserving direction and
+ *   collapsing to a caret when the two are equal. Carried by placements derived from
+ *   something outside the document - a click or drag on rendered Markdown, whose offsets come
+ *   from aligning what was drawn against the source. They are clamped when applied, because
+ *   the entry that carries them may rewrite the cell's padding in the same transaction.
  *
  * Omitting the value mirrors the main editor's own selection into the cell.
  */
-export type InitialCursorPos = 'start' | 'end' | 'lastLineStart' | CellTextSelection;
-
-/**
- * Exact offsets in a cell's own text, preserving selection direction.
- *
- * Carried by placements derived from something outside the document - a click or drag on
- * rendered Markdown, whose offsets come from aligning what was drawn against the source.
- * They are clamped when applied, because the entry that carries them may rewrite the cell's
- * padding in the same transaction.
- */
-export interface CellTextSelection {
-    localSelection: LocalSelection;
-}
+export type InitialCursorPos = 'start' | 'end' | 'lastLineStart' | LocalSelection;
 
 /** The placement that opens a cell with its caret at `offset` in the cell text. */
-export function cellTextCaret(offset: number): CellTextSelection {
-    return { localSelection: { anchor: offset, head: offset } };
+export function cellTextCaret(offset: number): LocalSelection {
+    return { anchor: offset, head: offset };
 }

--- a/src/contentScript/shared/cursorPlacement.ts
+++ b/src/contentScript/shared/cursorPlacement.ts
@@ -15,9 +15,6 @@ import type { LocalSelection } from '../editorBridge/cellTextCodec';
  * - {@link CellTextSelection}: exact offsets in the cell text, a caret when collapsed.
  *
  * Omitting the value mirrors the main editor's own selection into the cell.
- *
- * The named edges are strings and the offsets an object, so a placement is told from an
- * edge by its type alone; nothing here needs a guard of its own.
  */
 export type InitialCursorPos = 'start' | 'end' | 'lastLineStart' | CellTextSelection;
 

--- a/src/contentScript/shared/mouseEvents.ts
+++ b/src/contentScript/shared/mouseEvents.ts
@@ -22,13 +22,8 @@ export function isPrimaryMousePointer(event: PointerEvent): boolean {
  * - `claim`: taken from CodeMirror's handlers, with the browser default left to run.
  * - `consume`: taken from both.
  *
- * A `domEventHandlers` handler has only two of these: returning false leaves a press `native`,
- * and returning true is as close as it gets to `consume` — `runHandlers` calls `preventDefault`
- * and runs no further handlers, though the event still propagates. There is no way to stop the
- * editor acting on a press without also cancelling the browser default, which is exactly what
- * rendered cell text needs: the outer editor must not move its caret over it, while the browser
- * must still draw the text selection that the release maps into Markdown. So presses are
- * dispatched from a capture listener instead of `EditorView.domEventHandlers`.
+ * `EditorView.domEventHandlers` cannot express `claim`: a handler returning true also calls
+ * `preventDefault`. That is why presses are dispatched from a capture listener instead.
  */
 export type PressDisposition = 'native' | 'claim' | 'consume';
 

--- a/src/contentScript/shared/mouseEvents.ts
+++ b/src/contentScript/shared/mouseEvents.ts
@@ -22,11 +22,13 @@ export function isPrimaryMousePointer(event: PointerEvent): boolean {
  * - `claim`: taken from CodeMirror's handlers, with the browser default left to run.
  * - `consume`: taken from both.
  *
- * CodeMirror's own dispatch can express only the outer two: `runHandlers` calls
- * `preventDefault` on any handler that returns true. A press on rendered cell text needs the
- * middle one — the outer editor must not move its caret over it, while the browser must still
- * draw the text selection that the release maps into Markdown — which is why presses are routed
- * from a capture listener instead of `EditorView.domEventHandlers`.
+ * A `domEventHandlers` handler has only two of these: returning false leaves a press `native`,
+ * and returning true is as close as it gets to `consume` — `runHandlers` calls `preventDefault`
+ * and runs no further handlers, though the event still propagates. There is no way to stop the
+ * editor acting on a press without also cancelling the browser default, which is exactly what
+ * rendered cell text needs: the outer editor must not move its caret over it, while the browser
+ * must still draw the text selection that the release maps into Markdown. So presses are
+ * dispatched from a capture listener instead of `EditorView.domEventHandlers`.
  */
 export type PressDisposition = 'native' | 'claim' | 'consume';
 

--- a/src/contentScript/shared/mouseEvents.ts
+++ b/src/contentScript/shared/mouseEvents.ts
@@ -14,27 +14,3 @@ export function isPrimaryMouseButton(event: MouseEvent): boolean {
 export function isPrimaryMousePointer(event: PointerEvent): boolean {
     return event.pointerType === 'mouse' && event.isPrimary && isPrimaryMouseButton(event);
 }
-
-/**
- * What a press does to the event that carried it.
- *
- * - `native`: left entirely alone, for a press whose owner is the browser or another editor.
- * - `claim`: taken from CodeMirror's handlers, with the browser default left to run.
- * - `consume`: taken from both.
- *
- * `EditorView.domEventHandlers` cannot express `claim`: a handler returning true also calls
- * `preventDefault`. That is why presses are dispatched from a capture listener instead.
- */
-export type PressDisposition = 'native' | 'claim' | 'consume';
-
-/** Applies what {@link PressDisposition} says about an event to the event itself. */
-export function applyPressDisposition(event: Event, disposition: PressDisposition): void {
-    if (disposition === 'native') {
-        return;
-    }
-
-    event.stopPropagation();
-    if (disposition === 'consume') {
-        event.preventDefault();
-    }
-}

--- a/src/contentScript/shared/mouseEvents.ts
+++ b/src/contentScript/shared/mouseEvents.ts
@@ -14,3 +14,30 @@ export function isPrimaryMouseButton(event: MouseEvent): boolean {
 export function isPrimaryMousePointer(event: PointerEvent): boolean {
     return event.pointerType === 'mouse' && event.isPrimary && isPrimaryMouseButton(event);
 }
+
+/**
+ * What a press does to the event that carried it.
+ *
+ * - `native`: left entirely alone, for a press whose owner is the browser or another editor.
+ * - `claim`: taken from CodeMirror's handlers, with the browser default left to run.
+ * - `consume`: taken from both.
+ *
+ * CodeMirror's own dispatch can express only the outer two: `runHandlers` calls
+ * `preventDefault` on any handler that returns true. A press on rendered cell text needs the
+ * middle one — the outer editor must not move its caret over it, while the browser must still
+ * draw the text selection that the release maps into Markdown — which is why presses are routed
+ * from a capture listener instead of `EditorView.domEventHandlers`.
+ */
+export type PressDisposition = 'native' | 'claim' | 'consume';
+
+/** Applies what {@link PressDisposition} says about an event to the event itself. */
+export function applyPressDisposition(event: Event, disposition: PressDisposition): void {
+    if (disposition === 'native') {
+        return;
+    }
+
+    event.stopPropagation();
+    if (disposition === 'consume') {
+        event.preventDefault();
+    }
+}

--- a/src/contentScript/shared/textAlignment.ts
+++ b/src/contentScript/shared/textAlignment.ts
@@ -249,8 +249,7 @@ export function alignRenderedToSource(rendered: string, source: string): TextAli
  * Both ends are pinned: clicking past the last rendered character means the end of the
  * source, including any trailing syntax, and the same in reverse at the start.
  */
-export function mapCaretToSource(alignment: TextAlignment, caret: number, sourceLength: number): number {
-    const { toSource } = alignment;
+export function mapCaretToSource(toSource: Int32Array, caret: number, sourceLength: number): number {
     if (caret <= 0) {
         return 0;
     }

--- a/src/contentScript/shared/textAlignment.ts
+++ b/src/contentScript/shared/textAlignment.ts
@@ -53,34 +53,10 @@ export interface TextAlignment {
     readonly matchedRatio: number;
 }
 
-/** Half-open source range whose characters must not be used as alignment anchors. */
-export interface ExcludedSourceRange {
-    from: number;
-    to: number;
-}
-
-function excludedSourcePositions(sourceLength: number, ranges: readonly ExcludedSourceRange[]): Uint8Array | null {
-    if (ranges.length === 0) {
-        return null;
-    }
-
-    const excluded = new Uint8Array(sourceLength);
-    for (const range of ranges) {
-        const from = Math.max(0, Math.min(range.from, sourceLength));
-        const to = Math.max(from, Math.min(range.to, sourceLength));
-        excluded.fill(1, from, to);
-    }
-    return excluded;
-}
-
 /** Character to ascending list of positions, so block matching can skip non-candidates. */
-function indexCharacterPositions(source: string, excluded: Uint8Array | null): Map<string, number[]> {
+function indexCharacterPositions(source: string): Map<string, number[]> {
     const positions = new Map<string, number[]>();
     for (let i = 0; i < source.length; i++) {
-        if (excluded?.[i]) {
-            continue;
-        }
-
         const existing = positions.get(source[i]);
         if (existing) {
             existing.push(i);
@@ -99,15 +75,12 @@ function indexCharacterPositions(source: string, excluded: Uint8Array | null): M
  * subsequence. This repairs repeated-text cases where longest-block alignment commits to a
  * later run and strands otherwise matchable characters on one side of it.
  */
-function alignCompleteSubsequence(rendered: string, source: string, excluded: Uint8Array | null): TextAlignment | null {
+function alignCompleteSubsequence(rendered: string, source: string): TextAlignment | null {
     const toSource = new Int32Array(rendered.length);
     let sourceIndex = 0;
 
     for (let renderedIndex = 0; renderedIndex < rendered.length; renderedIndex++) {
-        while (
-            sourceIndex < source.length &&
-            (Boolean(excluded?.[sourceIndex]) || source[sourceIndex] !== rendered[renderedIndex])
-        ) {
+        while (sourceIndex < source.length && source[sourceIndex] !== rendered[renderedIndex]) {
             sourceIndex++;
         }
 
@@ -227,19 +200,12 @@ function collectMatchingBlocks(
 /**
  * Aligns rendered text back onto the source it came from.
  *
- * Characters inside `excludedRanges` cannot anchor a match. Callers use this for syntax that
- * may duplicate visible text, such as an HTML tag name or attribute value.
- *
  * Returns null when either side is longer than {@link MAX_ALIGNMENT_LENGTH}, or when the
  * text is shaped such that aligning it would cost more than {@link MAX_ALIGNMENT_CANDIDATES}
  * comparisons; callers treat that as "no better placement is available" rather than as an
  * error.
  */
-export function alignRenderedToSource(
-    rendered: string,
-    source: string,
-    excludedRanges: readonly ExcludedSourceRange[] = []
-): TextAlignment | null {
+export function alignRenderedToSource(rendered: string, source: string): TextAlignment | null {
     if (rendered.length > MAX_ALIGNMENT_LENGTH || source.length > MAX_ALIGNMENT_LENGTH) {
         return null;
     }
@@ -249,8 +215,7 @@ export function alignRenderedToSource(
         return { toSource: new Int32Array(), matchedRatio: 1 };
     }
 
-    const excluded = excludedSourcePositions(source.length, excludedRanges);
-    const blocks = collectMatchingBlocks(rendered, indexCharacterPositions(source, excluded), source.length);
+    const blocks = collectMatchingBlocks(rendered, indexCharacterPositions(source), source.length);
     if (!blocks) {
         return null;
     }
@@ -269,7 +234,7 @@ export function alignRenderedToSource(
         return blockAlignment;
     }
 
-    return alignCompleteSubsequence(rendered, source, excluded) ?? blockAlignment;
+    return alignCompleteSubsequence(rendered, source) ?? blockAlignment;
 }
 
 /**

--- a/src/contentScript/shared/textAlignment.ts
+++ b/src/contentScript/shared/textAlignment.ts
@@ -3,32 +3,33 @@
  * projection. The caller removes hidden Markdown before alignment; matching raw source
  * alone cannot distinguish visible text from identical link titles or image descriptions.
  *
- * Longest contiguous blocks anchor the mapping, with a complete-subsequence fallback for
- * repeated text. Renderer substitutions may leave unmatched characters, resolved by nearby
- * anchors. The matched ratio measures coverage, not semantic certainty.
+ * One forward scan walks both strings together, resynchronising within a small window wherever
+ * they diverge. Renderer substitutions are local - an entity, an em dash, an emoji standing in
+ * for its shortcode - so an anchor close by is enough to recover, and the characters between
+ * anchors are left unmatched for {@link mapCaretToSource} to step over.
+ *
+ * The scan never backtracks, so one anchor taken in the wrong place strands the rest of the
+ * cell. That is why the window is small: a wider one reaches further past a long run of hidden
+ * source, but also reaches coincidental matches that a near one would have won. The stranding
+ * is self-limiting rather than silent - it collapses the matched ratio, and the caller declines
+ * placement below its own threshold - so a poisoned scan falls back to mirroring the main
+ * editor's selection rather than placing a confidently wrong caret.
  */
 
-/** Maximum input length for fallback alignment; direct mappings bypass this limit. */
+/** Maximum input length for alignment; direct mappings bypass this limit. */
 const MAX_ALIGNMENT_LENGTH = 1000;
 
 /**
- * Comparison budget shared by all longest-block scans in one fallback alignment.
- * Repeated characters and fragmented matches can cause expensive rescans even within the
- * length limit. Exhausting this budget declines placement; it does not bound elapsed time.
+ * How far past the current source position a diverged scan looks for its next anchor.
+ *
+ * Wide enough for the substitutions a renderer actually makes, and for the syntax the projection
+ * could not identify; narrow enough that a character with no true counterpart cannot reach a
+ * coincidental match further down the cell.
  */
-const MAX_ALIGNMENT_CANDIDATES = 2_000_000;
+const RESYNC_WINDOW = 24;
 
-/** Remaining comparison budget, shared by every scan in one alignment. */
-interface AlignmentBudget {
-    remaining: number;
-}
-
-/** A run of characters that is identical in both strings. */
-interface MatchingBlock {
-    renderedFrom: number;
-    sourceFrom: number;
-    length: number;
-}
+/** How many characters must agree for a candidate anchor to beat a nearer coincidence. */
+const RESYNC_RUN = 3;
 
 export interface TextAlignment {
     /** Source index each rendered index maps to, or -1 where the character did not align. */
@@ -37,185 +38,78 @@ export interface TextAlignment {
     readonly matchedRatio: number;
 }
 
-/** Character to ascending list of positions, so block matching can skip non-candidates. */
-function indexCharacterPositions(source: string): Map<string, number[]> {
-    const positions = new Map<string, number[]>();
-    for (let i = 0; i < source.length; i++) {
-        const existing = positions.get(source[i]);
-        if (existing) {
-            existing.push(i);
-        } else {
-            positions.set(source[i], [i]);
+/** Whether the two strings agree for {@link RESYNC_RUN} characters from these offsets. */
+function runAgrees(rendered: string, renderedFrom: number, source: string, sourceFrom: number): boolean {
+    for (let k = 1; k < RESYNC_RUN; k++) {
+        if (renderedFrom + k >= rendered.length) {
+            // Nothing left to place, so nothing left to disagree.
+            return true;
+        }
+        // Source exhausted while rendered text remains is a disagreement, not a run. Reading it
+        // as agreement would confirm a candidate at the very end of the source purely because
+        // nothing follows it, and that beats the nearer candidate that actually continues.
+        if (sourceFrom + k >= source.length || rendered[renderedFrom + k] !== source[sourceFrom + k]) {
+            return false;
         }
     }
-    return positions;
+
+    return true;
 }
 
 /**
- * Maps every rendered character to its earliest available source occurrence in order.
+ * Source index anchoring `rendered[renderedFrom]`, searching forward from `sourceFrom`.
  *
- * Choosing the earliest match cannot prevent a later match that another subsequence could
- * make, so a single forward scan is enough to prove whether the rendered text is a complete
- * subsequence. This repairs repeated-text cases where longest-block alignment commits to a
- * later run and strands otherwise matchable characters on one side of it.
+ * A candidate that starts an agreeing run wins outright. Otherwise the nearest bare character
+ * match stands in, which is what keeps the character on either side of a substitution anchored:
+ * neither can agree for a full run, because the substitution itself is in the way.
  */
-function alignCompleteSubsequence(rendered: string, source: string): TextAlignment | null {
-    const toSource = new Int32Array(rendered.length);
-    let sourceIndex = 0;
+function findAnchor(rendered: string, renderedFrom: number, source: string, sourceFrom: number): number {
+    const limit = Math.min(sourceFrom + RESYNC_WINDOW, source.length);
+    let nearest = -1;
 
-    for (let renderedIndex = 0; renderedIndex < rendered.length; renderedIndex++) {
-        while (sourceIndex < source.length && source[sourceIndex] !== rendered[renderedIndex]) {
-            sourceIndex++;
-        }
-
-        if (sourceIndex >= source.length) {
-            return null;
-        }
-
-        toSource[renderedIndex] = sourceIndex;
-        sourceIndex++;
-    }
-
-    return { toSource, matchedRatio: 1 };
-}
-
-/**
- * Longest run common to `rendered[renderedFrom, renderedTo)` and `source[sourceFrom, sourceTo)`.
- *
- * `runLengths` holds, per source index, the length of the common run ending at the previous
- * rendered character, so extending a run is a single lookup. Ties keep the first run found,
- * which is the earliest position in both strings because the position lists ascend.
- *
- * Returns a zero-length block when the ranges share no characters, and null when `budget`
- * ran out before the scan finished, which makes a truncated scan impossible to mistake for
- * a completed one.
- */
-function findLongestMatch(
-    rendered: string,
-    sourcePositions: Map<string, number[]>,
-    renderedFrom: number,
-    renderedTo: number,
-    sourceFrom: number,
-    sourceTo: number,
-    budget: AlignmentBudget
-): MatchingBlock | null {
-    let best: MatchingBlock = { renderedFrom, sourceFrom, length: 0 };
-    let runLengths = new Map<number, number>();
-
-    for (let i = renderedFrom; i < renderedTo; i++) {
-        if (budget.remaining <= 0) {
-            return null;
-        }
-
-        const nextRunLengths = new Map<number, number>();
-        for (const j of sourcePositions.get(rendered[i]) ?? []) {
-            if (j < sourceFrom) {
-                continue;
-            }
-            if (j >= sourceTo) {
-                break;
-            }
-
-            budget.remaining--;
-            const length = (runLengths.get(j - 1) ?? 0) + 1;
-            nextRunLengths.set(j, length);
-            if (length > best.length) {
-                best = { renderedFrom: i - length + 1, sourceFrom: j - length + 1, length };
-            }
-        }
-        runLengths = nextRunLengths;
-    }
-
-    return best;
-}
-
-/**
- * Every matching block, found by anchoring on the longest one and recursing into the
- * unmatched region on each side of it.
- *
- * The recursion is an explicit stack: a pathological input can nest as deeply as the strings
- * are long. Blocks come back unordered, which is all the caller needs to fill a lookup table.
- *
- * Returns null once the shared budget runs out. Partial blocks are discarded: they would
- * anchor one end of the cell and leave the other, placing the caret confidently wrong.
- */
-function collectMatchingBlocks(
-    rendered: string,
-    sourcePositions: Map<string, number[]>,
-    sourceLength: number
-): MatchingBlock[] | null {
-    const blocks: MatchingBlock[] = [];
-    const budget: AlignmentBudget = { remaining: MAX_ALIGNMENT_CANDIDATES };
-    const pending: Array<[number, number, number, number]> = [[0, rendered.length, 0, sourceLength]];
-
-    while (pending.length > 0) {
-        const [renderedFrom, renderedTo, sourceFrom, sourceTo] = pending.pop() as [number, number, number, number];
-        if (renderedFrom >= renderedTo || sourceFrom >= sourceTo) {
+    for (let j = sourceFrom; j < limit; j++) {
+        if (source[j] !== rendered[renderedFrom]) {
             continue;
         }
-
-        const match = findLongestMatch(
-            rendered,
-            sourcePositions,
-            renderedFrom,
-            renderedTo,
-            sourceFrom,
-            sourceTo,
-            budget
-        );
-        if (!match) {
-            return null;
+        if (runAgrees(rendered, renderedFrom, source, j)) {
+            return j;
         }
-        if (match.length === 0) {
-            continue;
+        if (nearest < 0) {
+            nearest = j;
         }
-
-        blocks.push(match);
-        pending.push([renderedFrom, match.renderedFrom, sourceFrom, match.sourceFrom]);
-        pending.push([match.renderedFrom + match.length, renderedTo, match.sourceFrom + match.length, sourceTo]);
     }
 
-    return blocks;
+    return nearest;
 }
 
 /**
  * Aligns rendered text back onto the source it came from.
  *
- * Returns null when either side is longer than {@link MAX_ALIGNMENT_LENGTH}, or when the
- * text is shaped such that aligning it would cost more than {@link MAX_ALIGNMENT_CANDIDATES}
- * comparisons; callers treat that as "no better placement is available" rather than as an
- * error.
+ * Returns null only when either side is longer than {@link MAX_ALIGNMENT_LENGTH}, which callers
+ * treat as "no better placement is available" rather than as an error. Empty rendered text is
+ * fully matched: the only caret it has is at offset 0.
  */
 export function alignRenderedToSource(rendered: string, source: string): TextAlignment | null {
     if (rendered.length > MAX_ALIGNMENT_LENGTH || source.length > MAX_ALIGNMENT_LENGTH) {
         return null;
     }
 
-    if (rendered.length === 0) {
-        // Empty text: the only caret is at offset 0.
-        return { toSource: new Int32Array(), matchedRatio: 1 };
-    }
-
-    const blocks = collectMatchingBlocks(rendered, indexCharacterPositions(source), source.length);
-    if (!blocks) {
-        return null;
-    }
-
     const toSource = new Int32Array(rendered.length).fill(-1);
+    let sourceIndex = 0;
     let matched = 0;
-    for (const block of blocks) {
-        for (let k = 0; k < block.length; k++) {
-            toSource[block.renderedFrom + k] = block.sourceFrom + k;
+
+    for (let i = 0; i < rendered.length; i++) {
+        const anchor = findAnchor(rendered, i, source, sourceIndex);
+        if (anchor < 0) {
+            continue;
         }
-        matched += block.length;
+
+        toSource[i] = anchor;
+        sourceIndex = anchor + 1;
+        matched++;
     }
 
-    const blockAlignment = { toSource, matchedRatio: matched / rendered.length };
-    if (matched === rendered.length) {
-        return blockAlignment;
-    }
-
-    return alignCompleteSubsequence(rendered, source) ?? blockAlignment;
+    return { toSource, matchedRatio: rendered.length === 0 ? 1 : matched / rendered.length };
 }
 
 /**

--- a/src/contentScript/shared/textAlignment.ts
+++ b/src/contentScript/shared/textAlignment.ts
@@ -269,3 +269,49 @@ export function mapCaretToSource(toSource: Int32Array, caret: number, sourceLeng
 
     return after - caret <= caret - 1 - before ? toSource[after] : toSource[before] + 1;
 }
+
+/** A source range, as the offsets the nested editor should select between. */
+export interface SourceSpan {
+    from: number;
+    to: number;
+}
+
+/**
+ * Maps a selected range of rendered text to the source span covering it.
+ *
+ * A range is mapped from the characters it holds rather than by mapping each end as a caret.
+ * A caret at the seam between a matched run and hidden syntax has two equally good answers and
+ * takes the one after it, which is right for a caret but pulls a range's end across the syntax
+ * that follows it: selecting `bold text` out of `**bold text** aaa` would reach source offsets
+ * either side of the closing `**` and select `bold text**`. Reading the span off the covered
+ * characters instead makes both ends answer the same question - where the selected text begins
+ * and ends in the source - so syntax comes along only where the selection actually spans it.
+ *
+ * A range covering every rendered character takes the whole source, keeping both pins of
+ * {@link mapCaretToSource}: select-all inside a cell still selects its Markdown entire, and
+ * being both ends at once it stays symmetric.
+ *
+ * A range holding no aligned character at all - a run of emoji or a formula, where there is
+ * nothing to read a span off - falls back to mapping each end as a caret.
+ */
+export function mapSelectionToSource(toSource: Int32Array, from: number, to: number, sourceLength: number): SourceSpan {
+    if (from <= 0 && to >= toSource.length) {
+        return { from: 0, to: sourceLength };
+    }
+
+    let first = -1;
+    let last = -1;
+    for (let i = Math.max(from, 0); i < Math.min(to, toSource.length); i++) {
+        if (toSource[i] < 0) {
+            continue;
+        }
+        if (first < 0) {
+            first = toSource[i];
+        }
+        last = toSource[i];
+    }
+
+    return first < 0
+        ? { from: mapCaretToSource(toSource, from, sourceLength), to: mapCaretToSource(toSource, to, sourceLength) }
+        : { from: first, to: last + 1 };
+}

--- a/src/contentScript/shared/textAlignment.ts
+++ b/src/contentScript/shared/textAlignment.ts
@@ -1,0 +1,323 @@
+/**
+ * Bounded character alignment for rendered text that differs from its visible-source
+ * projection. The caller removes hidden Markdown before alignment; matching raw source
+ * alone cannot distinguish visible text from identical link titles or image descriptions.
+ *
+ * Longest contiguous blocks anchor the mapping, with a complete-subsequence fallback for
+ * repeated text. Renderer substitutions may leave unmatched characters, resolved by nearby
+ * anchors. The matched ratio measures coverage, not semantic certainty.
+ */
+
+/**
+ * Longest length either side may have before alignment is refused.
+ *
+ * Cells this long are far past the point where a caret lands somewhere the reader was
+ * looking anyway. The cap bounds a single {@link findLongestMatch} scan; it does not bound
+ * the recursion around it, which is what {@link MAX_ALIGNMENT_CANDIDATES} is for.
+ */
+const MAX_ALIGNMENT_LENGTH = 1000;
+
+/**
+ * Candidate comparisons alignment may spend before it gives up.
+ *
+ * The length cap alone does not bound the cost of a hit test that runs on a click. A cell
+ * whose longest common run is a single character - a row of short inline code spans, or
+ * emphasis around every character - recurses once per character and rescans the shrinking
+ * range each time, which is quadratic in the cell length rather than linear.
+ *
+ * Measured on the shapes this has to survive, a comparison costs roughly 30ns and the cells
+ * that read as prose stay near a million: a 1000-character cell with inline markup spends
+ * ~0.8M, a cell of 1000 identical characters ~1.0M. The degenerate shapes above spend 10M to
+ * 40M, or 0.3s to 1s. The budget sits above the first group and well below the second, which
+ * holds a click to ~60ms. What it gives up is the alignment of a cell that is both long and
+ * degenerate, which then falls back like any other cell that cannot be aligned.
+ */
+const MAX_ALIGNMENT_CANDIDATES = 2_000_000;
+
+/** Remaining comparison budget, shared by every scan in one alignment. */
+interface AlignmentBudget {
+    remaining: number;
+}
+
+/** A run of characters that is identical in both strings. */
+interface MatchingBlock {
+    renderedFrom: number;
+    sourceFrom: number;
+    length: number;
+}
+
+export interface TextAlignment {
+    /** Source index each rendered index maps to, or -1 where the character did not align. */
+    readonly toSource: Int32Array;
+    /** Fraction of the rendered text that aligned, from 0 (nothing) to 1 (everything). */
+    readonly matchedRatio: number;
+}
+
+/** Half-open source range whose characters must not be used as alignment anchors. */
+export interface ExcludedSourceRange {
+    from: number;
+    to: number;
+}
+
+function excludedSourcePositions(sourceLength: number, ranges: readonly ExcludedSourceRange[]): Uint8Array | null {
+    if (ranges.length === 0) {
+        return null;
+    }
+
+    const excluded = new Uint8Array(sourceLength);
+    for (const range of ranges) {
+        const from = Math.max(0, Math.min(range.from, sourceLength));
+        const to = Math.max(from, Math.min(range.to, sourceLength));
+        excluded.fill(1, from, to);
+    }
+    return excluded;
+}
+
+/** Character to ascending list of positions, so block matching can skip non-candidates. */
+function indexCharacterPositions(source: string, excluded: Uint8Array | null): Map<string, number[]> {
+    const positions = new Map<string, number[]>();
+    for (let i = 0; i < source.length; i++) {
+        if (excluded?.[i]) {
+            continue;
+        }
+
+        const existing = positions.get(source[i]);
+        if (existing) {
+            existing.push(i);
+        } else {
+            positions.set(source[i], [i]);
+        }
+    }
+    return positions;
+}
+
+/**
+ * Maps every rendered character to its earliest available source occurrence in order.
+ *
+ * Choosing the earliest match cannot prevent a later match that another subsequence could
+ * make, so a single forward scan is enough to prove whether the rendered text is a complete
+ * subsequence. This repairs repeated-text cases where longest-block alignment commits to a
+ * later run and strands otherwise matchable characters on one side of it.
+ */
+function alignCompleteSubsequence(rendered: string, source: string, excluded: Uint8Array | null): TextAlignment | null {
+    const toSource = new Int32Array(rendered.length);
+    let sourceIndex = 0;
+
+    for (let renderedIndex = 0; renderedIndex < rendered.length; renderedIndex++) {
+        while (
+            sourceIndex < source.length &&
+            (Boolean(excluded?.[sourceIndex]) || source[sourceIndex] !== rendered[renderedIndex])
+        ) {
+            sourceIndex++;
+        }
+
+        if (sourceIndex >= source.length) {
+            return null;
+        }
+
+        toSource[renderedIndex] = sourceIndex;
+        sourceIndex++;
+    }
+
+    return { toSource, matchedRatio: 1 };
+}
+
+/**
+ * Longest run common to `rendered[renderedFrom, renderedTo)` and `source[sourceFrom, sourceTo)`.
+ *
+ * `runLengths` holds, per source index, the length of the common run ending at the previous
+ * rendered character, so extending a run is a single lookup. Ties keep the first run found,
+ * which is the earliest position in both strings because the position lists ascend.
+ *
+ * Returns a zero-length block when the ranges share no characters, and null when `budget`
+ * ran out before the scan finished, which makes a truncated scan impossible to mistake for
+ * a completed one.
+ */
+function findLongestMatch(
+    rendered: string,
+    sourcePositions: Map<string, number[]>,
+    renderedFrom: number,
+    renderedTo: number,
+    sourceFrom: number,
+    sourceTo: number,
+    budget: AlignmentBudget
+): MatchingBlock | null {
+    let best: MatchingBlock = { renderedFrom, sourceFrom, length: 0 };
+    let runLengths = new Map<number, number>();
+
+    for (let i = renderedFrom; i < renderedTo; i++) {
+        if (budget.remaining <= 0) {
+            return null;
+        }
+
+        const nextRunLengths = new Map<number, number>();
+        for (const j of sourcePositions.get(rendered[i]) ?? []) {
+            if (j < sourceFrom) {
+                continue;
+            }
+            if (j >= sourceTo) {
+                break;
+            }
+
+            budget.remaining--;
+            const length = (runLengths.get(j - 1) ?? 0) + 1;
+            nextRunLengths.set(j, length);
+            if (length > best.length) {
+                best = { renderedFrom: i - length + 1, sourceFrom: j - length + 1, length };
+            }
+        }
+        runLengths = nextRunLengths;
+    }
+
+    return best;
+}
+
+/**
+ * Every matching block, found by anchoring on the longest one and recursing into the
+ * unmatched region on each side of it.
+ *
+ * The recursion is an explicit stack: a pathological input can nest as deeply as the strings
+ * are long, and the cap alone is not a reason to spend that on the call stack. Blocks come
+ * back unordered, which is all the caller needs to fill a lookup table.
+ *
+ * Returns null once the shared budget runs out. Partial blocks are discarded rather than
+ * returned, because the stack descends into one gap at a time: whatever it had found would
+ * cover one end of the cell and leave the other unanchored, which places a caret confidently
+ * in the wrong place. Declining hands the caller the fallback it already has.
+ */
+function collectMatchingBlocks(
+    rendered: string,
+    sourcePositions: Map<string, number[]>,
+    sourceLength: number
+): MatchingBlock[] | null {
+    const blocks: MatchingBlock[] = [];
+    const budget: AlignmentBudget = { remaining: MAX_ALIGNMENT_CANDIDATES };
+    const pending: Array<[number, number, number, number]> = [[0, rendered.length, 0, sourceLength]];
+
+    while (pending.length > 0) {
+        const [renderedFrom, renderedTo, sourceFrom, sourceTo] = pending.pop() as [number, number, number, number];
+        if (renderedFrom >= renderedTo || sourceFrom >= sourceTo) {
+            continue;
+        }
+
+        const match = findLongestMatch(
+            rendered,
+            sourcePositions,
+            renderedFrom,
+            renderedTo,
+            sourceFrom,
+            sourceTo,
+            budget
+        );
+        if (!match) {
+            return null;
+        }
+        if (match.length === 0) {
+            continue;
+        }
+
+        blocks.push(match);
+        pending.push([renderedFrom, match.renderedFrom, sourceFrom, match.sourceFrom]);
+        pending.push([match.renderedFrom + match.length, renderedTo, match.sourceFrom + match.length, sourceTo]);
+    }
+
+    return blocks;
+}
+
+/**
+ * Aligns rendered text back onto the source it came from.
+ *
+ * Characters inside `excludedRanges` cannot anchor a match. Callers use this for syntax that
+ * may duplicate visible text, such as an HTML tag name or attribute value.
+ *
+ * Returns null when either side is longer than {@link MAX_ALIGNMENT_LENGTH}, or when the
+ * text is shaped such that aligning it would cost more than {@link MAX_ALIGNMENT_CANDIDATES}
+ * comparisons; callers treat that as "no better placement is available" rather than as an
+ * error.
+ */
+export function alignRenderedToSource(
+    rendered: string,
+    source: string,
+    excludedRanges: readonly ExcludedSourceRange[] = []
+): TextAlignment | null {
+    if (rendered.length > MAX_ALIGNMENT_LENGTH || source.length > MAX_ALIGNMENT_LENGTH) {
+        return null;
+    }
+
+    if (rendered.length === 0) {
+        // Nothing to place is vacuously well aligned: the only caret is at offset 0.
+        return { toSource: new Int32Array(), matchedRatio: 1 };
+    }
+
+    const excluded = excludedSourcePositions(source.length, excludedRanges);
+    const blocks = collectMatchingBlocks(rendered, indexCharacterPositions(source, excluded), source.length);
+    if (!blocks) {
+        return null;
+    }
+
+    const toSource = new Int32Array(rendered.length).fill(-1);
+    let matched = 0;
+    for (const block of blocks) {
+        for (let k = 0; k < block.length; k++) {
+            toSource[block.renderedFrom + k] = block.sourceFrom + k;
+        }
+        matched += block.length;
+    }
+
+    const blockAlignment = { toSource, matchedRatio: matched / rendered.length };
+    if (matched === rendered.length) {
+        return blockAlignment;
+    }
+
+    return alignCompleteSubsequence(rendered, source, excluded) ?? blockAlignment;
+}
+
+/**
+ * Maps a caret offset in the rendered text to a caret offset in the source.
+ *
+ * A caret sits between characters, so it is resolved from the aligned character on either
+ * side of it, whichever is nearer; a tie prefers the character after the caret, which keeps
+ * a caret inside a matched run exactly where it was. Landing in a gap therefore yields the
+ * closest anchor rather than nothing, which is still far more useful than the start of
+ * the cell.
+ *
+ * Both ends are pinned: clicking past the last rendered character means the end of the
+ * source, including any trailing syntax, and the same in reverse at the start.
+ */
+export function mapCaretToSource(alignment: TextAlignment, caret: number, sourceLength: number): number {
+    const { toSource } = alignment;
+    if (caret <= 0) {
+        return 0;
+    }
+    if (caret >= toSource.length) {
+        return sourceLength;
+    }
+
+    let after = -1;
+    for (let i = caret; i < toSource.length; i++) {
+        if (toSource[i] >= 0) {
+            after = i;
+            break;
+        }
+    }
+
+    let before = -1;
+    for (let i = caret - 1; i >= 0; i--) {
+        if (toSource[i] >= 0) {
+            before = i;
+            break;
+        }
+    }
+
+    if (after < 0 && before < 0) {
+        return 0;
+    }
+    if (after < 0) {
+        return toSource[before] + 1;
+    }
+    if (before < 0) {
+        return toSource[after];
+    }
+
+    return after - caret <= caret - 1 - before ? toSource[after] : toSource[before] + 1;
+}

--- a/src/contentScript/shared/textAlignment.ts
+++ b/src/contentScript/shared/textAlignment.ts
@@ -134,13 +134,10 @@ function findLongestMatch(
  * unmatched region on each side of it.
  *
  * The recursion is an explicit stack: a pathological input can nest as deeply as the strings
- * are long, and the cap alone is not a reason to spend that on the call stack. Blocks come
- * back unordered, which is all the caller needs to fill a lookup table.
+ * are long. Blocks come back unordered, which is all the caller needs to fill a lookup table.
  *
- * Returns null once the shared budget runs out. Partial blocks are discarded rather than
- * returned, because the stack descends into one gap at a time: whatever it had found would
- * cover one end of the cell and leave the other unanchored, which places a caret confidently
- * in the wrong place. Declining hands the caller the fallback it already has.
+ * Returns null once the shared budget runs out. Partial blocks are discarded: they would
+ * anchor one end of the cell and leave the other, placing the caret confidently wrong.
  */
 function collectMatchingBlocks(
     rendered: string,
@@ -195,7 +192,7 @@ export function alignRenderedToSource(rendered: string, source: string): TextAli
     }
 
     if (rendered.length === 0) {
-        // Nothing to place is vacuously well aligned: the only caret is at offset 0.
+        // Empty text: the only caret is at offset 0.
         return { toSource: new Int32Array(), matchedRatio: 1 };
     }
 
@@ -280,19 +277,16 @@ export interface SourceSpan {
  * Maps a selected range of rendered text to the source span covering it.
  *
  * A range is mapped from the characters it holds rather than by mapping each end as a caret.
- * A caret at the seam between a matched run and hidden syntax has two equally good answers and
- * takes the one after it, which is right for a caret but pulls a range's end across the syntax
- * that follows it: selecting `bold text` out of `**bold text** aaa` would reach source offsets
- * either side of the closing `**` and select `bold text**`. Reading the span off the covered
- * characters instead makes both ends answer the same question - where the selected text begins
- * and ends in the source - so syntax comes along only where the selection actually spans it.
+ * A caret at the seam between a matched run and hidden syntax takes the offset after it, which
+ * is right for a caret but pulls a range's end across the syntax that follows: selecting
+ * `bold text` out of `**bold text** aaa` would select `bold text**`. Reading the span off the
+ * covered characters instead includes syntax only where the selection actually spans it.
  *
  * A range covering every rendered character takes the whole source, keeping both pins of
- * {@link mapCaretToSource}: select-all inside a cell still selects its Markdown entire, and
- * being both ends at once it stays symmetric.
+ * {@link mapCaretToSource}, so select-all inside a cell still selects its Markdown entire.
  *
- * A range holding no aligned character at all - a run of emoji or a formula, where there is
- * nothing to read a span off - falls back to mapping each end as a caret.
+ * A range holding no aligned character at all - a run of emoji or a formula - falls back to
+ * mapping each end as a caret.
  */
 export function mapSelectionToSource(toSource: Int32Array, from: number, to: number, sourceLength: number): SourceSpan {
     if (from <= 0 && to >= toSource.length) {

--- a/src/contentScript/shared/textAlignment.ts
+++ b/src/contentScript/shared/textAlignment.ts
@@ -8,29 +8,13 @@
  * anchors. The matched ratio measures coverage, not semantic certainty.
  */
 
-/**
- * Longest length either side may have before alignment is refused.
- *
- * Cells this long are far past the point where a caret lands somewhere the reader was
- * looking anyway. The cap bounds a single {@link findLongestMatch} scan; it does not bound
- * the recursion around it, which is what {@link MAX_ALIGNMENT_CANDIDATES} is for.
- */
+/** Maximum input length for fallback alignment; direct mappings bypass this limit. */
 const MAX_ALIGNMENT_LENGTH = 1000;
 
 /**
- * Candidate comparisons alignment may spend before it gives up.
- *
- * The length cap alone does not bound the cost of a hit test that runs on a click. A cell
- * whose longest common run is a single character - a row of short inline code spans, or
- * emphasis around every character - recurses once per character and rescans the shrinking
- * range each time, which is quadratic in the cell length rather than linear.
- *
- * Measured on the shapes this has to survive, a comparison costs roughly 30ns and the cells
- * that read as prose stay near a million: a 1000-character cell with inline markup spends
- * ~0.8M, a cell of 1000 identical characters ~1.0M. The degenerate shapes above spend 10M to
- * 40M, or 0.3s to 1s. The budget sits above the first group and well below the second, which
- * holds a click to ~60ms. What it gives up is the alignment of a cell that is both long and
- * degenerate, which then falls back like any other cell that cannot be aligned.
+ * Comparison budget shared by all longest-block scans in one fallback alignment.
+ * Repeated characters and fragmented matches can cause expensive rescans even within the
+ * length limit. Exhausting this budget declines placement; it does not bound elapsed time.
  */
 const MAX_ALIGNMENT_CANDIDATES = 2_000_000;
 

--- a/src/contentScript/tableRuntime/interaction/cellTextProjection.ts
+++ b/src/contentScript/tableRuntime/interaction/cellTextProjection.ts
@@ -1,0 +1,87 @@
+import type { EditorState } from '@codemirror/state';
+import { syntaxTree } from '@codemirror/language';
+import { toLocalSelection } from '../../editorBridge/cellTextCodec';
+import type { ResolvedActiveCell } from '../activeCell/resolvedActiveCell';
+
+/** Visible source characters and their offsets in the nested editor's decoded text. */
+export interface CellTextProjection {
+    text: string;
+    toLocal: Int32Array;
+}
+
+const HIDDEN_NODES = new Set([
+    'Image',
+    'HTMLTag',
+    'Comment',
+    'ProcessingInstruction',
+    'EmphasisMark',
+    'StrikethroughMark',
+    'CodeMark',
+    'LinkMark',
+    // Transformed entities are handled by alignment, never by matching their spelling.
+    'Entity',
+]);
+
+/**
+ * Projects inline syntax from the main editor into visible text. Link destinations and
+ * titles are excluded as a whole, including their whitespace. Autolink URLs remain visible.
+ * Unknown renderer extensions are left to the constrained alignment fallback.
+ */
+export function projectCellText(
+    state: EditorState,
+    cell: ResolvedActiveCell,
+    rootText: string,
+    localText: string
+): CellTextProjection {
+    const hidden = new Uint8Array(localText.length);
+    const exclude = (from: number, to: number): void => {
+        const range = toLocalSelection(
+            {
+                anchor: Math.max(from, cell.editableFrom) - cell.editableFrom,
+                head: Math.min(to, cell.editableTo) - cell.editableFrom,
+            },
+            rootText
+        );
+        hidden.fill(1, range.anchor, range.head);
+    };
+
+    syntaxTree(state).iterate({
+        from: cell.editableFrom,
+        to: cell.editableTo,
+        enter(node) {
+            if (node.name === 'Link') {
+                // The first direct closing bracket ends the label, even with nested emphasis.
+                for (let child = node.node.firstChild; child; child = child.nextSibling) {
+                    if (child.name === 'LinkMark' && state.doc.sliceString(child.from, child.to) === ']') {
+                        exclude(child.from, node.to);
+                        break;
+                    }
+                }
+            }
+            if (node.name === 'Escape') {
+                // Pipe escapes are already removed by the root-to-local codec.
+                if (state.doc.sliceString(node.from, node.to) !== '\\|') {
+                    exclude(node.from, node.from + 1);
+                }
+                return false;
+            }
+            if (HIDDEN_NODES.has(node.name)) {
+                // Stored line breaks become real newlines in the nested editor.
+                if (node.name !== 'HTMLTag' || state.doc.sliceString(node.from, node.to) !== '<br>') {
+                    exclude(node.from, node.to);
+                }
+                return false;
+            }
+        },
+    });
+
+    let text = '';
+    const offsets: number[] = [];
+    for (let i = 0; i < localText.length; i++) {
+        if (!hidden[i]) {
+            text += localText[i];
+            offsets.push(i);
+        }
+    }
+    return { text, toLocal: Int32Array.from(offsets) };
+}

--- a/src/contentScript/tableRuntime/interaction/cellTextProjection.ts
+++ b/src/contentScript/tableRuntime/interaction/cellTextProjection.ts
@@ -121,17 +121,12 @@ export function projectCellText(
 /**
  * Grows a range so it never holds one marker of a pair without the other.
  *
- * The range a drag selects is read off the rendered characters it covered, which leaves the
- * syntax around them outside it - the point of that rule, and why selecting a whole bolded word
- * yields `bold text` rather than `bold text**`.  A range that *started* earlier is a different
- * case: ending it at the closing `**` of `foo and **bold**` keeps the opening `**` in the middle
- * of the range while its partner sits just past the end, so what the nested editor selects is
- * Markdown that no longer parses as itself.  Here the missing marker is not syntax the reader
- * left out; it is the other half of syntax they already took.
- *
- * So an end grows past trailing syntax only when the leading syntax of the same construct is
- * already inside the range, and a start likewise.  Syntax with no partner - an entity, an HTML
- * tag, an image - owns exactly itself, and is never drawn in by a range that stops beside it.
+ * A range is read off the rendered characters it covered, so syntax around them stays outside:
+ * selecting a whole bolded word yields `bold text`, not `bold text**`. But a range ending at the
+ * closing `**` of `foo and **bold**` already holds the opening `**`, and selecting that alone
+ * gives the nested editor Markdown that no longer parses. So an end grows past trailing syntax
+ * only when the matching leading syntax is already inside the range, and likewise at the start.
+ * Syntax with no partner - an entity, an HTML tag, an image - owns itself and is never drawn in.
  * The loops repeat because constructs nest: `***both***` closes twice over.
  */
 export function balanceSyntaxMarkers(span: SourceSpan, hiddenSpans: readonly HiddenSyntaxSpan[]): SourceSpan {

--- a/src/contentScript/tableRuntime/interaction/cellTextProjection.ts
+++ b/src/contentScript/tableRuntime/interaction/cellTextProjection.ts
@@ -1,8 +1,9 @@
 import type { EditorState } from '@codemirror/state';
 import { syntaxTree } from '@codemirror/language';
 import type { SyntaxNodeRef } from '@lezer/common';
-import { toLocalSelection } from '../../editorBridge/cellTextCodec';
+import { rootToLocalOffsets } from '../../shared/cellTextNormalization';
 import type { ResolvedActiveCell } from '../activeCell/resolvedActiveCell';
+import { clamp } from '../../shared/numberUtils';
 import type { SourceSpan } from '../../shared/textAlignment';
 
 /** Visible source characters and their offsets in the nested editor's decoded text. */
@@ -61,16 +62,13 @@ export function projectCellText(
 ): CellTextProjection {
     const hidden = new Uint8Array(localText.length);
     const hiddenSpans: HiddenSyntaxSpan[] = [];
-    const toLocal = (from: number, to: number): { from: number; to: number } => {
-        const range = toLocalSelection(
-            {
-                anchor: Math.max(from, cell.editableFrom) - cell.editableFrom,
-                head: Math.min(to, cell.editableTo) - cell.editableFrom,
-            },
-            rootText
-        );
-        return { from: range.anchor, to: range.head };
-    };
+    // One offset map for the whole cell, read twice per span, rather than a selection mapped
+    // through the codec's text transform once per end.
+    const localOffsets = rootToLocalOffsets(rootText);
+    const toLocal = (from: number, to: number): { from: number; to: number } => ({
+        from: localOffsets[clamp(from - cell.editableFrom, 0, rootText.length)],
+        to: localOffsets[clamp(to - cell.editableFrom, 0, rootText.length)],
+    });
     /** Hides `from`-`to`, as part of `owner` when the syntax is one marker of a pair. */
     const exclude = (from: number, to: number, owner?: { from: number; to: number }): void => {
         const span = toLocal(from, to);

--- a/src/contentScript/tableRuntime/interaction/cellTextProjection.ts
+++ b/src/contentScript/tableRuntime/interaction/cellTextProjection.ts
@@ -62,8 +62,8 @@ export function projectCellText(
 ): CellTextProjection {
     const hidden = new Uint8Array(localText.length);
     const hiddenSpans: HiddenSyntaxSpan[] = [];
-    // One offset map for the whole cell, read twice per span, rather than a selection mapped
-    // through the codec's text transform once per end.
+    // One offset map for the whole cell, read twice per span, instead of transforming
+    // the whole cell again for each selection range.
     const localOffsets = rootToLocalOffsets(rootText);
     const toLocal = (from: number, to: number): { from: number; to: number } => ({
         from: localOffsets[clamp(from - cell.editableFrom, 0, rootText.length)],

--- a/src/contentScript/tableRuntime/interaction/cellTextProjection.ts
+++ b/src/contentScript/tableRuntime/interaction/cellTextProjection.ts
@@ -1,12 +1,38 @@
 import type { EditorState } from '@codemirror/state';
 import { syntaxTree } from '@codemirror/language';
+import type { SyntaxNodeRef } from '@lezer/common';
 import { toLocalSelection } from '../../editorBridge/cellTextCodec';
 import type { ResolvedActiveCell } from '../activeCell/resolvedActiveCell';
+import type { SourceSpan } from '../../shared/textAlignment';
 
 /** Visible source characters and their offsets in the nested editor's decoded text. */
 export interface CellTextProjection {
     text: string;
     toLocal: Int32Array;
+    hiddenSpans: HiddenSyntaxSpan[];
+}
+
+/**
+ * A run of hidden source, with the range of the construct it belongs to.
+ *
+ * A paired marker - the `**` of a strong span, the `](url)` of a link - is a span whose owner
+ * reaches beyond it to its partner at the other end. Syntax hidden whole, such as an entity or
+ * an HTML tag, owns exactly itself and so has no partner; {@link balanceSyntaxMarkers} tells the
+ * two apart by that.  All offsets are in the nested editor's decoded text.
+ */
+export interface HiddenSyntaxSpan {
+    from: number;
+    to: number;
+    ownerFrom: number;
+    ownerTo: number;
+}
+
+/** Inline marks whose owning node carries the partner marker at its other end. */
+const MARK_NODES = new Set(['EmphasisMark', 'StrikethroughMark', 'CodeMark', 'LinkMark']);
+
+/** The construct one marker of a pair belongs to; undefined for syntax that owns itself. */
+function markerOwner(node: SyntaxNodeRef): SyntaxNodeRef | undefined {
+    return MARK_NODES.has(node.name) ? (node.node.parent ?? undefined) : undefined;
 }
 
 const HIDDEN_NODES = new Set([
@@ -34,7 +60,8 @@ export function projectCellText(
     localText: string
 ): CellTextProjection {
     const hidden = new Uint8Array(localText.length);
-    const exclude = (from: number, to: number): void => {
+    const hiddenSpans: HiddenSyntaxSpan[] = [];
+    const toLocal = (from: number, to: number): { from: number; to: number } => {
         const range = toLocalSelection(
             {
                 anchor: Math.max(from, cell.editableFrom) - cell.editableFrom,
@@ -42,7 +69,14 @@ export function projectCellText(
             },
             rootText
         );
-        hidden.fill(1, range.anchor, range.head);
+        return { from: range.anchor, to: range.head };
+    };
+    /** Hides `from`-`to`, as part of `owner` when the syntax is one marker of a pair. */
+    const exclude = (from: number, to: number, owner?: { from: number; to: number }): void => {
+        const span = toLocal(from, to);
+        hidden.fill(1, span.from, span.to);
+        const ownerSpan = owner ? toLocal(owner.from, owner.to) : span;
+        hiddenSpans.push({ ...span, ownerFrom: ownerSpan.from, ownerTo: ownerSpan.to });
     };
 
     syntaxTree(state).iterate({
@@ -53,7 +87,7 @@ export function projectCellText(
                 // The first direct closing bracket ends the label, even with nested emphasis.
                 for (let child = node.node.firstChild; child; child = child.nextSibling) {
                     if (child.name === 'LinkMark' && state.doc.sliceString(child.from, child.to) === ']') {
-                        exclude(child.from, node.to);
+                        exclude(child.from, node.to, node);
                         break;
                     }
                 }
@@ -68,7 +102,7 @@ export function projectCellText(
             if (HIDDEN_NODES.has(node.name)) {
                 // Stored line breaks become real newlines in the nested editor.
                 if (node.name !== 'HTMLTag' || state.doc.sliceString(node.from, node.to) !== '<br>') {
-                    exclude(node.from, node.to);
+                    exclude(node.from, node.to, markerOwner(node));
                 }
                 return false;
             }
@@ -83,5 +117,51 @@ export function projectCellText(
             offsets.push(i);
         }
     }
-    return { text, toLocal: Int32Array.from(offsets) };
+    return { text, toLocal: Int32Array.from(offsets), hiddenSpans };
+}
+
+/**
+ * Grows a range so it never holds one marker of a pair without the other.
+ *
+ * The range a drag selects is read off the rendered characters it covered, which leaves the
+ * syntax around them outside it - the point of that rule, and why selecting a whole bolded word
+ * yields `bold text` rather than `bold text**`.  A range that *started* earlier is a different
+ * case: ending it at the closing `**` of `foo and **bold**` keeps the opening `**` in the middle
+ * of the range while its partner sits just past the end, so what the nested editor selects is
+ * Markdown that no longer parses as itself.  Here the missing marker is not syntax the reader
+ * left out; it is the other half of syntax they already took.
+ *
+ * So an end grows past trailing syntax only when the leading syntax of the same construct is
+ * already inside the range, and a start likewise.  Syntax with no partner - an entity, an HTML
+ * tag, an image - owns exactly itself, and is never drawn in by a range that stops beside it.
+ * The loops repeat because constructs nest: `***both***` closes twice over.
+ */
+export function balanceSyntaxMarkers(span: SourceSpan, hiddenSpans: readonly HiddenSyntaxSpan[]): SourceSpan {
+    let { from, to } = span;
+
+    for (let grew = true; grew;) {
+        grew = false;
+        for (const hiddenSpan of hiddenSpans) {
+            const { ownerFrom, ownerTo } = hiddenSpan;
+            if (
+                hiddenSpan.from === to &&
+                hiddenSpan.to === ownerTo &&
+                ownerFrom < hiddenSpan.from &&
+                ownerFrom >= from
+            ) {
+                to = hiddenSpan.to;
+                grew = true;
+            } else if (
+                hiddenSpan.to === from &&
+                hiddenSpan.from === ownerFrom &&
+                ownerTo > hiddenSpan.to &&
+                ownerTo <= to
+            ) {
+                from = hiddenSpan.from;
+                grew = true;
+            }
+        }
+    }
+
+    return { from, to };
 }

--- a/src/contentScript/tableRuntime/interaction/clickCursorPlacement.ts
+++ b/src/contentScript/tableRuntime/interaction/clickCursorPlacement.ts
@@ -18,6 +18,9 @@ import type { ResolvedActiveCell } from '../activeCell/resolvedActiveCell';
  * The rendered text of a normal cell aligns almost completely; a cell that is mostly formula,
  * emoji shortcodes or HTML entities does not, and the anchors left over are too sparse to place
  * a caret from. Half is well clear of both cases, not a tuned threshold.
+ *
+ * This is also what catches an alignment that anchored something in the wrong place: the scan
+ * never backtracks, so a bad anchor strands the rest of the cell and the ratio collapses with it.
  */
 const MIN_MATCHED_RATIO = 0.5;
 

--- a/src/contentScript/tableRuntime/interaction/clickCursorPlacement.ts
+++ b/src/contentScript/tableRuntime/interaction/clickCursorPlacement.ts
@@ -76,9 +76,7 @@ export function resolveRenderedSelection(
         alignment.hiddenSpans
     );
 
-    return {
-        localSelection: backward ? { anchor: span.to, head: span.from } : { anchor: span.from, head: span.to },
-    };
+    return backward ? { anchor: span.to, head: span.from } : { anchor: span.from, head: span.to };
 }
 
 /** Where each rendered character sits in the cell's own text; -1 where it has no anchor. */

--- a/src/contentScript/tableRuntime/interaction/clickCursorPlacement.ts
+++ b/src/contentScript/tableRuntime/interaction/clickCursorPlacement.ts
@@ -1,7 +1,7 @@
 import type { EditorState } from '@codemirror/state';
 import { unsanitizeRootText } from '../../shared/cellTextNormalization';
 import type { InitialCursorPos } from '../../shared/cursorPlacement';
-import { alignRenderedToSource, mapCaretToSource } from '../../shared/textAlignment';
+import { alignRenderedToSource, mapCaretToSource, mapSelectionToSource } from '../../shared/textAlignment';
 import type { RenderedCaretHit, RenderedSelectionHit } from '../../tableWidget/cellCaretHit';
 import { projectCellText } from './cellTextProjection';
 import type { ResolvedActiveCell } from '../activeCell/resolvedActiveCell';
@@ -42,25 +42,53 @@ export function resolveClickCursorPos(
         return undefined;
     }
 
-    const mapOffset = createRenderedOffsetMapper(state, resolvedCell, hit.renderedText);
-    return mapOffset ? { localOffset: mapOffset(hit.renderedOffset) } : undefined;
+    const alignment = alignRenderedCellText(state, resolvedCell, hit.renderedText);
+    return alignment
+        ? { localOffset: mapCaretToSource(alignment.toLocal, hit.renderedOffset, alignment.localLength) }
+        : undefined;
 }
 
-/** Uses one projection/alignment for both endpoints, including backward selections. */
+/**
+ * Resolves the range a rendered-text drag selected into the cell's own text.
+ *
+ * One alignment answers both ends, and `mapSelectionToSource` reads the span off the rendered
+ * characters the drag covered, so the Markdown syntax around them is included at both ends or
+ * neither. Direction is preserved: a backward drag opens the cell with a backward selection.
+ */
 export function resolveRenderedSelection(
     state: EditorState,
     resolvedCell: ResolvedActiveCell,
     hit: RenderedSelectionHit
 ): InitialCursorPos | undefined {
-    const mapOffset = createRenderedOffsetMapper(state, resolvedCell, hit.renderedText);
-    return mapOffset ? { localSelection: { anchor: mapOffset(hit.anchor), head: mapOffset(hit.head) } } : undefined;
+    const alignment = alignRenderedCellText(state, resolvedCell, hit.renderedText);
+    if (!alignment) {
+        return undefined;
+    }
+
+    const backward = hit.head < hit.anchor;
+    const span = mapSelectionToSource(
+        alignment.toLocal,
+        backward ? hit.head : hit.anchor,
+        backward ? hit.anchor : hit.head,
+        alignment.localLength
+    );
+
+    return {
+        localSelection: backward ? { anchor: span.to, head: span.from } : { anchor: span.from, head: span.to },
+    };
 }
 
-function createRenderedOffsetMapper(
+/** Where each rendered character sits in the cell's own text; -1 where it has no anchor. */
+interface RenderedCellAlignment {
+    toLocal: Int32Array;
+    localLength: number;
+}
+
+function alignRenderedCellText(
     state: EditorState,
     resolvedCell: ResolvedActiveCell,
     renderedText: string
-): ((offset: number) => number) | undefined {
+): RenderedCellAlignment | undefined {
     // Projection offsets must use the decoded text that the nested editor opens.
     const rootText = state.doc.sliceString(resolvedCell.editableFrom, resolvedCell.editableTo);
     const localText = unsanitizeRootText(rootText);
@@ -73,12 +101,15 @@ function createRenderedOffsetMapper(
 
     // The asynchronous renderer initially displays literal cell text.
     if (renderedText === localText) {
-        return (offset) => Math.max(0, Math.min(offset, localText.length));
+        return {
+            toLocal: Int32Array.from({ length: localText.length }, (_, index) => index),
+            localLength: localText.length,
+        };
     }
 
     const projection = projectCellText(state, resolvedCell, rootText, localText);
     if (renderedText === projection.text) {
-        return (offset) => mapCaretToSource(projection.toLocal, offset, localText.length);
+        return { toLocal: projection.toLocal, localLength: localText.length };
     }
 
     // Align only against visible source spans. Hidden syntax cannot become an anchor,
@@ -87,6 +118,9 @@ function createRenderedOffsetMapper(
     if (!alignment || alignment.matchedRatio < MIN_MATCHED_RATIO) {
         return undefined;
     }
-    const toLocal = Int32Array.from(alignment.toSource, (offset) => (offset < 0 ? -1 : projection.toLocal[offset]));
-    return (offset) => mapCaretToSource(toLocal, offset, localText.length);
+
+    return {
+        toLocal: Int32Array.from(alignment.toSource, (offset) => (offset < 0 ? -1 : projection.toLocal[offset])),
+        localLength: localText.length,
+    };
 }

--- a/src/contentScript/tableRuntime/interaction/clickCursorPlacement.ts
+++ b/src/contentScript/tableRuntime/interaction/clickCursorPlacement.ts
@@ -3,7 +3,7 @@ import { unsanitizeRootText } from '../../shared/cellTextNormalization';
 import type { InitialCursorPos } from '../../shared/cursorPlacement';
 import { alignRenderedToSource, mapCaretToSource, mapSelectionToSource } from '../../shared/textAlignment';
 import type { RenderedCaretHit, RenderedSelectionHit } from '../../tableWidget/cellCaretHit';
-import { projectCellText } from './cellTextProjection';
+import { balanceSyntaxMarkers, projectCellText, type HiddenSyntaxSpan } from './cellTextProjection';
 import type { ResolvedActiveCell } from '../activeCell/resolvedActiveCell';
 
 /**
@@ -53,7 +53,8 @@ export function resolveClickCursorPos(
  *
  * One alignment answers both ends, and `mapSelectionToSource` reads the span off the rendered
  * characters the drag covered, so the Markdown syntax around them is included at both ends or
- * neither. Direction is preserved: a backward drag opens the cell with a backward selection.
+ * neither, and `balanceSyntaxMarkers` keeps the range from holding half of a construct it
+ * reaches into. Direction is preserved: a backward drag opens the cell with a backward selection.
  */
 export function resolveRenderedSelection(
     state: EditorState,
@@ -66,11 +67,14 @@ export function resolveRenderedSelection(
     }
 
     const backward = hit.head < hit.anchor;
-    const span = mapSelectionToSource(
-        alignment.toLocal,
-        backward ? hit.head : hit.anchor,
-        backward ? hit.anchor : hit.head,
-        alignment.localLength
+    const span = balanceSyntaxMarkers(
+        mapSelectionToSource(
+            alignment.toLocal,
+            backward ? hit.head : hit.anchor,
+            backward ? hit.anchor : hit.head,
+            alignment.localLength
+        ),
+        alignment.hiddenSpans
     );
 
     return {
@@ -82,6 +86,8 @@ export function resolveRenderedSelection(
 interface RenderedCellAlignment {
     toLocal: Int32Array;
     localLength: number;
+    /** The cell's hidden syntax, for ranges that have to keep its markers paired. */
+    hiddenSpans: HiddenSyntaxSpan[];
 }
 
 function alignRenderedCellText(
@@ -101,15 +107,17 @@ function alignRenderedCellText(
 
     // The asynchronous renderer initially displays literal cell text.
     if (renderedText === localText) {
+        // Nothing is hidden while the literal text stands, so no range can split a marker pair.
         return {
             toLocal: Int32Array.from({ length: localText.length }, (_, index) => index),
             localLength: localText.length,
+            hiddenSpans: [],
         };
     }
 
     const projection = projectCellText(state, resolvedCell, rootText, localText);
     if (renderedText === projection.text) {
-        return { toLocal: projection.toLocal, localLength: localText.length };
+        return { toLocal: projection.toLocal, localLength: localText.length, hiddenSpans: projection.hiddenSpans };
     }
 
     // Align only against visible source spans. Hidden syntax cannot become an anchor,
@@ -122,5 +130,6 @@ function alignRenderedCellText(
     return {
         toLocal: Int32Array.from(alignment.toSource, (offset) => (offset < 0 ? -1 : projection.toLocal[offset])),
         localLength: localText.length,
+        hiddenSpans: projection.hiddenSpans,
     };
 }

--- a/src/contentScript/tableRuntime/interaction/clickCursorPlacement.ts
+++ b/src/contentScript/tableRuntime/interaction/clickCursorPlacement.ts
@@ -1,0 +1,85 @@
+import type { EditorState } from '@codemirror/state';
+import { unsanitizeRootText } from '../../shared/cellTextNormalization';
+import type { InitialCursorPos } from '../../shared/cursorPlacement';
+import { alignRenderedToSource, mapCaretToSource } from '../../shared/textAlignment';
+import type { RenderedCaretHit } from '../../tableWidget/cellCaretHit';
+import { projectCellText } from './cellTextProjection';
+import type { ResolvedActiveCell } from '../activeCell/resolvedActiveCell';
+
+/**
+ * Turns a press on a rendered cell into the caret placement the nested editor should open
+ * with, so clicking inside rendered Markdown lands the caret at the corresponding place in
+ * the Markdown source rather than at the start of the cell.
+ */
+
+/**
+ * Alignment quality below which the placement is abandoned.
+ *
+ * The rendered text of a normal cell aligns almost completely; a cell that is mostly
+ * formula, emoji shortcodes or HTML entities does not, and the anchors left over are too
+ * sparse to place a caret from. Half is well clear of both cases: it is a floor on
+ * "recognisably the same text", not a tuned threshold.
+ */
+const MIN_MATCHED_RATIO = 0.5;
+
+/**
+ * Resolves the caret placement for a press on `resolvedCell`.
+ *
+ * Returns undefined - not a placement of `'start'` - when there is nothing better to offer,
+ * which leaves the open request mirroring the main editor's own selection exactly as it did
+ * before. That is the established fallback for every other unplaced entry.
+ *
+ * The offset is measured against the cell text as it stands now. An entry that repairs the
+ * table into canonical form can restripe the cell's padding underneath it, so the offset is
+ * clamped where it is applied rather than trusted verbatim.
+ */
+export function resolveClickCursorPos(
+    state: EditorState,
+    resolvedCell: ResolvedActiveCell,
+    hit: RenderedCaretHit | null
+): InitialCursorPos | undefined {
+    if (!hit) {
+        return undefined;
+    }
+
+    // Projection offsets must use the decoded text that the nested editor opens.
+    const rootText = state.doc.sliceString(resolvedCell.editableFrom, resolvedCell.editableTo);
+    const localText = unsanitizeRootText(rootText);
+    if (hit.renderedText.length === 0 && localText.length > 0) {
+        // Images and skipped MathML contribute no rendered text. Their sole flattened offset
+        // cannot distinguish a press before the content from one after it, so keep the established
+        // mirrored-selection fallback instead of claiming every press belongs at source offset 0.
+        return undefined;
+    }
+
+    // The asynchronous renderer initially displays literal cell text.
+    if (hit.renderedText === localText) {
+        return { localOffset: Math.max(0, Math.min(hit.renderedOffset, localText.length)) };
+    }
+
+    const projection = projectCellText(state, resolvedCell, rootText, localText);
+    if (hit.renderedText === projection.text) {
+        return {
+            localOffset: mapCaretToSource(
+                { toSource: projection.toLocal, matchedRatio: 1 },
+                hit.renderedOffset,
+                localText.length
+            ),
+        };
+    }
+
+    // Align only against visible source spans. Hidden syntax cannot become an anchor,
+    // even when a URL, title or image label exactly duplicates the rendered text.
+    const alignment = alignRenderedToSource(hit.renderedText, projection.text);
+    if (!alignment || alignment.matchedRatio < MIN_MATCHED_RATIO) {
+        return undefined;
+    }
+    const toLocal = Int32Array.from(alignment.toSource, (offset) => (offset < 0 ? -1 : projection.toLocal[offset]));
+    return {
+        localOffset: mapCaretToSource(
+            { toSource: toLocal, matchedRatio: alignment.matchedRatio },
+            hit.renderedOffset,
+            localText.length
+        ),
+    };
+}

--- a/src/contentScript/tableRuntime/interaction/clickCursorPlacement.ts
+++ b/src/contentScript/tableRuntime/interaction/clickCursorPlacement.ts
@@ -1,6 +1,6 @@
 import type { EditorState } from '@codemirror/state';
 import { unsanitizeRootText } from '../../shared/cellTextNormalization';
-import type { InitialCursorPos } from '../../shared/cursorPlacement';
+import { cellTextCaret, type InitialCursorPos } from '../../shared/cursorPlacement';
 import { alignRenderedToSource, mapCaretToSource, mapSelectionToSource } from '../../shared/textAlignment';
 import type { RenderedCaretHit, RenderedSelectionHit } from '../../tableWidget/cellCaretHit';
 import { balanceSyntaxMarkers, projectCellText, type HiddenSyntaxSpan } from './cellTextProjection';
@@ -44,7 +44,7 @@ export function resolveClickCursorPos(
 
     const alignment = alignRenderedCellText(state, resolvedCell, hit.renderedText);
     return alignment
-        ? { localOffset: mapCaretToSource(alignment.toLocal, hit.renderedOffset, alignment.localLength) }
+        ? cellTextCaret(mapCaretToSource(alignment.toLocal, hit.renderedOffset, alignment.localLength))
         : undefined;
 }
 

--- a/src/contentScript/tableRuntime/interaction/clickCursorPlacement.ts
+++ b/src/contentScript/tableRuntime/interaction/clickCursorPlacement.ts
@@ -2,7 +2,7 @@ import type { EditorState } from '@codemirror/state';
 import { unsanitizeRootText } from '../../shared/cellTextNormalization';
 import type { InitialCursorPos } from '../../shared/cursorPlacement';
 import { alignRenderedToSource, mapCaretToSource } from '../../shared/textAlignment';
-import type { RenderedCaretHit } from '../../tableWidget/cellCaretHit';
+import type { RenderedCaretHit, RenderedSelectionHit } from '../../tableWidget/cellCaretHit';
 import { projectCellText } from './cellTextProjection';
 import type { ResolvedActiveCell } from '../activeCell/resolvedActiveCell';
 
@@ -42,10 +42,29 @@ export function resolveClickCursorPos(
         return undefined;
     }
 
+    const mapOffset = createRenderedOffsetMapper(state, resolvedCell, hit.renderedText);
+    return mapOffset ? { localOffset: mapOffset(hit.renderedOffset) } : undefined;
+}
+
+/** Uses one projection/alignment for both endpoints, including backward selections. */
+export function resolveRenderedSelection(
+    state: EditorState,
+    resolvedCell: ResolvedActiveCell,
+    hit: RenderedSelectionHit
+): InitialCursorPos | undefined {
+    const mapOffset = createRenderedOffsetMapper(state, resolvedCell, hit.renderedText);
+    return mapOffset ? { localSelection: { anchor: mapOffset(hit.anchor), head: mapOffset(hit.head) } } : undefined;
+}
+
+function createRenderedOffsetMapper(
+    state: EditorState,
+    resolvedCell: ResolvedActiveCell,
+    renderedText: string
+): ((offset: number) => number) | undefined {
     // Projection offsets must use the decoded text that the nested editor opens.
     const rootText = state.doc.sliceString(resolvedCell.editableFrom, resolvedCell.editableTo);
     const localText = unsanitizeRootText(rootText);
-    if (hit.renderedText.length === 0 && localText.length > 0) {
+    if (renderedText.length === 0 && localText.length > 0) {
         // Images and skipped MathML contribute no rendered text. Their sole flattened offset
         // cannot distinguish a press before the content from one after it, so keep the established
         // mirrored-selection fallback instead of claiming every press belongs at source offset 0.
@@ -53,25 +72,21 @@ export function resolveClickCursorPos(
     }
 
     // The asynchronous renderer initially displays literal cell text.
-    if (hit.renderedText === localText) {
-        return { localOffset: Math.max(0, Math.min(hit.renderedOffset, localText.length)) };
+    if (renderedText === localText) {
+        return (offset) => Math.max(0, Math.min(offset, localText.length));
     }
 
     const projection = projectCellText(state, resolvedCell, rootText, localText);
-    if (hit.renderedText === projection.text) {
-        return {
-            localOffset: mapCaretToSource(projection.toLocal, hit.renderedOffset, localText.length),
-        };
+    if (renderedText === projection.text) {
+        return (offset) => mapCaretToSource(projection.toLocal, offset, localText.length);
     }
 
     // Align only against visible source spans. Hidden syntax cannot become an anchor,
     // even when a URL, title or image label exactly duplicates the rendered text.
-    const alignment = alignRenderedToSource(hit.renderedText, projection.text);
+    const alignment = alignRenderedToSource(renderedText, projection.text);
     if (!alignment || alignment.matchedRatio < MIN_MATCHED_RATIO) {
         return undefined;
     }
     const toLocal = Int32Array.from(alignment.toSource, (offset) => (offset < 0 ? -1 : projection.toLocal[offset]));
-    return {
-        localOffset: mapCaretToSource(toLocal, hit.renderedOffset, localText.length),
-    };
+    return (offset) => mapCaretToSource(toLocal, offset, localText.length);
 }

--- a/src/contentScript/tableRuntime/interaction/clickCursorPlacement.ts
+++ b/src/contentScript/tableRuntime/interaction/clickCursorPlacement.ts
@@ -15,10 +15,9 @@ import type { ResolvedActiveCell } from '../activeCell/resolvedActiveCell';
 /**
  * Alignment quality below which the placement is abandoned.
  *
- * The rendered text of a normal cell aligns almost completely; a cell that is mostly
- * formula, emoji shortcodes or HTML entities does not, and the anchors left over are too
- * sparse to place a caret from. Half is well clear of both cases: it is a floor on
- * "recognisably the same text", not a tuned threshold.
+ * The rendered text of a normal cell aligns almost completely; a cell that is mostly formula,
+ * emoji shortcodes or HTML entities does not, and the anchors left over are too sparse to place
+ * a caret from. Half is well clear of both cases, not a tuned threshold.
  */
 const MIN_MATCHED_RATIO = 0.5;
 
@@ -30,7 +29,7 @@ const MIN_MATCHED_RATIO = 0.5;
  * before. That is the established fallback for every other unplaced entry.
  *
  * The offset is measured against the cell text as it stands now. An entry that repairs the
- * table into canonical form can restripe the cell's padding underneath it, so the offset is
+ * table into canonical form can rewrite the cell's padding underneath it, so the offset is
  * clamped where it is applied rather than trusted verbatim.
  */
 export function resolveClickCursorPos(

--- a/src/contentScript/tableRuntime/interaction/clickCursorPlacement.ts
+++ b/src/contentScript/tableRuntime/interaction/clickCursorPlacement.ts
@@ -60,11 +60,7 @@ export function resolveClickCursorPos(
     const projection = projectCellText(state, resolvedCell, rootText, localText);
     if (hit.renderedText === projection.text) {
         return {
-            localOffset: mapCaretToSource(
-                { toSource: projection.toLocal, matchedRatio: 1 },
-                hit.renderedOffset,
-                localText.length
-            ),
+            localOffset: mapCaretToSource(projection.toLocal, hit.renderedOffset, localText.length),
         };
     }
 
@@ -76,10 +72,6 @@ export function resolveClickCursorPos(
     }
     const toLocal = Int32Array.from(alignment.toSource, (offset) => (offset < 0 ? -1 : projection.toLocal[offset]));
     return {
-        localOffset: mapCaretToSource(
-            { toSource: toLocal, matchedRatio: alignment.matchedRatio },
-            hit.renderedOffset,
-            localText.length
-        ),
+        localOffset: mapCaretToSource(toLocal, hit.renderedOffset, localText.length),
     };
 }

--- a/src/contentScript/tableRuntime/interaction/mouseCellDragSelection.ts
+++ b/src/contentScript/tableRuntime/interaction/mouseCellDragSelection.ts
@@ -44,7 +44,6 @@ interface MouseCellGesture {
     anchorCell: HTMLElement;
     resolvedCell: ResolvedActiveCell;
     dragged: boolean;
-    previousUserSelect?: string;
     lastFocus: CellCoords | null;
     lastClientX: number;
     lastClientY: number;
@@ -142,9 +141,10 @@ class MouseCellDragSelectionController {
                 return;
             }
             if (gesture.origin === 'renderedCell') {
+                // The press began as a native text selection; drop the range it made. Further
+                // selection is suppressed by `tableWidget/cellSelectionVisuals.ts`, which keys
+                // off the drag state the rectangle above has just entered.
                 this.capturePointer(gesture);
-                gesture.previousUserSelect = gesture.widget.style.userSelect;
-                gesture.widget.style.userSelect = 'none';
                 this.view.dom.ownerDocument.getSelection()?.removeAllRanges();
             }
         } else {
@@ -452,9 +452,6 @@ class MouseCellDragSelectionController {
         }
 
         this.gesture = null;
-        if (gesture.previousUserSelect !== undefined) {
-            gesture.widget.style.userSelect = gesture.previousUserSelect;
-        }
         const doc = this.view.dom.ownerDocument;
         doc.removeEventListener('pointermove', this.onPointerMove, true);
         doc.removeEventListener('pointerup', this.onPointerUp, true);

--- a/src/contentScript/tableRuntime/interaction/mouseCellDragSelection.ts
+++ b/src/contentScript/tableRuntime/interaction/mouseCellDragSelection.ts
@@ -11,6 +11,9 @@ import { getViewportHeight, resolveViewportBounds } from '../../shared/editorVie
 import { clamp } from '../../shared/numberUtils';
 import { isPrimaryMouseButton, isPrimaryMousePointer } from '../../shared/mouseEvents';
 import { SELECTOR_CELL, getWidgetSelector, readCellCoords } from '../../tableWidget/domHelpers';
+import { readRenderedCaretHit, type RenderedCaretHit } from '../../tableWidget/cellCaretHit';
+import { resolveClickCursorPos } from './clickCursorPlacement';
+import type { InitialCursorPos } from '../../shared/cursorPlacement';
 import { CellDragAutoScroller } from './mouseCellDragAutoScroll';
 
 const DRAG_START_DISTANCE_PX = 5;
@@ -44,6 +47,27 @@ interface MouseCellGesture {
     lastFocus: CellCoords | null;
     lastClientX: number;
     lastClientY: number;
+    /**
+     * Caret the press pointed at, read while the rendered content was still mounted.
+     * Only a press on a rendered cell carries one: an active-editor press already has a
+     * nested editor to place its own caret, and a drag discards it.
+     */
+    pressCaretHit: RenderedCaretHit | null;
+}
+
+/**
+ * What a pointer release resolved to, read before the release dispatches anything.
+ *
+ * Both the anchor and the caret placement depend on the document and the widget DOM as the
+ * press left them, and settling the release changes both.
+ */
+interface GestureRelease {
+    /** The pressed anchor against the current document, or null when it no longer resolves. */
+    resolvedAnchor: ResolvedActiveCell | null;
+    /** Caret the press pointed at, for a click that reopens the anchor. */
+    cursorPos: InitialCursorPos | undefined;
+    /** The drag ended back on the cell it started from, so that cell takes the caret again. */
+    reactivateAnchor: boolean;
 }
 
 /** Squared distance between two points. */
@@ -137,45 +161,74 @@ class MouseCellDragSelectionController {
             return;
         }
 
-        const pointedCell = this.resolveCellAtPoint(event, gesture);
-        const resolvedAnchor = gesture.origin === 'renderedCell' ? this.resolveCurrentRenderedAnchor(gesture) : null;
-        const shouldReactivateAnchor =
-            gesture.dragged && pointedCell !== null && isSameCellCoords(gesture.resolvedCell.activeCell, pointedCell);
+        const release = this.resolveRelease(event, gesture);
         const willReactivateAnchor =
-            shouldReactivateAnchor && (gesture.origin === 'activeEditor' || resolvedAnchor !== null);
-        const shouldConsume = gesture.origin === 'renderedCell' || gesture.dragged;
-        if (shouldConsume) {
+            release.reactivateAnchor && (gesture.origin === 'activeEditor' || release.resolvedAnchor !== null);
+
+        if (gesture.origin === 'renderedCell' || gesture.dragged) {
             event.preventDefault();
             event.stopPropagation();
         }
+
         // Only an active-editor drag can hand its own still-open anchor back; a rendered-cell
         // drag reopens the anchor below, so whatever cell it left active is cleared first.
         this.finishGesture({
-            keepActiveCell: shouldReactivateAnchor && gesture.origin === 'activeEditor',
+            keepActiveCell: release.reactivateAnchor && gesture.origin === 'activeEditor',
             focusSelection: !willReactivateAnchor,
         });
 
-        if (gesture.origin === 'renderedCell' && !gesture.dragged) {
-            if (resolvedAnchor) {
-                requestOpenCell(this.view, {
-                    resolvedCell: resolvedAnchor,
-                    clearCellSelection: Boolean(getCellSelection(this.view.state)),
-                });
-            }
-        } else if (shouldReactivateAnchor && gesture.origin === 'renderedCell') {
-            if (resolvedAnchor) {
-                requestOpenCell(this.view, {
-                    resolvedCell: resolvedAnchor,
-                    clearCellSelection: true,
-                });
-            }
-        } else if (shouldReactivateAnchor) {
-            // The anchor editor never left the DOM, so contracting back to it only needs
-            // to discard the provisional rectangle and restore keyboard focus.
-            this.view.dispatch({ effects: clearCellSelectionEffect.of(undefined) });
-            refocusNestedEditor(this.view);
-        }
+        this.settleRelease(gesture, release);
     };
+
+    /**
+     * Reads everything about the release that depends on the view as the press left it.
+     *
+     * Resolved before `finishGesture` dispatches, so the caret placement is aligned against
+     * the cell text that was actually pressed.
+     */
+    private resolveRelease(event: PointerEvent, gesture: MouseCellGesture): GestureRelease {
+        const pointedCell = this.resolveCellAtPoint(event, gesture);
+        const resolvedAnchor = gesture.origin === 'renderedCell' ? this.resolveCurrentRenderedAnchor(gesture) : null;
+
+        return {
+            resolvedAnchor,
+            cursorPos:
+                !gesture.dragged && resolvedAnchor
+                    ? resolveClickCursorPos(this.view.state, resolvedAnchor, gesture.pressCaretHit)
+                    : undefined,
+            reactivateAnchor:
+                gesture.dragged &&
+                pointedCell !== null &&
+                isSameCellCoords(gesture.resolvedCell.activeCell, pointedCell),
+        };
+    }
+
+    /** Hands the released gesture to whichever cell should own the caret now. */
+    private settleRelease(gesture: MouseCellGesture, release: GestureRelease): void {
+        if (gesture.origin !== 'renderedCell') {
+            if (release.reactivateAnchor) {
+                // The anchor editor never left the DOM, so contracting back to it only needs
+                // to discard the provisional rectangle and restore keyboard focus.
+                this.view.dispatch({ effects: clearCellSelectionEffect.of(undefined) });
+                refocusNestedEditor(this.view);
+            }
+            return;
+        }
+
+        // An anchor that no longer resolves cannot be reopened, and a drag that ended
+        // anywhere but its anchor leaves its own selection standing.
+        if (!release.resolvedAnchor || (gesture.dragged && !release.reactivateAnchor)) {
+            return;
+        }
+
+        requestOpenCell(this.view, {
+            resolvedCell: release.resolvedAnchor,
+            clearCellSelection: gesture.dragged || Boolean(getCellSelection(this.view.state)),
+            // A drag that contracted back onto its anchor asked for a cell selection, not for
+            // a caret at the point the press happened to start from.
+            initialCursorPos: gesture.dragged ? undefined : release.cursorPos,
+        });
+    }
 
     private readonly onPointerCancel = (event: PointerEvent): void => {
         if (this.gesture?.pointerId === event.pointerId) {
@@ -226,6 +279,8 @@ class MouseCellDragSelectionController {
             lastFocus: null,
             lastClientX: event.clientX,
             lastClientY: event.clientY,
+            pressCaretHit:
+                options.origin === 'renderedCell' ? readRenderedCaretHit(cell, event.clientX, event.clientY) : null,
         });
 
         if (options.origin === 'renderedCell') {

--- a/src/contentScript/tableRuntime/interaction/mouseCellDragSelection.ts
+++ b/src/contentScript/tableRuntime/interaction/mouseCellDragSelection.ts
@@ -11,7 +11,12 @@ import { getViewportHeight, resolveViewportBounds } from '../../shared/editorVie
 import { clamp } from '../../shared/numberUtils';
 import { isPrimaryMouseButton, isPrimaryMousePointer, type PressDisposition } from '../../shared/mouseEvents';
 import { SELECTOR_CELL, getWidgetSelector, readCellCoords } from '../../tableWidget/domHelpers';
-import { readRenderedCaretHit, readRenderedSelectionHit, type RenderedCaretHit } from '../../tableWidget/cellCaretHit';
+import {
+    readRenderedCaretHit,
+    readRenderedSelectionHit,
+    setRenderedTextSelection,
+    type RenderedCaretDomHit,
+} from '../../tableWidget/cellCaretHit';
 import { resolveClickCursorPos, resolveRenderedSelection } from './clickCursorPlacement';
 import type { InitialCursorPos } from '../../shared/cursorPlacement';
 import { CellDragAutoScroller } from './mouseCellDragAutoScroll';
@@ -34,9 +39,9 @@ export type MouseCellGestureOrigin = 'renderedCell' | 'activeEditorPadding' | 'a
 
 /** What a press on each origin does to its own pointerdown and compatibility mousedown. */
 const ORIGIN_PRESS_DISPOSITION: Record<MouseCellGestureOrigin, PressDisposition> = {
-    // Claimed but not prevented: the browser draws the text selection the release maps back
-    // into Markdown, and the outer editor must not move its caret over the top of it.
-    renderedCell: 'claim',
+    // Drive the rendered text range ourselves. A native drag would keep auto-scrolling
+    // the editor even after promotion to a cell rectangle.
+    renderedCell: 'consume',
     // Padding has no native text-selection behaviour worth preserving.
     activeEditorPadding: 'consume',
     // The nested editor owns its own press; the gesture only watches for the pointer leaving.
@@ -66,7 +71,7 @@ interface MouseCellGesture {
      * Only a press on a rendered cell carries one: an active-editor press already has a
      * nested editor to place its own caret, and a drag discards it.
      */
-    pressCaretHit: RenderedCaretHit | null;
+    pressCaretHit: RenderedCaretDomHit | null;
 }
 
 /**
@@ -144,6 +149,7 @@ class MouseCellDragSelectionController {
                 distanceSquared(event.clientX, event.clientY, gesture.startX, gesture.startY) <
                     DRAG_START_DISTANCE_SQUARED
             ) {
+                this.updateRenderedTextSelection(gesture);
                 return;
             }
 
@@ -155,9 +161,7 @@ class MouseCellDragSelectionController {
                 return;
             }
             if (gesture.origin === 'renderedCell') {
-                // The press began as a native text selection; drop the range it made. Further
-                // selection is suppressed by `tableWidget/cellSelectionVisuals.ts`, which keys
-                // off the drag state the rectangle above has just entered.
+                // The rendered range belongs to this gesture; stop painting it on promotion.
                 this.capturePointer(gesture);
                 this.view.dom.ownerDocument.getSelection()?.removeAllRanges();
             }
@@ -284,6 +288,9 @@ class MouseCellDragSelectionController {
             return false;
         }
 
+        const pressCaretHit =
+            origin === 'renderedCell' ? readRenderedCaretHit(cell, event.clientX, event.clientY) : null;
+
         this.beginGesture({
             origin,
             pointerId: event.pointerId,
@@ -297,8 +304,18 @@ class MouseCellDragSelectionController {
             lastFocus: null,
             lastClientX: event.clientX,
             lastClientY: event.clientY,
-            pressCaretHit: origin === 'renderedCell' ? readRenderedCaretHit(cell, event.clientX, event.clientY) : null,
+            pressCaretHit,
         });
+
+        if (origin === 'renderedCell') {
+            // The gesture owns the DOM selection from here. Collapse it at the pressed caret,
+            // or drop whatever was standing when the press had no caret to offer.
+            if (pressCaretHit) {
+                setRenderedTextSelection(cell, pressCaretHit, pressCaretHit);
+            } else {
+                this.view.dom.ownerDocument.getSelection()?.removeAllRanges();
+            }
+        }
 
         return true;
     }
@@ -320,6 +337,19 @@ class MouseCellDragSelectionController {
 
     private resolveCellAtPoint(event: PointerEvent, gesture: MouseCellGesture): CellCoords | null {
         return this.resolveCellAtClientPoint(event.clientX, event.clientY, gesture);
+    }
+
+    /** Extends the range the press is drawing to the caret the pointer now rests on. */
+    private updateRenderedTextSelection(gesture: MouseCellGesture): void {
+        const anchor = gesture.pressCaretHit;
+        if (!anchor) {
+            return;
+        }
+
+        const head = readRenderedCaretHit(gesture.anchorCell, gesture.lastClientX, gesture.lastClientY);
+        if (head) {
+            setRenderedTextSelection(gesture.anchorCell, anchor, head);
+        }
     }
 
     private resolveCellAtClientPoint(clientX: number, clientY: number, gesture: MouseCellGesture): CellCoords | null {

--- a/src/contentScript/tableRuntime/interaction/mouseCellDragSelection.ts
+++ b/src/contentScript/tableRuntime/interaction/mouseCellDragSelection.ts
@@ -9,7 +9,7 @@ import { flushNestedEditorState, refocusNestedEditor } from '../../nestedEditor/
 import { getViewWindow } from '../../shared/domContext';
 import { getViewportHeight, resolveViewportBounds } from '../../shared/editorViewport';
 import { clamp } from '../../shared/numberUtils';
-import { isPrimaryMouseButton, isPrimaryMousePointer, type PressDisposition } from '../../shared/mouseEvents';
+import { isPrimaryMouseButton, isPrimaryMousePointer } from '../../shared/mouseEvents';
 import { SELECTOR_CELL, getWidgetSelector, readCellCoords } from '../../tableWidget/domHelpers';
 import {
     readRenderedCaretHit,
@@ -37,15 +37,18 @@ const BOUNDARY_EXIT_DISTANCE_SQUARED = BOUNDARY_EXIT_DISTANCE_PX * BOUNDARY_EXIT
  */
 export type MouseCellGestureOrigin = 'renderedCell' | 'activeEditorPadding' | 'activeEditorText';
 
-/** What a press on each origin does to its own pointerdown and compatibility mousedown. */
-const ORIGIN_PRESS_DISPOSITION: Record<MouseCellGestureOrigin, PressDisposition> = {
+/**
+ * Whether a press on each origin is taken from the editor, along with the compatibility
+ * mousedown behind it.
+ */
+const ORIGIN_CONSUMES_PRESS: Record<MouseCellGestureOrigin, boolean> = {
     // Drive the rendered text range ourselves. A native drag would keep auto-scrolling
     // the editor even after promotion to a cell rectangle.
-    renderedCell: 'consume',
+    renderedCell: true,
     // Padding has no native text-selection behaviour worth preserving.
-    activeEditorPadding: 'consume',
+    activeEditorPadding: true,
     // The nested editor owns its own press; the gesture only watches for the pointer leaving.
-    activeEditorText: 'native',
+    activeEditorText: false,
 };
 
 /** True for the origins whose press belongs to the nested editor rather than to a rendered cell. */
@@ -320,13 +323,9 @@ class MouseCellDragSelectionController {
         return true;
     }
 
-    /** The compatibility mousedown behind a press this gesture already owns. */
-    compatibilityMouseDownDisposition(event: MouseEvent): PressDisposition {
-        if (!this.gesture || !isPrimaryMouseButton(event)) {
-            return 'native';
-        }
-
-        return ORIGIN_PRESS_DISPOSITION[this.gesture.origin];
+    /** True when the compatibility mousedown behind a press this gesture owns should be taken. */
+    consumesCompatibilityMouseDown(event: MouseEvent): boolean {
+        return Boolean(this.gesture && isPrimaryMouseButton(event) && ORIGIN_CONSUMES_PRESS[this.gesture.origin]);
     }
 
     destroy(): void {
@@ -524,10 +523,10 @@ class MouseCellDragSelectionController {
 export const mouseCellDragSelectionPlugin = ViewPlugin.fromClass(MouseCellDragSelectionController);
 
 /**
- * Starts a gesture for a press on `cell`, and reports what should happen to that event.
+ * Starts a gesture for a press on `cell`, and reports whether that press is taken from the editor.
  *
- * The disposition is returned rather than applied, so one router decides what happens to every
- * press it sees; see `tableWidget/tableWidgetInteractions.ts`.
+ * The answer is returned rather than applied, so one router decides what happens to every press
+ * it sees; see `tableWidget/tableWidgetInteractions.ts`.
  */
 export function beginMouseCellGesture(
     view: EditorView,
@@ -535,12 +534,12 @@ export function beginMouseCellGesture(
     cell: HTMLElement,
     resolvedCell: ResolvedActiveCell,
     origin: MouseCellGestureOrigin
-): PressDisposition {
+): boolean {
     const started = view.plugin?.(mouseCellDragSelectionPlugin)?.begin(event, cell, resolvedCell, origin) ?? false;
-    return started ? ORIGIN_PRESS_DISPOSITION[origin] : 'native';
+    return started && ORIGIN_CONSUMES_PRESS[origin];
 }
 
-/** What should happen to the compatibility mousedown behind a running gesture's press. */
-export function mouseCellGestureMouseDownDisposition(view: EditorView, event: MouseEvent): PressDisposition {
-    return view.plugin?.(mouseCellDragSelectionPlugin)?.compatibilityMouseDownDisposition(event) ?? 'native';
+/** True when the compatibility mousedown behind a running gesture's press should be taken. */
+export function mouseCellGestureConsumesMouseDown(view: EditorView, event: MouseEvent): boolean {
+    return view.plugin?.(mouseCellDragSelectionPlugin)?.consumesCompatibilityMouseDown(event) ?? false;
 }

--- a/src/contentScript/tableRuntime/interaction/mouseCellDragSelection.ts
+++ b/src/contentScript/tableRuntime/interaction/mouseCellDragSelection.ts
@@ -13,9 +13,9 @@ import { isPrimaryMouseButton, isPrimaryMousePointer } from '../../shared/mouseE
 import { SELECTOR_CELL, getWidgetSelector, readCellCoords } from '../../tableWidget/domHelpers';
 import {
     readRenderedCaretHit,
-    readRenderedSelectionHit,
     setRenderedTextSelection,
     type RenderedCaretDomHit,
+    type RenderedSelectionHit,
 } from '../../tableWidget/cellCaretHit';
 import { resolveClickCursorPos, resolveRenderedSelection } from './clickCursorPlacement';
 import type { InitialCursorPos } from '../../shared/cursorPlacement';
@@ -75,6 +75,8 @@ interface MouseCellGesture {
      * nested editor to place its own caret, and a drag discards it.
      */
     pressCaretHit: RenderedCaretDomHit | null;
+    /** Caret the last painted range ran to, which with `pressCaretHit` is that range. */
+    lastHeadHit: RenderedCaretDomHit | null;
 }
 
 /**
@@ -90,6 +92,29 @@ interface GestureRelease {
     cursorPos: InitialCursorPos | undefined;
     /** The drag ended back on the cell it started from, so that cell takes the caret again. */
     reactivateAnchor: boolean;
+}
+
+/**
+ * The range the press drew across its anchor cell, or null when it drew none.
+ *
+ * The gesture is the only writer of the DOM selection inside a rendered cell: the press is taken
+ * from the browser, so there is no native drag or double-click word selection to add one. Both
+ * endpoints are therefore the hits it painted from, and reading the range back out of the DOM
+ * would only re-derive them.
+ *
+ * The two must be measured against the same rendered text. A re-render between press and release
+ * leaves their offsets incomparable, and the caret the press read is the better answer then.
+ */
+function renderedSelectionFromGesture(gesture: MouseCellGesture): RenderedSelectionHit | null {
+    const anchor = gesture.pressCaretHit;
+    const head = gesture.lastHeadHit;
+    if (!anchor || !head || head.renderedText !== anchor.renderedText) {
+        return null;
+    }
+
+    return head.renderedOffset === anchor.renderedOffset
+        ? null
+        : { renderedText: anchor.renderedText, anchor: anchor.renderedOffset, head: head.renderedOffset };
 }
 
 /** Squared distance between two points. */
@@ -222,7 +247,7 @@ class MouseCellDragSelectionController {
 
         let cursorPos: InitialCursorPos | undefined;
         if (!gesture.dragged && resolvedAnchor) {
-            const selectionHit = readRenderedSelectionHit(gesture.anchorCell);
+            const selectionHit = renderedSelectionFromGesture(gesture);
             cursorPos = selectionHit
                 ? resolveRenderedSelection(this.view.state, resolvedAnchor, selectionHit)
                 : resolveClickCursorPos(this.view.state, resolvedAnchor, gesture.pressCaretHit);
@@ -308,6 +333,7 @@ class MouseCellDragSelectionController {
             lastClientX: event.clientX,
             lastClientY: event.clientY,
             pressCaretHit,
+            lastHeadHit: null,
         });
 
         if (origin === 'renderedCell') {
@@ -347,6 +373,7 @@ class MouseCellDragSelectionController {
 
         const head = readRenderedCaretHit(gesture.anchorCell, gesture.lastClientX, gesture.lastClientY);
         if (head) {
+            gesture.lastHeadHit = head;
             setRenderedTextSelection(gesture.anchorCell, anchor, head);
         }
     }

--- a/src/contentScript/tableRuntime/interaction/mouseCellDragSelection.ts
+++ b/src/contentScript/tableRuntime/interaction/mouseCellDragSelection.ts
@@ -25,7 +25,7 @@ const BOUNDARY_EXIT_DISTANCE_PX = 8;
 const BOUNDARY_EXIT_DISTANCE_SQUARED = BOUNDARY_EXIT_DISTANCE_PX * BOUNDARY_EXIT_DISTANCE_PX;
 
 /**
- * Where the press landed, which is also what the gesture owes the event that carried it.
+ * Where the press landed, which also decides what the gesture does with the event.
  *
  * The active cell is two origins rather than one because its editor and its row-height padding
  * want opposite things from the same press.
@@ -494,7 +494,7 @@ class MouseCellDragSelectionController {
 export const mouseCellDragSelectionPlugin = ViewPlugin.fromClass(MouseCellDragSelectionController);
 
 /**
- * Starts a gesture for a press on `cell`, and reports what the press owes its own event.
+ * Starts a gesture for a press on `cell`, and reports what should happen to that event.
  *
  * The disposition is returned rather than applied, so one router decides what happens to every
  * press it sees; see `tableWidget/tableWidgetInteractions.ts`.
@@ -510,7 +510,7 @@ export function beginMouseCellGesture(
     return started ? ORIGIN_PRESS_DISPOSITION[origin] : 'native';
 }
 
-/** What the compatibility mousedown behind a running gesture's press owes that gesture. */
+/** What should happen to the compatibility mousedown behind a running gesture's press. */
 export function mouseCellGestureMouseDownDisposition(view: EditorView, event: MouseEvent): PressDisposition {
     return view.plugin?.(mouseCellDragSelectionPlugin)?.compatibilityMouseDownDisposition(event) ?? 'native';
 }

--- a/src/contentScript/tableRuntime/interaction/mouseCellDragSelection.ts
+++ b/src/contentScript/tableRuntime/interaction/mouseCellDragSelection.ts
@@ -9,7 +9,7 @@ import { flushNestedEditorState, refocusNestedEditor } from '../../nestedEditor/
 import { getViewWindow } from '../../shared/domContext';
 import { getViewportHeight, resolveViewportBounds } from '../../shared/editorViewport';
 import { clamp } from '../../shared/numberUtils';
-import { isPrimaryMouseButton, isPrimaryMousePointer } from '../../shared/mouseEvents';
+import { isPrimaryMouseButton, isPrimaryMousePointer, type PressDisposition } from '../../shared/mouseEvents';
 import { SELECTOR_CELL, getWidgetSelector, readCellCoords } from '../../tableWidget/domHelpers';
 import { readRenderedCaretHit, readRenderedSelectionHit, type RenderedCaretHit } from '../../tableWidget/cellCaretHit';
 import { resolveClickCursorPos, resolveRenderedSelection } from './clickCursorPlacement';
@@ -24,18 +24,32 @@ const HIT_TEST_INSET_PX = 1;
 const BOUNDARY_EXIT_DISTANCE_PX = 8;
 const BOUNDARY_EXIT_DISTANCE_SQUARED = BOUNDARY_EXIT_DISTANCE_PX * BOUNDARY_EXIT_DISTANCE_PX;
 
-type MouseCellGestureOrigin = 'renderedCell' | 'activeEditor';
+/**
+ * Where the press landed, which is also what the gesture owes the event that carried it.
+ *
+ * The active cell is two origins rather than one because its editor and its row-height padding
+ * want opposite things from the same press.
+ */
+export type MouseCellGestureOrigin = 'renderedCell' | 'activeEditorPadding' | 'activeEditorText';
 
-export interface MouseCellGestureOptions {
-    /** Where the press landed: a rendered cell, or the active cell that already owns an editor. */
-    origin: MouseCellGestureOrigin;
-    /** Claim the pointerdown and its compatibility mousedown rather than leaving them native. */
-    consumeInitialEvents: boolean;
+/** What a press on each origin does to its own pointerdown and compatibility mousedown. */
+const ORIGIN_PRESS_DISPOSITION: Record<MouseCellGestureOrigin, PressDisposition> = {
+    // Claimed but not prevented: the browser draws the text selection the release maps back
+    // into Markdown, and the outer editor must not move its caret over the top of it.
+    renderedCell: 'claim',
+    // Padding has no native text-selection behaviour worth preserving.
+    activeEditorPadding: 'consume',
+    // The nested editor owns its own press; the gesture only watches for the pointer leaving.
+    activeEditorText: 'native',
+};
+
+/** True for the origins whose press belongs to the nested editor rather than to a rendered cell. */
+function ownsNestedEditor(origin: MouseCellGestureOrigin): boolean {
+    return origin !== 'renderedCell';
 }
 
 interface MouseCellGesture {
     origin: MouseCellGestureOrigin;
-    consumeCompatibilityMouseDown: boolean;
     pointerId: number;
     startX: number;
     startY: number;
@@ -106,7 +120,7 @@ class MouseCellDragSelectionController {
 
         const pointedCell = this.resolveCellAtPoint(event, gesture);
         if (!gesture.dragged) {
-            if (gesture.origin === 'activeEditor') {
+            if (ownsNestedEditor(gesture.origin)) {
                 // Until the pointer clears the anchor cell's border by a margin, the nested
                 // editor retains full ownership so its native text-selection drag continues
                 // uninterrupted.
@@ -172,7 +186,7 @@ class MouseCellDragSelectionController {
 
         const release = this.resolveRelease(event, gesture);
         const willReactivateAnchor =
-            release.reactivateAnchor && (gesture.origin === 'activeEditor' || release.resolvedAnchor !== null);
+            release.reactivateAnchor && (ownsNestedEditor(gesture.origin) || release.resolvedAnchor !== null);
 
         if (gesture.origin === 'renderedCell' || gesture.dragged) {
             event.preventDefault();
@@ -182,7 +196,7 @@ class MouseCellDragSelectionController {
         // Only an active-editor drag can hand its own still-open anchor back; a rendered-cell
         // drag reopens the anchor below, so whatever cell it left active is cleared first.
         this.finishGesture({
-            keepActiveCell: release.reactivateAnchor && gesture.origin === 'activeEditor',
+            keepActiveCell: release.reactivateAnchor && ownsNestedEditor(gesture.origin),
             focusSelection: !willReactivateAnchor,
         });
 
@@ -258,7 +272,7 @@ class MouseCellDragSelectionController {
         event: PointerEvent,
         cell: HTMLElement,
         resolvedCell: ResolvedActiveCell,
-        options: MouseCellGestureOptions
+        origin: MouseCellGestureOrigin
     ): boolean {
         if (!isPrimaryMousePointer(event)) {
             return false;
@@ -270,14 +284,8 @@ class MouseCellDragSelectionController {
             return false;
         }
 
-        // Rendered text keeps the browser default, while capture prevents the outer editor
-        // from handling the same press. Active-editor padding retains its existing behavior.
-        if (options.consumeInitialEvents) event.preventDefault();
-        if (options.consumeInitialEvents || options.origin === 'renderedCell') event.stopPropagation();
-
         this.beginGesture({
-            origin: options.origin,
-            consumeCompatibilityMouseDown: options.consumeInitialEvents || options.origin === 'renderedCell',
+            origin,
             pointerId: event.pointerId,
             startX: event.clientX,
             startY: event.clientY,
@@ -289,21 +297,19 @@ class MouseCellDragSelectionController {
             lastFocus: null,
             lastClientX: event.clientX,
             lastClientY: event.clientY,
-            pressCaretHit:
-                options.origin === 'renderedCell' ? readRenderedCaretHit(cell, event.clientX, event.clientY) : null,
+            pressCaretHit: origin === 'renderedCell' ? readRenderedCaretHit(cell, event.clientX, event.clientY) : null,
         });
 
         return true;
     }
 
-    consumeCompatibilityMouseDown(event: MouseEvent): boolean {
-        if (!this.gesture?.consumeCompatibilityMouseDown || !isPrimaryMouseButton(event)) {
-            return false;
+    /** The compatibility mousedown behind a press this gesture already owns. */
+    compatibilityMouseDownDisposition(event: MouseEvent): PressDisposition {
+        if (!this.gesture || !isPrimaryMouseButton(event)) {
+            return 'native';
         }
 
-        if (this.gesture.origin !== 'renderedCell') event.preventDefault();
-        event.stopPropagation();
-        return true;
+        return ORIGIN_PRESS_DISPOSITION[this.gesture.origin];
     }
 
     destroy(): void {
@@ -487,16 +493,24 @@ class MouseCellDragSelectionController {
 
 export const mouseCellDragSelectionPlugin = ViewPlugin.fromClass(MouseCellDragSelectionController);
 
+/**
+ * Starts a gesture for a press on `cell`, and reports what the press owes its own event.
+ *
+ * The disposition is returned rather than applied, so one router decides what happens to every
+ * press it sees; see `tableWidget/tableWidgetInteractions.ts`.
+ */
 export function beginMouseCellGesture(
     view: EditorView,
     event: PointerEvent,
     cell: HTMLElement,
     resolvedCell: ResolvedActiveCell,
-    options: MouseCellGestureOptions
-): boolean {
-    return view.plugin?.(mouseCellDragSelectionPlugin)?.begin(event, cell, resolvedCell, options) ?? false;
+    origin: MouseCellGestureOrigin
+): PressDisposition {
+    const started = view.plugin?.(mouseCellDragSelectionPlugin)?.begin(event, cell, resolvedCell, origin) ?? false;
+    return started ? ORIGIN_PRESS_DISPOSITION[origin] : 'native';
 }
 
-export function consumeMouseCellGestureMouseDown(view: EditorView, event: MouseEvent): boolean {
-    return view.plugin?.(mouseCellDragSelectionPlugin)?.consumeCompatibilityMouseDown(event) ?? false;
+/** What the compatibility mousedown behind a running gesture's press owes that gesture. */
+export function mouseCellGestureMouseDownDisposition(view: EditorView, event: MouseEvent): PressDisposition {
+    return view.plugin?.(mouseCellDragSelectionPlugin)?.compatibilityMouseDownDisposition(event) ?? 'native';
 }

--- a/src/contentScript/tableRuntime/interaction/mouseCellDragSelection.ts
+++ b/src/contentScript/tableRuntime/interaction/mouseCellDragSelection.ts
@@ -153,38 +153,26 @@ class MouseCellDragSelectionController {
 
         const pointedCell = this.resolveCellAtPoint(event, gesture);
         if (!gesture.dragged) {
-            if (ownsNestedEditor(gesture.origin)) {
-                // Until the pointer clears the anchor cell's border by a margin, the nested
-                // editor retains full ownership so its native text-selection drag continues
-                // uninterrupted.
-                if (
-                    !pointedCell ||
-                    isSameCellCoords(gesture.resolvedCell.activeCell, pointedCell) ||
-                    distanceOutsideRectSquared(
-                        event.clientX,
-                        event.clientY,
-                        gesture.anchorCell.getBoundingClientRect()
-                    ) < BOUNDARY_EXIT_DISTANCE_SQUARED
-                ) {
-                    return;
+            const promoteTo = this.promotionTarget(gesture, event, pointedCell);
+            if (!promoteTo) {
+                // The press keeps whatever it is still doing in its own cell: drawing a rendered
+                // text range, or leaving the nested editor's native drag alone.
+                if (!ownsNestedEditor(gesture.origin)) {
+                    this.updateRenderedTextSelection(gesture);
                 }
+                return;
+            }
+
+            if (ownsNestedEditor(gesture.origin)) {
                 this.capturePointer(gesture);
                 flushNestedEditorState(this.view);
                 this.endNativeTextDrag(event);
-            } else if (
-                !pointedCell ||
-                isSameCellCoords(gesture.resolvedCell.activeCell, pointedCell) ||
-                distanceSquared(event.clientX, event.clientY, gesture.startX, gesture.startY) <
-                    DRAG_START_DISTANCE_SQUARED
-            ) {
-                this.updateRenderedTextSelection(gesture);
-                return;
             }
 
             // A rectangle that cannot be dispatched — the table moved or was rewritten under
             // the gesture — leaves the press provisional. Release re-resolves the pressed
             // widget and opens it only if it still identifies a current table.
-            gesture.dragged = this.applyFocus(gesture, pointedCell ?? gesture.resolvedCell.activeCell);
+            gesture.dragged = this.applyFocus(gesture, promoteTo);
             if (!gesture.dragged) {
                 return;
             }
@@ -362,6 +350,33 @@ class MouseCellDragSelectionController {
 
     private resolveCellAtPoint(event: PointerEvent, gesture: MouseCellGesture): CellCoords | null {
         return this.resolveCellAtClientPoint(event.clientX, event.clientY, gesture);
+    }
+
+    /**
+     * The cell a press has moved far enough into to make the gesture a rectangle, or null while
+     * it still belongs to the cell it started in.
+     *
+     * Only another cell promotes a press, and only past a threshold that keeps a jittering
+     * pointer from tearing down what it landed on. A press that owns the nested editor measures
+     * from the anchor cell's border, so its own text-selection drag survives a pointer that
+     * merely grazes the neighbour; every other press measures from where it started.
+     */
+    private promotionTarget(
+        gesture: MouseCellGesture,
+        event: PointerEvent,
+        pointedCell: CellCoords | null
+    ): CellCoords | null {
+        if (!pointedCell || isSameCellCoords(gesture.resolvedCell.activeCell, pointedCell)) {
+            return null;
+        }
+
+        const moved = ownsNestedEditor(gesture.origin)
+            ? distanceOutsideRectSquared(event.clientX, event.clientY, gesture.anchorCell.getBoundingClientRect()) >=
+              BOUNDARY_EXIT_DISTANCE_SQUARED
+            : distanceSquared(event.clientX, event.clientY, gesture.startX, gesture.startY) >=
+              DRAG_START_DISTANCE_SQUARED;
+
+        return moved ? pointedCell : null;
     }
 
     /** Extends the range the press is drawing to the caret the pointer now rests on. */

--- a/src/contentScript/tableRuntime/interaction/mouseCellDragSelection.ts
+++ b/src/contentScript/tableRuntime/interaction/mouseCellDragSelection.ts
@@ -11,8 +11,8 @@ import { getViewportHeight, resolveViewportBounds } from '../../shared/editorVie
 import { clamp } from '../../shared/numberUtils';
 import { isPrimaryMouseButton, isPrimaryMousePointer } from '../../shared/mouseEvents';
 import { SELECTOR_CELL, getWidgetSelector, readCellCoords } from '../../tableWidget/domHelpers';
-import { readRenderedCaretHit, type RenderedCaretHit } from '../../tableWidget/cellCaretHit';
-import { resolveClickCursorPos } from './clickCursorPlacement';
+import { readRenderedCaretHit, readRenderedSelectionHit, type RenderedCaretHit } from '../../tableWidget/cellCaretHit';
+import { resolveClickCursorPos, resolveRenderedSelection } from './clickCursorPlacement';
 import type { InitialCursorPos } from '../../shared/cursorPlacement';
 import { CellDragAutoScroller } from './mouseCellDragAutoScroll';
 
@@ -44,6 +44,7 @@ interface MouseCellGesture {
     anchorCell: HTMLElement;
     resolvedCell: ResolvedActiveCell;
     dragged: boolean;
+    previousUserSelect?: string;
     lastFocus: CellCoords | null;
     lastClientX: number;
     lastClientY: number;
@@ -125,8 +126,10 @@ class MouseCellDragSelectionController {
                 flushNestedEditorState(this.view);
                 this.endNativeTextDrag(event);
             } else if (
+                !pointedCell ||
+                isSameCellCoords(gesture.resolvedCell.activeCell, pointedCell) ||
                 distanceSquared(event.clientX, event.clientY, gesture.startX, gesture.startY) <
-                DRAG_START_DISTANCE_SQUARED
+                    DRAG_START_DISTANCE_SQUARED
             ) {
                 return;
             }
@@ -137,6 +140,12 @@ class MouseCellDragSelectionController {
             gesture.dragged = this.applyFocus(gesture, pointedCell ?? gesture.resolvedCell.activeCell);
             if (!gesture.dragged) {
                 return;
+            }
+            if (gesture.origin === 'renderedCell') {
+                this.capturePointer(gesture);
+                gesture.previousUserSelect = gesture.widget.style.userSelect;
+                gesture.widget.style.userSelect = 'none';
+                this.view.dom.ownerDocument.getSelection()?.removeAllRanges();
             }
         } else {
             // Once dragging, a pointer outside the table still tracks the nearest cell, so a
@@ -190,12 +199,17 @@ class MouseCellDragSelectionController {
         const pointedCell = this.resolveCellAtPoint(event, gesture);
         const resolvedAnchor = gesture.origin === 'renderedCell' ? this.resolveCurrentRenderedAnchor(gesture) : null;
 
+        let cursorPos: InitialCursorPos | undefined;
+        if (!gesture.dragged && resolvedAnchor) {
+            const selectionHit = readRenderedSelectionHit(gesture.anchorCell);
+            cursorPos = selectionHit
+                ? resolveRenderedSelection(this.view.state, resolvedAnchor, selectionHit)
+                : resolveClickCursorPos(this.view.state, resolvedAnchor, gesture.pressCaretHit);
+        }
+
         return {
             resolvedAnchor,
-            cursorPos:
-                !gesture.dragged && resolvedAnchor
-                    ? resolveClickCursorPos(this.view.state, resolvedAnchor, gesture.pressCaretHit)
-                    : undefined,
+            cursorPos,
             reactivateAnchor:
                 gesture.dragged &&
                 pointedCell !== null &&
@@ -256,18 +270,14 @@ class MouseCellDragSelectionController {
             return false;
         }
 
-        // Editable content retains native pointer and mouse handling. Everything else — a
-        // rendered cell, or the active cell's row-height padding — has no native text-selection
-        // behavior to preserve, so claim its initial events to keep the outer editor from
-        // moving its caret or reopening the cell.
-        if (options.consumeInitialEvents) {
-            event.preventDefault();
-            event.stopPropagation();
-        }
+        // Rendered text keeps the browser default, while capture prevents the outer editor
+        // from handling the same press. Active-editor padding retains its existing behavior.
+        if (options.consumeInitialEvents) event.preventDefault();
+        if (options.consumeInitialEvents || options.origin === 'renderedCell') event.stopPropagation();
 
         this.beginGesture({
             origin: options.origin,
-            consumeCompatibilityMouseDown: options.consumeInitialEvents,
+            consumeCompatibilityMouseDown: options.consumeInitialEvents || options.origin === 'renderedCell',
             pointerId: event.pointerId,
             startX: event.clientX,
             startY: event.clientY,
@@ -283,12 +293,6 @@ class MouseCellDragSelectionController {
                 options.origin === 'renderedCell' ? readRenderedCaretHit(cell, event.clientX, event.clientY) : null,
         });
 
-        if (options.origin === 'renderedCell') {
-            // No nested editor to share the pointer with, so the gesture owns it from the
-            // start. An active-editor drag only takes the pointer when it converts.
-            this.capturePointer(this.gesture);
-        }
-
         return true;
     }
 
@@ -297,7 +301,7 @@ class MouseCellDragSelectionController {
             return false;
         }
 
-        event.preventDefault();
+        if (this.gesture.origin !== 'renderedCell') event.preventDefault();
         event.stopPropagation();
         return true;
     }
@@ -448,6 +452,9 @@ class MouseCellDragSelectionController {
         }
 
         this.gesture = null;
+        if (gesture.previousUserSelect !== undefined) {
+            gesture.widget.style.userSelect = gesture.previousUserSelect;
+        }
         const doc = this.view.dom.ownerDocument;
         doc.removeEventListener('pointermove', this.onPointerMove, true);
         doc.removeEventListener('pointerup', this.onPointerUp, true);

--- a/src/contentScript/tableWidget/TableWidget.ts
+++ b/src/contentScript/tableWidget/TableWidget.ts
@@ -230,6 +230,9 @@ export class TableWidget extends WidgetType {
         // creates on activation, ensuring CSS rules (like white-space: normal) apply consistently.
         const contentWrapper = doc.createElement('div');
         contentWrapper.className = CLASS_CELL_CONTENT;
+        // Native selection must focus the rendered content rather than the outer editor,
+        // whose focus handler would replace the browser range with its document caret.
+        contentWrapper.tabIndex = -1;
         cell.appendChild(contentWrapper);
 
         renderCellMarkdownInto(contentWrapper, markdown, renderer);
@@ -333,9 +336,10 @@ export class TableWidget extends WidgetType {
         return findCellForPos(ctx.cellRanges, docPos - ctx.from);
     }
 
-    ignoreEvent(): boolean {
-        // Events are handled by extension-level domEventHandlers.
-        return false;
+    ignoreEvent(event: Event): boolean {
+        // A native range inside rendered text belongs to the pending cell gesture, not
+        // the outer document selection. Pointer/mouse events use the interaction handlers.
+        return event.type === 'selectionchange';
     }
 
     destroy(dom: HTMLElement): void {

--- a/src/contentScript/tableWidget/TableWidget.ts
+++ b/src/contentScript/tableWidget/TableWidget.ts
@@ -72,6 +72,37 @@ function requestTableMeasurement(container: HTMLElement): void {
     });
 }
 
+/** The element a selection endpoint sits in, which for a text node is its parent. */
+function endpointElement(node: Node): Element | null {
+    return node.nodeType === Node.ELEMENT_NODE ? (node as Element) : node.parentElement;
+}
+
+/**
+ * True when the browser's own selection lies wholly inside rendered cell content.
+ *
+ * Such a selection is the browser's to copy: CodeMirror would answer the copy from its own
+ * document selection instead, which sits somewhere else entirely - it is empty during a
+ * long-press on mobile, so `copiedRange` falls back to copying the caret's whole source line
+ * over the top of what the reader actually selected.
+ *
+ * A whole-table selection is deliberately not covered: its endpoints sit at the widget's own
+ * boundary rather than inside a cell, so the main editor keeps copying the table's Markdown.
+ */
+function isSelectionInsideRenderedCell(event: Event): boolean {
+    const target = event.target as Node | null;
+    const doc = target && (target.nodeType === Node.DOCUMENT_NODE ? (target as Document) : target.ownerDocument);
+    const selection = doc?.getSelection();
+    if (!selection || selection.isCollapsed || !selection.anchorNode || !selection.focusNode) {
+        return false;
+    }
+
+    const contentSelector = `.${CLASS_CELL_CONTENT}`;
+    return Boolean(
+        endpointElement(selection.anchorNode)?.closest(contentSelector) &&
+        endpointElement(selection.focusNode)?.closest(contentSelector)
+    );
+}
+
 /**
  * Widget that renders a markdown table as an interactive HTML table
  * Supports rendering markdown content inside cells
@@ -339,7 +370,11 @@ export class TableWidget extends WidgetType {
     ignoreEvent(event: Event): boolean {
         // A native range inside rendered text belongs to the pending cell gesture, not
         // the outer document selection. Pointer/mouse events use the interaction handlers.
-        return event.type === 'selectionchange';
+        if (event.type === 'selectionchange') {
+            return true;
+        }
+
+        return event.type === 'copy' && isSelectionInsideRenderedCell(event);
     }
 
     destroy(dom: HTMLElement): void {

--- a/src/contentScript/tableWidget/cellCaretHit.ts
+++ b/src/contentScript/tableWidget/cellCaretHit.ts
@@ -1,0 +1,182 @@
+import { CLASS_CELL_CONTENT } from '../shared/tableDomClasses';
+
+/**
+ * Turns a point inside a rendered cell into an offset in that cell's rendered text.
+ *
+ * This is the half of click-to-caret placement that owns widget DOM; converting the
+ * result back into a Markdown offset belongs to the runtime, which has the document.
+ */
+
+/** A press inside a rendered cell, expressed against the text the reader can see. */
+export interface RenderedCaretHit {
+    /** Flattened text of the cell's rendered content, as {@link indexRenderedText} defines it. */
+    renderedText: string;
+    /** Caret offset within `renderedText`. */
+    renderedOffset: number;
+}
+
+/** Where a node's text sits in the flattened rendered text. */
+interface TextSpan {
+    start: number;
+    end: number;
+}
+
+export interface RenderedTextIndex {
+    text: string;
+    spans: Map<Node, TextSpan>;
+}
+
+/**
+ * Elements whose descendant text bears no useful resemblance to the Markdown that produced
+ * it. KaTeX output is rewritten into MathML during post-processing, so its text is a
+ * transcription of the formula rather than of the `$...$` source. Skipping the subtree
+ * leaves the formula as one unmatched gap the alignment can step over, instead of a run of
+ * characters that align convincingly to the wrong places.
+ */
+const OPAQUE_LOCAL_NAMES = new Set(['math']);
+
+const LINE_BREAK_LOCAL_NAME = 'br';
+
+/**
+ * Flattens a rendered cell's text and records where each node's text landed.
+ *
+ * `<br>` counts as a single character because that is what it is in the cell's own text: a
+ * newline has to survive a GFM table row as `<br>`, and the nested editor shows it as `\n`
+ * again. Counting it as one keeps the flattened text directly comparable to the text the
+ * editor will open with.
+ *
+ * Spans are recorded for every node visited. Descendants of opaque subtrees are not visited,
+ * so a caret reported inside one declines placement and uses the established fallback.
+ */
+export function indexRenderedText(root: HTMLElement): RenderedTextIndex {
+    const spans = new Map<Node, TextSpan>();
+    let text = '';
+
+    const visit = (node: Node): void => {
+        const start = text.length;
+
+        if (node.nodeType === Node.TEXT_NODE) {
+            text += (node as Text).data;
+        } else if (node.nodeType === Node.ELEMENT_NODE) {
+            const element = node as Element;
+            if (element.localName === LINE_BREAK_LOCAL_NAME) {
+                text += '\n';
+            } else if (!OPAQUE_LOCAL_NAMES.has(element.localName)) {
+                for (const child of Array.from(element.childNodes)) {
+                    visit(child);
+                }
+            }
+        }
+
+        spans.set(node, { start, end: text.length });
+    };
+
+    for (const child of Array.from(root.childNodes)) {
+        visit(child);
+    }
+    spans.set(root, { start: 0, end: text.length });
+
+    return { text, spans };
+}
+
+/**
+ * Converts a DOM caret position into an offset in the flattened text.
+ *
+ * A caret in a text node offsets into its characters; a caret in an element offsets into
+ * its child list, and resolves to the start of the child it precedes. Returns null for a
+ * node the index never saw, which means the caret was not inside the cell content.
+ */
+export function flatOffsetFromDomPosition(index: RenderedTextIndex, node: Node, offset: number): number | null {
+    const span = index.spans.get(node);
+    if (!span) {
+        return null;
+    }
+
+    if (node.nodeType === Node.TEXT_NODE) {
+        const data = (node as Text).data;
+        return span.start + Math.min(Math.max(offset, 0), data.length);
+    }
+
+    const children = node.childNodes;
+    if (offset <= 0) {
+        return span.start;
+    }
+    if (offset >= children.length) {
+        return span.end;
+    }
+
+    return index.spans.get(children[offset])?.start ?? span.end;
+}
+
+interface CaretDomPosition {
+    node: Node;
+    offset: number;
+}
+
+/**
+ * Document APIs for hit-testing a caret, neither of which is in every engine's lib types.
+ *
+ * `caretRangeFromPoint` is the Chromium and WebKit spelling, which covers Joplin desktop and
+ * both mobile webviews; `caretPositionFromPoint` is the standard one, which Firefox ships.
+ */
+interface CaretHitTestDocument {
+    caretRangeFromPoint?: (x: number, y: number) => Range | null;
+    caretPositionFromPoint?: (x: number, y: number) => { offsetNode: Node; offset: number } | null;
+}
+
+function caretFromPoint(doc: Document, clientX: number, clientY: number): CaretDomPosition | null {
+    const hitTest = doc as Document & CaretHitTestDocument;
+
+    const range = hitTest.caretRangeFromPoint?.(clientX, clientY);
+    if (range) {
+        return { node: range.startContainer, offset: range.startOffset };
+    }
+
+    const position = hitTest.caretPositionFromPoint?.(clientX, clientY);
+    return position ? { node: position.offsetNode, offset: position.offset } : null;
+}
+
+/**
+ * Offset for a press that missed the content box, which is what clicking a cell's padding
+ * produces. Past the content's end in reading order means the end of the text and before its
+ * start means the beginning; anything else has no obvious answer and declines.
+ */
+function offsetOutsideContent(
+    content: HTMLElement,
+    textLength: number,
+    clientX: number,
+    clientY: number
+): number | null {
+    const rect = content.getBoundingClientRect();
+
+    if (clientY > rect.bottom || (clientY >= rect.top && clientX > rect.right)) {
+        return textLength;
+    }
+    if (clientY < rect.top || clientX < rect.left) {
+        return 0;
+    }
+
+    return null;
+}
+
+/**
+ * Reads the caret a press at (`clientX`, `clientY`) implies within `cell`'s rendered content.
+ *
+ * Returns null when the cell has no rendered content wrapper or the press cannot be
+ * resolved against it, which callers treat as "no placement to offer".
+ */
+export function readRenderedCaretHit(cell: HTMLElement, clientX: number, clientY: number): RenderedCaretHit | null {
+    const content = cell.querySelector(`:scope > .${CLASS_CELL_CONTENT}`) as HTMLElement | null;
+    if (!content) {
+        return null;
+    }
+
+    const index = indexRenderedText(content);
+    const caret = caretFromPoint(cell.ownerDocument, clientX, clientY);
+    const renderedOffset =
+        caret && content.contains(caret.node)
+            ? flatOffsetFromDomPosition(index, caret.node, caret.offset)
+            : offsetOutsideContent(content, index.text.length, clientX, clientY);
+
+    return renderedOffset === null ? null : { renderedText: index.text, renderedOffset };
+}

--- a/src/contentScript/tableWidget/cellCaretHit.ts
+++ b/src/contentScript/tableWidget/cellCaretHit.ts
@@ -224,50 +224,14 @@ export function setRenderedTextSelection(
     cell.ownerDocument.getSelection()?.setBaseAndExtent(anchor.node, anchor.offset, head.node, head.offset);
 }
 
-/** A native selection anchored in one rendered cell. */
+/**
+ * A range drawn across one rendered cell, as the two hits that bound it.
+ *
+ * Both offsets are into the same `renderedText`, and the order of the two carries the drag's
+ * direction.
+ */
 export interface RenderedSelectionHit {
     renderedText: string;
     anchor: number;
     head: number;
-}
-
-/**
- * Offset for an endpoint the index has no entry for.
- *
- * An endpoint outside the content is where the drag left the cell, so it clamps to that end of
- * the rendered text: dragging out of the table selects to the end of the cell instead of losing
- * the range.
- */
-function offsetForEscapedEndpoint(content: HTMLElement, index: RenderedTextIndex, node: Node): number | null {
-    if (content.contains(node)) {
-        return null;
-    }
-
-    const precedesContent = (content.compareDocumentPosition(node) & Node.DOCUMENT_POSITION_PRECEDING) !== 0;
-    return precedesContent ? 0 : index.text.length;
-}
-
-/**
- * Reads both endpoints before opening the editor replaces the selected DOM.
- *
- * At least one endpoint must resolve inside the cell, so a selection that has nothing to do with
- * this cell is never read as one covering all of it.
- */
-export function readRenderedSelectionHit(cell: HTMLElement): RenderedSelectionHit | null {
-    const content = cell.querySelector(`:scope > .${CLASS_CELL_CONTENT}`) as HTMLElement | null;
-    const selection = cell.ownerDocument.getSelection();
-    if (!content || !selection || selection.isCollapsed || !selection.anchorNode || !selection.focusNode) {
-        return null;
-    }
-
-    const index = indexRenderedText(content);
-    const anchorInside = flatOffsetFromDomPosition(index, selection.anchorNode, selection.anchorOffset);
-    const headInside = flatOffsetFromDomPosition(index, selection.focusNode, selection.focusOffset);
-    if (anchorInside === null && headInside === null) {
-        return null;
-    }
-
-    const anchor = anchorInside ?? offsetForEscapedEndpoint(content, index, selection.anchorNode);
-    const head = headInside ?? offsetForEscapedEndpoint(content, index, selection.focusNode);
-    return anchor === null || head === null ? null : { renderedText: index.text, anchor, head };
 }

--- a/src/contentScript/tableWidget/cellCaretHit.ts
+++ b/src/contentScript/tableWidget/cellCaretHit.ts
@@ -181,22 +181,50 @@ export function readRenderedCaretHit(cell: HTMLElement, clientX: number, clientY
     return renderedOffset === null ? null : { renderedText: index.text, renderedOffset };
 }
 
-/** A native selection wholly contained in one rendered cell. */
+/** A native selection anchored in one rendered cell. */
 export interface RenderedSelectionHit {
     renderedText: string;
     anchor: number;
     head: number;
 }
 
-/** Reads both endpoints before opening the editor replaces the selected DOM. */
+/**
+ * Offset for an endpoint the index has no entry for.
+ *
+ * An endpoint outside the content is where the drag left the cell, so it clamps to that end of
+ * the rendered text: dragging out of the table selects to the end of the cell instead of losing
+ * the range.
+ */
+function offsetForEscapedEndpoint(content: HTMLElement, index: RenderedTextIndex, node: Node): number | null {
+    if (content.contains(node)) {
+        return null;
+    }
+
+    const precedesContent = (content.compareDocumentPosition(node) & Node.DOCUMENT_POSITION_PRECEDING) !== 0;
+    return precedesContent ? 0 : index.text.length;
+}
+
+/**
+ * Reads both endpoints before opening the editor replaces the selected DOM.
+ *
+ * At least one endpoint must resolve inside the cell, so a selection that has nothing to do with
+ * this cell is never read as one covering all of it.
+ */
 export function readRenderedSelectionHit(cell: HTMLElement): RenderedSelectionHit | null {
     const content = cell.querySelector(`:scope > .${CLASS_CELL_CONTENT}`) as HTMLElement | null;
     const selection = cell.ownerDocument.getSelection();
     if (!content || !selection || selection.isCollapsed || !selection.anchorNode || !selection.focusNode) {
         return null;
     }
+
     const index = indexRenderedText(content);
-    const anchor = flatOffsetFromDomPosition(index, selection.anchorNode, selection.anchorOffset);
-    const head = flatOffsetFromDomPosition(index, selection.focusNode, selection.focusOffset);
+    const anchorInside = flatOffsetFromDomPosition(index, selection.anchorNode, selection.anchorOffset);
+    const headInside = flatOffsetFromDomPosition(index, selection.focusNode, selection.focusOffset);
+    if (anchorInside === null && headInside === null) {
+        return null;
+    }
+
+    const anchor = anchorInside ?? offsetForEscapedEndpoint(content, index, selection.anchorNode);
+    const head = headInside ?? offsetForEscapedEndpoint(content, index, selection.focusNode);
     return anchor === null || head === null ? null : { renderedText: index.text, anchor, head };
 }

--- a/src/contentScript/tableWidget/cellCaretHit.ts
+++ b/src/contentScript/tableWidget/cellCaretHit.ts
@@ -180,3 +180,23 @@ export function readRenderedCaretHit(cell: HTMLElement, clientX: number, clientY
 
     return renderedOffset === null ? null : { renderedText: index.text, renderedOffset };
 }
+
+/** A native selection wholly contained in one rendered cell. */
+export interface RenderedSelectionHit {
+    renderedText: string;
+    anchor: number;
+    head: number;
+}
+
+/** Reads both endpoints before opening the editor replaces the selected DOM. */
+export function readRenderedSelectionHit(cell: HTMLElement): RenderedSelectionHit | null {
+    const content = cell.querySelector(`:scope > .${CLASS_CELL_CONTENT}`) as HTMLElement | null;
+    const selection = cell.ownerDocument.getSelection();
+    if (!content || !selection || selection.isCollapsed || !selection.anchorNode || !selection.focusNode) {
+        return null;
+    }
+    const index = indexRenderedText(content);
+    const anchor = flatOffsetFromDomPosition(index, selection.anchorNode, selection.anchorOffset);
+    const head = flatOffsetFromDomPosition(index, selection.focusNode, selection.focusOffset);
+    return anchor === null || head === null ? null : { renderedText: index.text, anchor, head };
+}

--- a/src/contentScript/tableWidget/cellCaretHit.ts
+++ b/src/contentScript/tableWidget/cellCaretHit.ts
@@ -114,6 +114,15 @@ interface CaretDomPosition {
 }
 
 /**
+ * A caret hit together with the DOM position it resolved to.
+ *
+ * Mapping a hit back into Markdown needs only the flattened offset; drawing the range the
+ * press is making needs the DOM endpoint, and reading it here costs nothing because the hit
+ * test produced it.
+ */
+export interface RenderedCaretDomHit extends RenderedCaretHit, CaretDomPosition {}
+
+/**
  * Document APIs for hit-testing a caret, neither of which is in every engine's lib types.
  *
  * `caretRangeFromPoint` is the Chromium and WebKit spelling, which covers Joplin desktop and
@@ -165,7 +174,7 @@ function offsetOutsideContent(
  * Returns null when the cell has no rendered content wrapper or the press cannot be
  * resolved against it, which callers treat as "no placement to offer".
  */
-export function readRenderedCaretHit(cell: HTMLElement, clientX: number, clientY: number): RenderedCaretHit | null {
+export function readRenderedCaretHit(cell: HTMLElement, clientX: number, clientY: number): RenderedCaretDomHit | null {
     const content = cell.querySelector(`:scope > .${CLASS_CELL_CONTENT}`) as HTMLElement | null;
     if (!content) {
         return null;
@@ -173,12 +182,46 @@ export function readRenderedCaretHit(cell: HTMLElement, clientX: number, clientY
 
     const index = indexRenderedText(content);
     const caret = caretFromPoint(cell.ownerDocument, clientX, clientY);
-    const renderedOffset =
-        caret && content.contains(caret.node)
-            ? flatOffsetFromDomPosition(index, caret.node, caret.offset)
-            : offsetOutsideContent(content, index.text.length, clientX, clientY);
+    if (caret && content.contains(caret.node)) {
+        const renderedOffset = flatOffsetFromDomPosition(index, caret.node, caret.offset);
+        return renderedOffset === null ? null : { renderedText: index.text, renderedOffset, ...caret };
+    }
 
-    return renderedOffset === null ? null : { renderedText: index.text, renderedOffset };
+    const renderedOffset = offsetOutsideContent(content, index.text.length, clientX, clientY);
+    if (renderedOffset === null) {
+        return null;
+    }
+
+    // A press that missed the content box has no DOM caret of its own, so it takes the
+    // matching edge of the content element.
+    return {
+        renderedText: index.text,
+        renderedOffset,
+        node: content,
+        offset: renderedOffset === 0 ? 0 : content.childNodes.length,
+    };
+}
+
+/**
+ * Paints the range a press is drawing across one rendered cell.
+ *
+ * A rendered-cell press is consumed rather than left to the browser, so there is no native
+ * text-selection drag to draw this: a native drag keeps auto-scrolling the outer editor after
+ * the gesture becomes a cell rectangle, and nothing can cancel it once it has started.
+ *
+ * The endpoints are the ones the hit test read, so a re-render between the press and now
+ * leaves them outside the cell rather than pointing at the wrong text.
+ */
+export function setRenderedTextSelection(
+    cell: HTMLElement,
+    anchor: RenderedCaretDomHit,
+    head: RenderedCaretDomHit
+): void {
+    if (!cell.contains(anchor.node) || !cell.contains(head.node)) {
+        return;
+    }
+
+    cell.ownerDocument.getSelection()?.setBaseAndExtent(anchor.node, anchor.offset, head.node, head.offset);
 }
 
 /** A native selection anchored in one rendered cell. */

--- a/src/contentScript/tableWidget/cellSelectionVisuals.ts
+++ b/src/contentScript/tableWidget/cellSelectionVisuals.ts
@@ -8,6 +8,7 @@ import {
     CLASS_TABLE_WIDGET_TABLE,
     SELECTOR_CELL,
     findTableWidgetElement,
+    getWidgetSelector,
     readCellCoords,
 } from './domHelpers';
 import { makeTableId } from '../tableModel/types';
@@ -58,6 +59,12 @@ const cellSelectionFillTheme = EditorView.baseTheme(selectedCellRules(selectedCe
 /** Marks the editor root while a cell drag is sweeping out a rectangle. */
 const ATTR_CELL_DRAG = 'data-rt-cell-drag';
 
+/** Puts {@link ATTR_CELL_DRAG} on the editor root for as long as a drag is in progress. */
+const cellDragAttribute: Extension = EditorView.editorAttributes.compute(
+    [cellDragField],
+    (state): Record<string, string> => (isCellDragInProgress(state) ? { [ATTR_CELL_DRAG]: '' } : {})
+);
+
 /**
  * Keeps a rectangle being dragged out looking focused.
  *
@@ -67,23 +74,32 @@ const ATTR_CELL_DRAG = 'data-rt-cell-drag';
  * otherwise render unfocused, and snap to focused on release. A gesture in progress is as focused
  * as a selection gets, whatever the DOM says.
  */
-const cellDragFocusOverride: Extension = [
-    EditorView.editorAttributes.compute([cellDragField], (state): Record<string, string> =>
-        isCellDragInProgress(state) ? { [ATTR_CELL_DRAG]: '' } : {}
-    ),
-    EditorView.baseTheme({
-        [`&[${ATTR_CELL_DRAG}]`]: {
-            '--rt-tint': 'var(--rt-tint-focused)',
-            '--rt-tint-alpha': 'var(--rt-tint-focused-alpha)',
-        } as Record<string, string>,
-    }),
-];
+const cellDragFocusOverride: Extension = EditorView.baseTheme({
+    [`&[${ATTR_CELL_DRAG}]`]: {
+        '--rt-tint': 'var(--rt-tint-focused)',
+        '--rt-tint-alpha': 'var(--rt-tint-focused-alpha)',
+    } as Record<string, string>,
+});
+
+/**
+ * Stops a drag that has become a rectangle from also selecting rendered text as it sweeps.
+ *
+ * A press on a rendered cell starts as a native text selection, so the browser keeps extending
+ * one until told otherwise (`tableRuntime/interaction/mouseCellDragSelection.ts` clears the range
+ * it had made at the moment of promotion). Every widget is covered rather than only the one being
+ * dragged: the drag owns the pointer until release, so no other table has a selection to make.
+ */
+const cellDragTextSelectionSuppression: Extension = EditorView.baseTheme({
+    [`&[${ATTR_CELL_DRAG}] ${getWidgetSelector()}`]: { userSelect: 'none' },
+});
 
 /** Multi-cell selection visuals: the class on each selected cell, and the fill it carries. */
 export const cellSelectionVisuals: Extension = [
     measuredClassSyncPlugin(CLASS_CELL_SELECTED, collectSelectedCells),
     cellSelectionFillTheme,
+    cellDragAttribute,
     cellDragFocusOverride,
+    cellDragTextSelectionSuppression,
 ];
 
 /**

--- a/src/contentScript/tableWidget/cellSelectionVisuals.ts
+++ b/src/contentScript/tableWidget/cellSelectionVisuals.ts
@@ -84,10 +84,8 @@ const cellDragFocusOverride: Extension = EditorView.baseTheme({
 /**
  * Stops a drag that has become a rectangle from also selecting rendered text as it sweeps.
  *
- * A press on a rendered cell starts as a native text selection, so the browser keeps extending
- * one until told otherwise (`tableRuntime/interaction/mouseCellDragSelection.ts` clears the range
- * it had made at the moment of promotion). Every widget is covered rather than only the one being
- * dragged: the drag owns the pointer until release, so no other table has a selection to make.
+ * The gesture clears its rendered text range on promotion and owns selection until release.
+ * Every widget is covered: no other table has a text selection to make during that gesture.
  */
 const cellDragTextSelectionSuppression: Extension = EditorView.baseTheme({
     [`&[${ATTR_CELL_DRAG}] ${getWidgetSelector()}`]: { userSelect: 'none' },

--- a/src/contentScript/tableWidget/renderedTextSelectionTheme.ts
+++ b/src/contentScript/tableWidget/renderedTextSelectionTheme.ts
@@ -18,10 +18,10 @@ import { JOPLIN_SELECTION_COLORS } from './richTableThemeVars';
  * - `:not(.${CLASS_CELL_ACTIVE})` leaves the open cell to the nested editor, whose selection
  *   `drawSelection` draws and `nestedEditor/rootEditorSelectionTheme.ts` blanks natively.
  *
- * Being mutually exclusive with both, this rule cannot contend with either on specificity — only
- * with Joplin's own `&.cm-focused ::selection !important`, which it outweighs.  The coordinate
- * attributes anchor the chain to the widget's own cells, so a raw HTML table inside a cell's
- * Markdown is reached through the cell that contains it rather than matching on its own.
+ * Being mutually exclusive with both, this rule contends on specificity only with Joplin's own
+ * `&.cm-focused ::selection !important`, which it outweighs. The coordinate attributes anchor the
+ * chain to the widget's own cells, so a raw HTML table inside a cell's Markdown is reached through
+ * the cell that contains it rather than matching on its own.
  */
 function renderedCellText(scope: string): string {
     return CELL_TAGS.map(
@@ -36,14 +36,10 @@ function renderedCellText(scope: string): string {
  *
  * A highlight pseudo-element inherits through the chain of `::selection` pseudo-elements above it,
  * which bottoms out at the document root; the `--rt-*` variables are defined on the editor root, so
- * they are not reliably visible here.  `!important` is needed to beat Joplin's own rule, which
- * carries it.
+ * they are not reliably visible here. `!important` beats Joplin's own rule, which carries it.
  *
- * Always the focused colour: this highlight only exists while its drag is in progress, and the
- * nested editor it becomes on release opens focused, so the selection keeps one colour across the
- * hand-off.  Focus is on the rendered content itself during the drag (`TableWidget` makes it
- * focusable), which means the editor is not `.cm-focused` and a focus-dependent fill would read as
- * blurred throughout.
+ * Always the focused colour: focus sits on the rendered content during the drag, not the editor,
+ * so a focus-dependent fill would read as blurred throughout.
  */
 function selectionFill(mode: keyof typeof JOPLIN_SELECTION_COLORS): Record<string, string> {
     return { backgroundColor: `${JOPLIN_SELECTION_COLORS[mode].focused} !important` };

--- a/src/contentScript/tableWidget/renderedTextSelectionTheme.ts
+++ b/src/contentScript/tableWidget/renderedTextSelectionTheme.ts
@@ -5,11 +5,11 @@ import { CELL_COORDS_ATTRIBUTES, CELL_TAGS, CLASS_TABLE_WIDGET_SELECTED, getWidg
 import { JOPLIN_SELECTION_COLORS } from './richTableThemeVars';
 
 /**
- * Rendered cell text whose selection the browser still owns.
+ * Rendered cell text highlighted by the DOM selection.
  *
- * Dragging across an inactive cell selects its rendered text natively, and pointerup maps that
+ * Dragging across an inactive cell selects its rendered text, and pointerup maps that
  * range into the Markdown the cell opens with (`tableRuntime/interaction/mouseCellDragSelection.ts`).
- * That is the one native highlight inside a table widget that has to stay visible, so it is
+ * That is the one DOM selection inside a table widget that has to stay visible, so it is
  * excluded from the two rules that blank the rest:
  *
  * - `:not(.${CLASS_TABLE_WIDGET_SELECTED})` leaves a table the main editor has selected whole to
@@ -38,14 +38,15 @@ function renderedCellText(scope: string): string {
  * which bottoms out at the document root; the `--rt-*` variables are defined on the editor root, so
  * they are not reliably visible here. `!important` beats Joplin's own rule, which carries it.
  *
- * Always the focused colour: focus sits on the rendered content during the drag, not the editor,
- * so a focus-dependent fill would read as blurred throughout.
+ * Always the focused colour: the gesture consumes its own press, so keyboard focus stays wherever
+ * it was and a focus-dependent fill would read as blurred for a range the reader is actively
+ * dragging out.
  */
 function selectionFill(mode: keyof typeof JOPLIN_SELECTION_COLORS): Record<string, string> {
     return { backgroundColor: `${JOPLIN_SELECTION_COLORS[mode].focused} !important` };
 }
 
-/** Paints the browser's own selection over rendered cell text in Joplin's selection colour. */
+/** Paints the DOM selection over rendered cell text in Joplin's selection colour. */
 export const renderedTextSelectionTheme: Extension = EditorView.baseTheme({
     [renderedCellText('&light')]: selectionFill('light'),
     [renderedCellText('&dark')]: selectionFill('dark'),

--- a/src/contentScript/tableWidget/renderedTextSelectionTheme.ts
+++ b/src/contentScript/tableWidget/renderedTextSelectionTheme.ts
@@ -1,0 +1,56 @@
+import type { Extension } from '@codemirror/state';
+import { EditorView } from '@codemirror/view';
+import { CLASS_CELL_ACTIVE } from '../shared/tableDomClasses';
+import { CELL_COORDS_ATTRIBUTES, CELL_TAGS, CLASS_TABLE_WIDGET_SELECTED, getWidgetSelector } from './domHelpers';
+import { JOPLIN_SELECTION_COLORS } from './richTableThemeVars';
+
+/**
+ * Rendered cell text whose selection the browser still owns.
+ *
+ * Dragging across an inactive cell selects its rendered text natively, and pointerup maps that
+ * range into the Markdown the cell opens with (`tableRuntime/interaction/mouseCellDragSelection.ts`).
+ * That is the one native highlight inside a table widget that has to stay visible, so it is
+ * excluded from the two rules that blank the rest:
+ *
+ * - `:not(.${CLASS_TABLE_WIDGET_SELECTED})` leaves a table the main editor has selected whole to
+ *   `wholeTableSelectionVisuals.ts`, which paints the block itself and needs the browser's own
+ *   highlight out of the way underneath.
+ * - `:not(.${CLASS_CELL_ACTIVE})` leaves the open cell to the nested editor, whose selection
+ *   `drawSelection` draws and `nestedEditor/rootEditorSelectionTheme.ts` blanks natively.
+ *
+ * Being mutually exclusive with both, this rule cannot contend with either on specificity — only
+ * with Joplin's own `&.cm-focused ::selection !important`, which it outweighs.  The coordinate
+ * attributes anchor the chain to the widget's own cells, so a raw HTML table inside a cell's
+ * Markdown is reached through the cell that contains it rather than matching on its own.
+ */
+function renderedCellText(scope: string): string {
+    return CELL_TAGS.map(
+        (tag) =>
+            `${scope} ${getWidgetSelector()}:not(.${CLASS_TABLE_WIDGET_SELECTED}) ` +
+            `${tag}${CELL_COORDS_ATTRIBUTES}:not(.${CLASS_CELL_ACTIVE}) ::selection`
+    ).join(', ');
+}
+
+/**
+ * Joplin's focused selection colour, written out rather than read from `--rt-selection-focused-bg`.
+ *
+ * A highlight pseudo-element inherits through the chain of `::selection` pseudo-elements above it,
+ * which bottoms out at the document root; the `--rt-*` variables are defined on the editor root, so
+ * they are not reliably visible here.  `!important` is needed to beat Joplin's own rule, which
+ * carries it.
+ *
+ * Always the focused colour: this highlight only exists while its drag is in progress, and the
+ * nested editor it becomes on release opens focused, so the selection keeps one colour across the
+ * hand-off.  Focus is on the rendered content itself during the drag (`TableWidget` makes it
+ * focusable), which means the editor is not `.cm-focused` and a focus-dependent fill would read as
+ * blurred throughout.
+ */
+function selectionFill(mode: keyof typeof JOPLIN_SELECTION_COLORS): Record<string, string> {
+    return { backgroundColor: `${JOPLIN_SELECTION_COLORS[mode].focused} !important` };
+}
+
+/** Paints the browser's own selection over rendered cell text in Joplin's selection colour. */
+export const renderedTextSelectionTheme: Extension = EditorView.baseTheme({
+    [renderedCellText('&light')]: selectionFill('light'),
+    [renderedCellText('&dark')]: selectionFill('dark'),
+});

--- a/src/contentScript/tableWidget/richTableThemeVars.ts
+++ b/src/contentScript/tableWidget/richTableThemeVars.ts
@@ -9,8 +9,11 @@ import { alphaEquivalentLayer, parseHexColor, toPercentageCss, toRgbCss } from '
  * values below are therefore CodeMirror's defaults, restated here so both modes read from one
  * place.  `--joplin-selected-color` is deliberately not used: it is the list-item selection
  * color (light `#e5e5e5`, dark `#616161`), not the text-selection color.
+ *
+ * Exported for `renderedTextSelectionTheme.ts`, which needs the colors themselves rather than the
+ * variables below: a `::selection` rule cannot read them.
  */
-const JOPLIN_SELECTION_COLORS = {
+export const JOPLIN_SELECTION_COLORS = {
     light: { focused: '#d7d4f0', blurred: '#d9d9d9' },
     dark: { focused: '#6b6b6b', blurred: '#444444' },
 } as const;

--- a/src/contentScript/tableWidget/tableWidgetExtension.ts
+++ b/src/contentScript/tableWidget/tableWidgetExtension.ts
@@ -28,7 +28,7 @@ import { tableSelectionSnapFilter } from '../tableRuntime/selection/tableSelecti
 import { isNestedEditorOpen, nestedEditorPlugin } from '../nestedEditor/nestedEditorController';
 import { nestedEditorFocusGuard } from '../nestedEditor/nestedEditorFocusGuard';
 import { createMainEditorActiveCellGuard } from '../editorBridge/mainEditorGuard';
-import { handleWidgetClick, tableWidgetPressPlugin } from './tableWidgetInteractions';
+import { handleWidgetClick, handleWidgetPress } from './tableWidgetInteractions';
 import { tableToolbarPlugin, tableToolbarTheme } from '../toolbar/tableToolbarPlugin';
 import { tableStyles } from './tableStyles';
 import { richTableThemeVars } from './richTableThemeVars';
@@ -56,10 +56,16 @@ import {
 } from '../nestedEditor/rootEditorSelectionTheme';
 import { mouseCellDragSelectionPlugin } from '../tableRuntime/interaction/mouseCellDragSelection';
 
-// Clicks are the only widget event still registered as a handler. Presses go through
-// `tableWidgetPressPlugin`, which can take an event from the editor while leaving the browser
-// default in place — something a handler returning true here cannot do.
+// Registered ahead of `closeOnOutsideMouseDown` so a widget press is routed first. CodeMirror
+// stops running handlers for an event once one returns true, and appends its own built-in
+// handlers after every plugin's, so a press this router takes reaches neither.
 const tableWidgetInteractionHandlers = EditorView.domEventHandlers({
+    pointerdown: (event, view) => {
+        return handleWidgetPress(view, event);
+    },
+    mousedown: (event, view) => {
+        return handleWidgetPress(view, event);
+    },
     click: (event, view) => {
         return handleWidgetClick(view, event);
     },
@@ -137,7 +143,6 @@ async function registerTableWidgetExtension(
         openCellRequestTimeoutPlugin,
 
         mouseCellDragSelectionPlugin,
-        tableWidgetPressPlugin,
         tableWidgetInteractionHandlers,
         closeOnOutsideMouseDown,
         outsideInteractionCapturePlugin,

--- a/src/contentScript/tableWidget/tableWidgetExtension.ts
+++ b/src/contentScript/tableWidget/tableWidgetExtension.ts
@@ -28,7 +28,7 @@ import { tableSelectionSnapFilter } from '../tableRuntime/selection/tableSelecti
 import { isNestedEditorOpen, nestedEditorPlugin } from '../nestedEditor/nestedEditorController';
 import { nestedEditorFocusGuard } from '../nestedEditor/nestedEditorFocusGuard';
 import { createMainEditorActiveCellGuard } from '../editorBridge/mainEditorGuard';
-import { handleTableInteraction, renderedCellNativeSelectionPlugin } from './tableWidgetInteractions';
+import { handleWidgetClick, tableWidgetPressPlugin } from './tableWidgetInteractions';
 import { tableToolbarPlugin, tableToolbarTheme } from '../toolbar/tableToolbarPlugin';
 import { tableStyles } from './tableStyles';
 import { richTableThemeVars } from './richTableThemeVars';
@@ -56,15 +56,12 @@ import {
 } from '../nestedEditor/rootEditorSelectionTheme';
 import { mouseCellDragSelectionPlugin } from '../tableRuntime/interaction/mouseCellDragSelection';
 
+// Clicks are the only widget event still registered as a handler. Presses go through
+// `tableWidgetPressPlugin`, which can take an event from the editor while leaving the browser
+// default in place — something a handler returning true here cannot do.
 const tableWidgetInteractionHandlers = EditorView.domEventHandlers({
-    pointerdown: (event, view) => {
-        return handleTableInteraction(view, event);
-    },
-    mousedown: (event, view) => {
-        return handleTableInteraction(view, event);
-    },
     click: (event, view) => {
-        return handleTableInteraction(view, event);
+        return handleWidgetClick(view, event);
     },
 });
 
@@ -140,7 +137,7 @@ async function registerTableWidgetExtension(
         openCellRequestTimeoutPlugin,
 
         mouseCellDragSelectionPlugin,
-        renderedCellNativeSelectionPlugin,
+        tableWidgetPressPlugin,
         tableWidgetInteractionHandlers,
         closeOnOutsideMouseDown,
         outsideInteractionCapturePlugin,

--- a/src/contentScript/tableWidget/tableWidgetExtension.ts
+++ b/src/contentScript/tableWidget/tableWidgetExtension.ts
@@ -27,7 +27,7 @@ import { tableSelectionSnapFilter } from '../tableRuntime/selection/tableSelecti
 import { isNestedEditorOpen, nestedEditorPlugin } from '../nestedEditor/nestedEditorController';
 import { nestedEditorFocusGuard } from '../nestedEditor/nestedEditorFocusGuard';
 import { createMainEditorActiveCellGuard } from '../editorBridge/mainEditorGuard';
-import { handleTableInteraction } from './tableWidgetInteractions';
+import { handleTableInteraction, renderedCellNativeSelectionPlugin } from './tableWidgetInteractions';
 import { tableToolbarPlugin, tableToolbarTheme } from '../toolbar/tableToolbarPlugin';
 import { tableStyles } from './tableStyles';
 import { richTableThemeVars } from './richTableThemeVars';
@@ -139,6 +139,7 @@ async function registerTableWidgetExtension(
         openCellRequestTimeoutPlugin,
 
         mouseCellDragSelectionPlugin,
+        renderedCellNativeSelectionPlugin,
         tableWidgetInteractionHandlers,
         closeOnOutsideMouseDown,
         outsideInteractionCapturePlugin,

--- a/src/contentScript/tableWidget/tableWidgetExtension.ts
+++ b/src/contentScript/tableWidget/tableWidgetExtension.ts
@@ -23,6 +23,7 @@ import { cellSelectionFocusPlugin } from '../tableRuntime/selection/cellSelectio
 import { cellSelectionScopeGuard } from '../tableRuntime/selection/cellSelectionScopeGuard';
 import { cellSelectionCaretSuppression, cellSelectionVisuals } from './cellSelectionVisuals';
 import { wholeTableSelectionVisuals } from './wholeTableSelectionVisuals';
+import { renderedTextSelectionTheme } from './renderedTextSelectionTheme';
 import { tableSelectionSnapFilter } from '../tableRuntime/selection/tableSelectionSnap';
 import { isNestedEditorOpen, nestedEditorPlugin } from '../nestedEditor/nestedEditorController';
 import { nestedEditorFocusGuard } from '../nestedEditor/nestedEditorFocusGuard';
@@ -150,6 +151,7 @@ async function registerTableWidgetExtension(
         cellSelectionVisuals,
         cellSelectionCaretSuppression,
         wholeTableSelectionVisuals,
+        renderedTextSelectionTheme,
         nestedEditorFocusGuard,
         nestedEditorLifecyclePlugin,
         tableDecorationField,

--- a/src/contentScript/tableWidget/tableWidgetInteractions.ts
+++ b/src/contentScript/tableWidget/tableWidgetInteractions.ts
@@ -348,9 +348,7 @@ export function handleWidgetPress(view: EditorView, event: MouseEvent | PointerE
  */
 export const tableWidgetPressPlugin = ViewPlugin.define((view) => {
     const onPress = (event: MouseEvent | PointerEvent): void => {
-        // Capture runs ahead of CodeMirror, which drops a default-prevented event in both
-        // `runHandlers` and `eventBelongsToEditor`. `claim` also depends on the browser default
-        // still running, so a cancelled press has no native selection for the release to map.
+        // Respect presses already consumed by an earlier handler, as CodeMirror does.
         if (event.defaultPrevented) {
             return;
         }

--- a/src/contentScript/tableWidget/tableWidgetInteractions.ts
+++ b/src/contentScript/tableWidget/tableWidgetInteractions.ts
@@ -348,6 +348,13 @@ export function handleWidgetPress(view: EditorView, event: MouseEvent | PointerE
  */
 export const tableWidgetPressPlugin = ViewPlugin.define((view) => {
     const onPress = (event: MouseEvent | PointerEvent): void => {
+        // Capture runs ahead of CodeMirror, which drops a default-prevented event in both
+        // `runHandlers` and `eventBelongsToEditor`. `claim` also depends on the browser default
+        // still running, so a cancelled press has no native selection for the release to map.
+        if (event.defaultPrevented) {
+            return;
+        }
+
         applyPressDisposition(event, handleWidgetPress(view, event));
     };
 

--- a/src/contentScript/tableWidget/tableWidgetInteractions.ts
+++ b/src/contentScript/tableWidget/tableWidgetInteractions.ts
@@ -1,4 +1,4 @@
-import { ViewPlugin, type EditorView } from '@codemirror/view';
+import type { EditorView } from '@codemirror/view';
 import { CLASS_CELL_ACTIVE, CLASS_CELL_EDITOR } from '../shared/tableDomClasses';
 import { slugify } from '../shared/cellContentUtils';
 import { parseFootnoteHref } from '../shared/footnoteAnchor';
@@ -7,12 +7,7 @@ import { clearCellSelectionEffect, getCellSelection } from '../tableState/cellSe
 import { setOrExtendCellSelectionToCoords } from '../tableRuntime/selection/cellSelectionController';
 import { resolveTableContextFromEventTarget } from '../tableRuntime/tablePositioning';
 import { linkOpenerFacet } from '../services/linkOpener';
-import {
-    applyPressDisposition,
-    isPrimaryMouseButton,
-    isPrimaryMousePointer,
-    type PressDisposition,
-} from '../shared/mouseEvents';
+import { isPrimaryMouseButton, isPrimaryMousePointer } from '../shared/mouseEvents';
 import { SELECTOR_CELL, getWidgetSelector, readCellCoords } from './domHelpers';
 import { readRenderedCaretHit } from './cellCaretHit';
 import { resolveClickCursorPos } from '../tableRuntime/interaction/clickCursorPlacement';
@@ -20,7 +15,7 @@ import { requestOpenCell } from '../tableRuntime/openCellRequest';
 import { createResolvedActiveCell, type ResolvedActiveCell } from '../tableRuntime/activeCell/resolvedActiveCell';
 import {
     beginMouseCellGesture,
-    mouseCellGestureMouseDownDisposition,
+    mouseCellGestureConsumesMouseDown,
 } from '../tableRuntime/interaction/mouseCellDragSelection';
 
 /** Matches fenced code block delimiters (``` or ~~~) */
@@ -133,13 +128,7 @@ function escapeRegex(str: string): string {
     return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
-/**
- * Opens a link clicked inside a rendered cell.
- *
- * The only widget event still routed through `EditorView.domEventHandlers`: a click asks nothing
- * unusual of CodeMirror, so it keeps the ordering that registration gives it. Presses go through
- * {@link handleWidgetPress} instead.
- */
+/** Opens a link clicked inside a rendered cell. */
 export function handleWidgetClick(view: EditorView, event: MouseEvent): boolean {
     const target = event.target as HTMLElement | null;
     if (!isPrimaryMouseButton(event) || !target?.closest(getWidgetSelector())) {
@@ -171,7 +160,7 @@ export function handleWidgetClick(view: EditorView, event: MouseEvent): boolean 
 }
 
 /** Mousedown events: cell activation. */
-function handleWidgetMouseDown(view: EditorView, event: MouseEvent, target: HTMLElement): PressDisposition {
+function handleWidgetMouseDown(view: EditorView, event: MouseEvent, target: HTMLElement): boolean {
     // If clicking a link with LEFT click, we want to PREVENT cell handling so the Click event can fire cleanly
     // and open the link.
     // If we processed cell activation here, it might swallow the event or change focus
@@ -182,17 +171,17 @@ function handleWidgetMouseDown(view: EditorView, event: MouseEvent, target: HTML
         if (getCellSelection(view.state)) {
             view.dispatch({ effects: clearCellSelectionEffect.of(undefined) });
         }
-        // Claim the event to prevent CodeMirror default selection, but don't activate cell.
-        return 'consume';
+        // Take the event to prevent CodeMirror default selection, but don't activate cell.
+        return true;
     }
 
     const cell = target.closest(SELECTOR_CELL) as HTMLElement | null;
     if (!cell) {
-        // Consume the event to prevent CodeMirror's internal mousedown handler from
+        // Take the event to prevent CodeMirror's internal mousedown handler from
         // repositioning the cursor. Without this, clicking the widget's horizontal
         // scrollbar maps to a document position at or after the table, which clears
         // the active cell state and closes the nested editor.
-        return 'consume';
+        return true;
     }
 
     return activateCellFromMouseDown(view, event, cell);
@@ -229,14 +218,14 @@ function resolveCellTarget(view: EditorView, target: HTMLElement): ResolvedCellT
  *
  * Declining leaves the press to the compatibility mousedown; see {@link handleWidgetPress}.
  */
-function handleWidgetPointerDown(view: EditorView, event: PointerEvent, target: HTMLElement): PressDisposition {
+function handleWidgetPointerDown(view: EditorView, event: PointerEvent, target: HTMLElement): boolean {
     if (!isPrimaryMousePointer(event) || event.shiftKey || target.closest(SELECTOR_LINK)) {
-        return 'native';
+        return false;
     }
 
     const pressed = resolveCellTarget(view, target);
     if (!pressed) {
-        return 'native';
+        return false;
     }
 
     const { cell, resolvedCell } = pressed;
@@ -256,25 +245,25 @@ function handleWidgetPointerDown(view: EditorView, event: PointerEvent, target: 
 }
 
 /** Passively observes a text-selection drag until it crosses into another table cell. */
-function observeActiveEditorPointerDown(view: EditorView, event: PointerEvent, target: HTMLElement): PressDisposition {
+function observeActiveEditorPointerDown(view: EditorView, event: PointerEvent, target: HTMLElement): boolean {
     const activeTarget = resolveCellTarget(view, target);
     if (!activeTarget || !isSameActiveCell(getActiveCell(view.state), activeTarget.resolvedCell.activeCell)) {
-        return 'native';
+        return false;
     }
 
     return beginMouseCellGesture(view, event, activeTarget.cell, activeTarget.resolvedCell, 'activeEditorText');
 }
 
 /** Extend the cell selection (shift-click) or open the clicked cell. */
-function activateCellFromMouseDown(view: EditorView, event: MouseEvent, cell: HTMLElement): PressDisposition {
+function activateCellFromMouseDown(view: EditorView, event: MouseEvent, cell: HTMLElement): boolean {
     const resolvedCell = resolveCell(view, cell);
     if (!resolvedCell) {
-        return 'native';
+        return false;
     }
 
     const hasSelection = Boolean(getCellSelection(view.state));
     if (event.shiftKey && setOrExtendCellSelectionToCoords(view, resolvedCell.activeCell, resolvedCell.tableFrom)) {
-        return 'consume';
+        return true;
     }
 
     // Read the press against the rendered content before the open request replaces it, so
@@ -287,12 +276,15 @@ function activateCellFromMouseDown(view: EditorView, event: MouseEvent, cell: HT
         initialCursorPos: resolveClickCursorPos(view.state, resolvedCell, caretHit),
     });
 
-    return 'consume';
+    return true;
 }
 
 /**
- * Routes a press inside a table widget to the handler that owns it, and reports what that
- * handler wants done with the event.
+ * Routes a press inside a table widget to the handler that owns it, and reports whether that
+ * handler took the event.
+ *
+ * Returning true takes the press from CodeMirror and calls `preventDefault` on it; returning
+ * false leaves the event untouched for CodeMirror's own handlers and the browser.
  *
  * A cell press is split across two events by input type. Pointerdown claims only a plain
  * left-mouse press — the one that can become a drag — and leaves the rest native, which the
@@ -310,20 +302,17 @@ function activateCellFromMouseDown(view: EditorView, event: MouseEvent, cell: HT
  * excluded there as it is above: shift-click extends the cell's own text selection, and the
  * gesture stays out of the way unless the pointer crosses into another cell.
  */
-export function handleWidgetPress(view: EditorView, event: MouseEvent | PointerEvent): PressDisposition {
+export function handleWidgetPress(view: EditorView, event: MouseEvent | PointerEvent): boolean {
     // A pointerdown that started a gesture is followed by a compatibility mousedown in some
     // browsers. It belongs to the gesture, whatever it landed on, so it is answered before
     // anything about this press is resolved again.
-    if (event.type === 'mousedown') {
-        const gestureDisposition = mouseCellGestureMouseDownDisposition(view, event);
-        if (gestureDisposition !== 'native') {
-            return gestureDisposition;
-        }
+    if (event.type === 'mousedown' && mouseCellGestureConsumesMouseDown(view, event)) {
+        return true;
     }
 
     const target = event.target as HTMLElement | null;
     if (!target?.closest || !target.closest(getWidgetSelector())) {
-        return 'native';
+        return false;
     }
 
     const insideNestedEditor = Boolean(target.closest(`.${CLASS_CELL_EDITOR}`));
@@ -336,32 +325,5 @@ export function handleWidgetPress(view: EditorView, event: MouseEvent | PointerE
     }
 
     // The nested editor owns the rest of its own events.
-    return insideNestedEditor ? 'native' : handleWidgetMouseDown(view, event, target);
+    return insideNestedEditor ? false : handleWidgetMouseDown(view, event, target);
 }
-
-/**
- * The one place a press inside a table widget is dispatched from.
- *
- * Capture phase, because the disposition a press needs is not always one CodeMirror's own
- * dispatch can express: see {@link PressDisposition}. Running ahead of the outer editor's
- * handlers also means a press this router claims never reaches them at all.
- */
-export const tableWidgetPressPlugin = ViewPlugin.define((view) => {
-    const onPress = (event: MouseEvent | PointerEvent): void => {
-        // Respect presses already consumed by an earlier handler, as CodeMirror does.
-        if (event.defaultPrevented) {
-            return;
-        }
-
-        applyPressDisposition(event, handleWidgetPress(view, event));
-    };
-
-    view.dom.addEventListener('pointerdown', onPress, true);
-    view.dom.addEventListener('mousedown', onPress, true);
-    return {
-        destroy() {
-            view.dom.removeEventListener('pointerdown', onPress, true);
-            view.dom.removeEventListener('mousedown', onPress, true);
-        },
-    };
-});

--- a/src/contentScript/tableWidget/tableWidgetInteractions.ts
+++ b/src/contentScript/tableWidget/tableWidgetInteractions.ts
@@ -1,4 +1,4 @@
-import type { EditorView } from '@codemirror/view';
+import { ViewPlugin, type EditorView } from '@codemirror/view';
 import { CLASS_CELL_ACTIVE, CLASS_CELL_EDITOR } from '../shared/tableDomClasses';
 import { slugify } from '../shared/cellContentUtils';
 import { parseFootnoteHref } from '../shared/footnoteAnchor';
@@ -242,7 +242,7 @@ function handleWidgetPointerDown(view: EditorView, event: PointerEvent, target: 
 
     return beginMouseCellGesture(view, event, cell, resolvedCell, {
         origin: 'renderedCell',
-        consumeInitialEvents: true,
+        consumeInitialEvents: false,
     });
 }
 
@@ -345,3 +345,28 @@ export function handleTableInteraction(view: EditorView, event: Event): boolean 
 
     return false;
 }
+
+/**
+ * Native rendered-text selection must bypass CodeMirror's handlers: returning true from a
+ * domEventHandler prevents the browser default. Capture stops propagation without doing so.
+ */
+export const renderedCellNativeSelectionPlugin = ViewPlugin.define((view) => {
+    const pointerDown = (event: PointerEvent): void => {
+        const target = event.target as HTMLElement;
+        if (!target.closest || target.closest(`.${CLASS_CELL_EDITOR}`)) return;
+        const cell = target.closest(SELECTOR_CELL);
+        if (!cell || cell.classList.contains(CLASS_CELL_ACTIVE)) return;
+        handleWidgetPointerDown(view, event, target);
+    };
+    const mouseDown = (event: MouseEvent): void => {
+        consumeMouseCellGestureMouseDown(view, event);
+    };
+    view.dom.addEventListener('pointerdown', pointerDown, true);
+    view.dom.addEventListener('mousedown', mouseDown, true);
+    return {
+        destroy() {
+            view.dom.removeEventListener('pointerdown', pointerDown, true);
+            view.dom.removeEventListener('mousedown', mouseDown, true);
+        },
+    };
+});

--- a/src/contentScript/tableWidget/tableWidgetInteractions.ts
+++ b/src/contentScript/tableWidget/tableWidgetInteractions.ts
@@ -7,7 +7,12 @@ import { clearCellSelectionEffect, getCellSelection } from '../tableState/cellSe
 import { setOrExtendCellSelectionToCoords } from '../tableRuntime/selection/cellSelectionController';
 import { resolveTableContextFromEventTarget } from '../tableRuntime/tablePositioning';
 import { linkOpenerFacet } from '../services/linkOpener';
-import { isPrimaryMouseButton, isPrimaryMousePointer } from '../shared/mouseEvents';
+import {
+    applyPressDisposition,
+    isPrimaryMouseButton,
+    isPrimaryMousePointer,
+    type PressDisposition,
+} from '../shared/mouseEvents';
 import { SELECTOR_CELL, getWidgetSelector, readCellCoords } from './domHelpers';
 import { readRenderedCaretHit } from './cellCaretHit';
 import { resolveClickCursorPos } from '../tableRuntime/interaction/clickCursorPlacement';
@@ -15,7 +20,7 @@ import { requestOpenCell } from '../tableRuntime/openCellRequest';
 import { createResolvedActiveCell, type ResolvedActiveCell } from '../tableRuntime/activeCell/resolvedActiveCell';
 import {
     beginMouseCellGesture,
-    consumeMouseCellGestureMouseDown,
+    mouseCellGestureMouseDownDisposition,
 } from '../tableRuntime/interaction/mouseCellDragSelection';
 
 /** Matches fenced code block delimiters (``` or ~~~) */
@@ -128,10 +133,21 @@ function escapeRegex(str: string): string {
     return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
-/** Click events: strict link opening. */
-function handleWidgetClick(view: EditorView, event: MouseEvent, target: HTMLElement): boolean {
-    // Only handle left clicks
-    if (!isPrimaryMouseButton(event)) {
+/**
+ * Opens a link clicked inside a rendered cell.
+ *
+ * The only widget event still routed through `EditorView.domEventHandlers`: a click asks nothing
+ * unusual of CodeMirror, so it keeps the ordering that registration gives it. Presses go through
+ * {@link handleWidgetPress} instead.
+ */
+export function handleWidgetClick(view: EditorView, event: MouseEvent): boolean {
+    const target = event.target as HTMLElement | null;
+    if (!isPrimaryMouseButton(event) || !target?.closest(getWidgetSelector())) {
+        return false;
+    }
+
+    if (target.closest(`.${CLASS_CELL_EDITOR}`)) {
+        // The nested editor owns the rest of its own events.
         return false;
     }
 
@@ -155,14 +171,7 @@ function handleWidgetClick(view: EditorView, event: MouseEvent, target: HTMLElem
 }
 
 /** Mousedown events: cell activation. */
-function handleWidgetMouseDown(view: EditorView, event: MouseEvent, target: HTMLElement): boolean {
-    // A mouse pointerdown starts a provisional click-or-drag gesture. Some browsers still
-    // emit the compatibility mousedown even though pointerdown was prevented; consume it so
-    // the nested editor is not opened before the gesture resolves on pointerup.
-    if (consumeMouseCellGestureMouseDown(view, event)) {
-        return true;
-    }
-
+function handleWidgetMouseDown(view: EditorView, event: MouseEvent, target: HTMLElement): PressDisposition {
     // If clicking a link with LEFT click, we want to PREVENT cell handling so the Click event can fire cleanly
     // and open the link.
     // If we processed cell activation here, it might swallow the event or change focus
@@ -173,7 +182,8 @@ function handleWidgetMouseDown(view: EditorView, event: MouseEvent, target: HTML
         if (getCellSelection(view.state)) {
             view.dispatch({ effects: clearCellSelectionEffect.of(undefined) });
         }
-        return true; // Claim the event to prevent CodeMirror default selection, but don't activate cell
+        // Claim the event to prevent CodeMirror default selection, but don't activate cell.
+        return 'consume';
     }
 
     const cell = target.closest(SELECTOR_CELL) as HTMLElement | null;
@@ -182,7 +192,7 @@ function handleWidgetMouseDown(view: EditorView, event: MouseEvent, target: HTML
         // repositioning the cursor. Without this, clicking the widget's horizontal
         // scrollbar maps to a document position at or after the table, which clears
         // the active cell state and closes the nested editor.
-        return true;
+        return 'consume';
     }
 
     return activateCellFromMouseDown(view, event, cell);
@@ -217,61 +227,54 @@ function resolveCellTarget(view: EditorView, target: HTMLElement): ResolvedCellT
 /**
  * Starts a desktop-mouse gesture that becomes either cell activation or drag selection.
  *
- * Declining leaves the press to the compatibility mousedown; see `handleTableInteraction`.
+ * Declining leaves the press to the compatibility mousedown; see {@link handleWidgetPress}.
  */
-function handleWidgetPointerDown(view: EditorView, event: PointerEvent, target: HTMLElement): boolean {
+function handleWidgetPointerDown(view: EditorView, event: PointerEvent, target: HTMLElement): PressDisposition {
     if (!isPrimaryMousePointer(event) || event.shiftKey || target.closest(SELECTOR_LINK)) {
-        return false;
+        return 'native';
     }
 
     const pressed = resolveCellTarget(view, target);
     if (!pressed) {
-        return false;
+        return 'native';
     }
 
     const { cell, resolvedCell } = pressed;
-    if (
+    // A press that reaches here on the active cell landed on its row-height padding rather than
+    // on its editor, which is a separate origin reached through `observeActiveEditorPointerDown`.
+    const pressedActiveCell =
         cell.classList.contains(CLASS_CELL_ACTIVE) &&
-        isSameActiveCell(getActiveCell(view.state), resolvedCell.activeCell)
-    ) {
-        return beginMouseCellGesture(view, event, cell, resolvedCell, {
-            origin: 'activeEditor',
-            consumeInitialEvents: true,
-        });
-    }
+        isSameActiveCell(getActiveCell(view.state), resolvedCell.activeCell);
 
-    return beginMouseCellGesture(view, event, cell, resolvedCell, {
-        origin: 'renderedCell',
-        consumeInitialEvents: false,
-    });
+    return beginMouseCellGesture(
+        view,
+        event,
+        cell,
+        resolvedCell,
+        pressedActiveCell ? 'activeEditorPadding' : 'renderedCell'
+    );
 }
 
 /** Passively observes a text-selection drag until it crosses into another table cell. */
-function observeActiveEditorPointerDown(view: EditorView, event: PointerEvent, target: HTMLElement): void {
+function observeActiveEditorPointerDown(view: EditorView, event: PointerEvent, target: HTMLElement): PressDisposition {
     const activeTarget = resolveCellTarget(view, target);
     if (!activeTarget || !isSameActiveCell(getActiveCell(view.state), activeTarget.resolvedCell.activeCell)) {
-        return;
+        return 'native';
     }
 
-    beginMouseCellGesture(view, event, activeTarget.cell, activeTarget.resolvedCell, {
-        origin: 'activeEditor',
-        consumeInitialEvents: false,
-    });
+    return beginMouseCellGesture(view, event, activeTarget.cell, activeTarget.resolvedCell, 'activeEditorText');
 }
 
 /** Extend the cell selection (shift-click) or open the clicked cell. */
-function activateCellFromMouseDown(view: EditorView, event: MouseEvent, cell: HTMLElement): boolean {
+function activateCellFromMouseDown(view: EditorView, event: MouseEvent, cell: HTMLElement): PressDisposition {
     const resolvedCell = resolveCell(view, cell);
     if (!resolvedCell) {
-        return false;
+        return 'native';
     }
-
-    event.preventDefault();
-    event.stopPropagation();
 
     const hasSelection = Boolean(getCellSelection(view.state));
     if (event.shiftKey && setOrExtendCellSelectionToCoords(view, resolvedCell.activeCell, resolvedCell.tableFrom)) {
-        return true;
+        return 'consume';
     }
 
     // Read the press against the rendered content before the open request replaces it, so
@@ -284,14 +287,15 @@ function activateCellFromMouseDown(view: EditorView, event: MouseEvent, cell: HT
         initialCursorPos: resolveClickCursorPos(view.state, resolvedCell, caretHit),
     });
 
-    return true;
+    return 'consume';
 }
 
 /**
- * Routes a widget event to the handler that owns it.
+ * Routes a press inside a table widget to the handler that owns it, and reports what that
+ * handler wants done with the event.
  *
  * A cell press is split across two events by input type. Pointerdown claims only a plain
- * left-mouse press — the one that can become a drag — and declines the rest, which the
+ * left-mouse press — the one that can become a drag — and leaves the rest native, which the
  * compatibility mousedown behind it then handles:
  *
  * - left mouse, no shift: pointerdown starts a click-or-drag gesture
@@ -306,67 +310,53 @@ function activateCellFromMouseDown(view: EditorView, event: MouseEvent, cell: HT
  * excluded there as it is above: shift-click extends the cell's own text selection, and the
  * gesture stays out of the way unless the pointer crosses into another cell.
  */
-export function handleTableInteraction(view: EditorView, event: Event): boolean {
-    const target = event.target as HTMLElement | null;
-    if (!target) {
-        return false;
+export function handleWidgetPress(view: EditorView, event: MouseEvent | PointerEvent): PressDisposition {
+    // A pointerdown that started a gesture is followed by a compatibility mousedown in some
+    // browsers. It belongs to the gesture, whatever it landed on, so it is answered before
+    // anything about this press is resolved again.
+    if (event.type === 'mousedown') {
+        const gestureDisposition = mouseCellGestureMouseDownDisposition(view, event);
+        if (gestureDisposition !== 'native') {
+            return gestureDisposition;
+        }
     }
 
-    // Only handle events inside table widgets.
-    const widget = target.closest(getWidgetSelector());
-    if (!widget) {
-        return false;
+    const target = event.target as HTMLElement | null;
+    if (!target?.closest || !target.closest(getWidgetSelector())) {
+        return 'native';
     }
 
     const insideNestedEditor = Boolean(target.closest(`.${CLASS_CELL_EDITOR}`));
     if (event.type === 'pointerdown') {
-        if (insideNestedEditor) {
-            // Observed but never claimed, so the nested editor keeps its native text-selection
-            // drag until the pointer crosses into another cell.
-            observeActiveEditorPointerDown(view, event as PointerEvent, target);
-            return false;
-        }
-
-        return handleWidgetPointerDown(view, event as PointerEvent, target);
+        return insideNestedEditor
+            ? // Observed but never claimed, so the nested editor keeps its native text-selection
+              // drag until the pointer crosses into another cell.
+              observeActiveEditorPointerDown(view, event as PointerEvent, target)
+            : handleWidgetPointerDown(view, event as PointerEvent, target);
     }
 
     // The nested editor owns the rest of its own events.
-    if (insideNestedEditor) {
-        return false;
-    }
-
-    if (event.type === 'click') {
-        return handleWidgetClick(view, event as MouseEvent, target);
-    }
-
-    if (event.type === 'mousedown') {
-        return handleWidgetMouseDown(view, event as MouseEvent, target);
-    }
-
-    return false;
+    return insideNestedEditor ? 'native' : handleWidgetMouseDown(view, event, target);
 }
 
 /**
- * Native rendered-text selection must bypass CodeMirror's handlers: returning true from a
- * domEventHandler prevents the browser default. Capture stops propagation without doing so.
+ * The one place a press inside a table widget is dispatched from.
+ *
+ * Capture phase, because the disposition a press needs is not always one CodeMirror's own
+ * dispatch can express: see {@link PressDisposition}. Running ahead of the outer editor's
+ * handlers also means a press this router claims never reaches them at all.
  */
-export const renderedCellNativeSelectionPlugin = ViewPlugin.define((view) => {
-    const pointerDown = (event: PointerEvent): void => {
-        const target = event.target as HTMLElement;
-        if (!target.closest || target.closest(`.${CLASS_CELL_EDITOR}`)) return;
-        const cell = target.closest(SELECTOR_CELL);
-        if (!cell || cell.classList.contains(CLASS_CELL_ACTIVE)) return;
-        handleWidgetPointerDown(view, event, target);
+export const tableWidgetPressPlugin = ViewPlugin.define((view) => {
+    const onPress = (event: MouseEvent | PointerEvent): void => {
+        applyPressDisposition(event, handleWidgetPress(view, event));
     };
-    const mouseDown = (event: MouseEvent): void => {
-        consumeMouseCellGestureMouseDown(view, event);
-    };
-    view.dom.addEventListener('pointerdown', pointerDown, true);
-    view.dom.addEventListener('mousedown', mouseDown, true);
+
+    view.dom.addEventListener('pointerdown', onPress, true);
+    view.dom.addEventListener('mousedown', onPress, true);
     return {
         destroy() {
-            view.dom.removeEventListener('pointerdown', pointerDown, true);
-            view.dom.removeEventListener('mousedown', mouseDown, true);
+            view.dom.removeEventListener('pointerdown', onPress, true);
+            view.dom.removeEventListener('mousedown', onPress, true);
         },
     };
 });

--- a/src/contentScript/tableWidget/tableWidgetInteractions.ts
+++ b/src/contentScript/tableWidget/tableWidgetInteractions.ts
@@ -9,6 +9,8 @@ import { resolveTableContextFromEventTarget } from '../tableRuntime/tablePositio
 import { linkOpenerFacet } from '../services/linkOpener';
 import { isPrimaryMouseButton, isPrimaryMousePointer } from '../shared/mouseEvents';
 import { SELECTOR_CELL, getWidgetSelector, readCellCoords } from './domHelpers';
+import { readRenderedCaretHit } from './cellCaretHit';
+import { resolveClickCursorPos } from '../tableRuntime/interaction/clickCursorPlacement';
 import { requestOpenCell } from '../tableRuntime/openCellRequest';
 import { createResolvedActiveCell, type ResolvedActiveCell } from '../tableRuntime/activeCell/resolvedActiveCell';
 import {
@@ -272,9 +274,14 @@ function activateCellFromMouseDown(view: EditorView, event: MouseEvent, cell: HT
         return true;
     }
 
+    // Read the press against the rendered content before the open request replaces it, so
+    // the caret lands where the reader pointed rather than at the start of the cell.
+    const caretHit = readRenderedCaretHit(cell, event.clientX, event.clientY);
+
     requestOpenCell(view, {
         resolvedCell,
         clearCellSelection: hasSelection,
+        initialCursorPos: resolveClickCursorPos(view.state, resolvedCell, caretHit),
     });
 
     return true;

--- a/src/contentScript/tableWidget/tableWidgetInteractions.ts
+++ b/src/contentScript/tableWidget/tableWidgetInteractions.ts
@@ -318,7 +318,7 @@ export function handleWidgetPress(view: EditorView, event: MouseEvent | PointerE
     const insideNestedEditor = Boolean(target.closest(`.${CLASS_CELL_EDITOR}`));
     if (event.type === 'pointerdown') {
         return insideNestedEditor
-            ? // Observed but never claimed, so the nested editor keeps its native text-selection
+            ? // Observed but never taken from the nested editor, so the nested editor keeps its native text-selection
               // drag until the pointer crosses into another cell.
               observeActiveEditorPointerDown(view, event as PointerEvent, target)
             : handleWidgetPointerDown(view, event as PointerEvent, target);

--- a/src/contentScript/tableWidget/wholeTableSelectionVisuals.ts
+++ b/src/contentScript/tableWidget/wholeTableSelectionVisuals.ts
@@ -79,6 +79,10 @@ function selectedCells(pseudo = ''): string {
  * The `&.cm-focused` copies exist for specificity: Joplin's own `&.cm-focused ::selection` rule
  * is two classes with `!important`, so the unfocused rules alone would tie with it and be
  * settled by stylesheet order. Same approach as `nestedEditor/rootEditorSelectionTheme.ts`.
+ *
+ * The one native highlight that survives this is a text selection dragged out inside a rendered
+ * cell, which `renderedTextSelectionTheme.ts` paints instead; its selectors match only cells this
+ * one has no fill to protect.
  */
 const NATIVE_SELECTION_RESET = {
     'background-color': 'transparent !important',


### PR DESCRIPTION
Clicking a rendered cell opened it with the main editor's selection mirrored in, so every click landed in the same place. This maps the click back to the Markdown behind it: clicking inside a bolded word now lands between the same two letters once the syntax is visible.

The rendering service returns HTML without offsets, so placement combines DOM hit testing with CodeMirror's syntax tree. How a cell is mapped depends on how far its rendered text has drifted from its source, and the exact strategies are tried first:

**Plain text** — the rendered text is the cell's own text, so offsets map one to one. Nothing is hidden and nothing can drift.

**Inline Markdown that renders verbatim** — `**bold**`, `[label](url)`, `` `code` ``, `<br>`, escaped pipes. The syntax tree projects the visible source into text with a map back to cell offsets, excluding hidden syntax — delimiters, link targets, images, raw HTML — so it can never become an anchor for a click. When that projection equals the rendered text, placement is still exact.

**Text the renderer rewrote** — entities, smart quotes, em dashes, emoji shortcodes, unknown plugins. Only here does character alignment run, matching the rendered text against the projection. It is approximate by nature, capped at 1000 characters a side, and declines when less than half the text finds an anchor.

Declining keeps the mirrored selection, which is the behaviour on `main` today. A cell that renders no text at all — a lone image or formula — declines for the same reason.

## Changes

- Place the caret at the clicked point, and map a text selection dragged inside a cell onto the Markdown it covers, preserving direction. A range takes the syntax it spans and leaves the syntax around it, and never keeps one marker of a pair without the other.
- Paint rendered-text selections in Joplin's selection colour while the drag is in progress; crossing into another cell promotes the gesture to a rectangle as before.
- Route every widget press through one handler, registered for `pointerdown` and `mousedown` next to the existing click handler. It reports whether it took the press; CodeMirror stops running handlers once one returns true, so a press this router takes reaches neither its built-ins nor `closeOnOutsideMouseDown`.
- For mobile (which opens a context menu on long-press selected cell text instead of opening the cell editor): let the browser copy text selected inside a rendered cell. CodeMirror answered the copy from its own selection, which is empty during a long press on mobile, so Copy put the caret's whole source line on the clipboard.
- For that third case, align the transformed text with a single forward scan that resynchronises within a small window. Renderer substitutions are local — an entity, an em dash, an emoji for its shortcode — so a nearby anchor recovers from them. The scan never backtracks, so a hidden run wider than the window strands the rest of the cell; that collapses the matched ratio, which the existing threshold already declines on, so it falls back to the mirrored selection rather than a confidently wrong caret.
- Build cell offset maps once per cell rather than running the text transform once per range.

## Verification

`npm test` (1110 tests across 83 files), `npm run lint`, `npm run knip`, `npm run format`, and `npm run dist` pass.

The simplified alignment fallback from 1caff5dc2f0f763a2e2b703c317fac2bcdbc9c51 was checked against the branch's previous longest-matching-block implementation over a corpus of realistic rendered/source pairs — em dashes, ellipses, smart quotes, entities, emoji shortcodes, repeated tokens. It places every caret identically in all of them, and handles two shapes the old implementation declined outright. Those cases are now tests, pinning the placements the two agreed on.

Three paths jsdom cannot exercise are worth checking in the app:

- Long-press copy on mobile, and Ctrl+C over a whole-table selection on desktop, which must still copy the table's Markdown.
- Ordinary presses inside a table — clicks, drags, shift-clicks, right-clicks, link clicks. Widget presses no longer call `stopPropagation`, which a `domEventHandlers` return cannot do. Nothing in the plugin relied on it, but it did previously shield these presses from any non-CodeMirror listener Joplin may have.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

