### PR TITLE
fix: hide the main caret while a cell is opening

### DIFF
--- a/docs/Architecture/Interaction-and-Navigation.md
+++ b/docs/Architecture/Interaction-and-Navigation.md
@@ -108,6 +108,10 @@ CodeMirror's Markdown syntax tree:
 
 The offset or range travels through the open-cell request to the nested editor.
 
+That request moves the main selection into the table's block widget an animation frame before the nested editor
+mounts, so `tableWidget/mainCaretSuppression.ts` hides the main caret until it settles. The same extension hides it
+for a cell selection, which parks its caret in the table for the length of the selection.
+
 Every press inside a widget is routed by `handleWidgetPress` in `tableWidget/tableWidgetInteractions.ts`, registered
 for `pointerdown` and `mousedown` alongside the click handler. It reports whether it took the press. CodeMirror stops
 running handlers for an event once one returns true and appends its own built-ins after every plugin's, so a press the

--- a/src/contentScript/__tests__/cellSelectionVisuals.test.ts
+++ b/src/contentScript/__tests__/cellSelectionVisuals.test.ts
@@ -8,7 +8,7 @@ import { GFM } from '@lezer/markdown';
 import { afterEach, describe, expect, it } from 'vitest';
 import { cellSelectionField, clearCellSelectionEffect, setCellSelectionEffect } from '../tableState/cellSelectionState';
 import { cellDragField, endCellDragEffect, startCellDragEffect } from '../tableState/cellDragState';
-import { cellSelectionCaretSuppression, cellSelectionVisuals } from '../tableWidget/cellSelectionVisuals';
+import { cellSelectionVisuals } from '../tableWidget/cellSelectionVisuals';
 
 const TABLE = ['| H1 | H2 |', '| --- | --- |', '| a1 | a2 |'].join('\n');
 const DOC = `above\n${TABLE}\nbelow`;
@@ -23,13 +23,7 @@ function mountView(): EditorView {
     const view = new EditorView({
         parent,
         doc: DOC,
-        extensions: [
-            markdown({ extensions: [GFM] }),
-            cellSelectionField,
-            cellDragField,
-            cellSelectionCaretSuppression,
-            cellSelectionVisuals,
-        ],
+        extensions: [markdown({ extensions: [GFM] }), cellSelectionField, cellDragField, cellSelectionVisuals],
     });
     mountedViews.push(view);
 
@@ -41,25 +35,6 @@ afterEach(() => {
         mountedViews.pop()?.destroy();
     }
     document.body.replaceChildren();
-});
-
-describe('cellSelectionCaretSuppression', () => {
-    it('marks the editor while a cell selection is active and unmarks it afterwards', () => {
-        const view = mountView();
-        expect(view.dom.hasAttribute('data-rt-cell-selection')).toBe(false);
-
-        view.dispatch({
-            effects: setCellSelectionEffect.of({
-                tableFrom: TABLE_FROM,
-                anchor: { section: 'header', row: 0, col: 0 },
-                focus: { section: 'body', row: 0, col: 1 },
-            }),
-        });
-        expect(view.dom.hasAttribute('data-rt-cell-selection')).toBe(true);
-
-        view.dispatch({ effects: clearCellSelectionEffect.of(undefined) });
-        expect(view.dom.hasAttribute('data-rt-cell-selection')).toBe(false);
-    });
 });
 
 describe('cell drag focus override', () => {

--- a/src/contentScript/__tests__/mainCaretSuppression.test.ts
+++ b/src/contentScript/__tests__/mainCaretSuppression.test.ts
@@ -1,0 +1,111 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { markdown } from '@codemirror/lang-markdown';
+import { EditorView } from '@codemirror/view';
+import { GFM } from '@lezer/markdown';
+import { afterEach, describe, expect, it } from 'vitest';
+import { cellSelectionField, clearCellSelectionEffect, setCellSelectionEffect } from '../tableState/cellSelectionState';
+import { activeCellField } from '../tableState/activeCellState';
+import {
+    beginOpenCellRequestEffect,
+    clearOpenCellRequestEffect,
+    openCellRequestField,
+} from '../tableRuntime/openCellRequest';
+import { mainCaretSuppression } from '../tableWidget/mainCaretSuppression';
+
+const TABLE = ['| H1 | H2 |', '| --- | --- |', '| a1 | a2 |'].join('\n');
+const DOC = `above\n${TABLE}\nbelow`;
+const TABLE_FROM = 'above'.length + 1;
+const ATTR = 'data-rt-caret-suppressed';
+
+const REQUEST_ID = 'open-cell-test';
+
+const mountedViews: EditorView[] = [];
+
+function mountView(): EditorView {
+    const parent = document.createElement('div');
+    document.body.appendChild(parent);
+
+    const view = new EditorView({
+        parent,
+        doc: DOC,
+        extensions: [
+            markdown({ extensions: [GFM] }),
+            cellSelectionField,
+            activeCellField,
+            openCellRequestField,
+            mainCaretSuppression,
+        ],
+    });
+    mountedViews.push(view);
+
+    return view;
+}
+
+function beginOpenRequest(view: EditorView): void {
+    view.dispatch({
+        effects: beginOpenCellRequestEffect.of({
+            requestId: REQUEST_ID,
+            activeCell: { tableFrom: TABLE_FROM, section: 'body', row: 0, col: 0 },
+            suppressKeys: false,
+        }),
+    });
+}
+
+function selectCells(view: EditorView): void {
+    view.dispatch({
+        effects: setCellSelectionEffect.of({
+            tableFrom: TABLE_FROM,
+            anchor: { section: 'header', row: 0, col: 0 },
+            focus: { section: 'body', row: 0, col: 1 },
+        }),
+    });
+}
+
+afterEach(() => {
+    while (mountedViews.length > 0) {
+        mountedViews.pop()?.destroy();
+    }
+    document.body.replaceChildren();
+});
+
+describe('mainCaretSuppression', () => {
+    it('suppresses the caret while a cell selection is active', () => {
+        const view = mountView();
+        expect(view.dom.hasAttribute(ATTR)).toBe(false);
+
+        selectCells(view);
+        expect(view.dom.hasAttribute(ATTR)).toBe(true);
+
+        view.dispatch({ effects: clearCellSelectionEffect.of(undefined) });
+        expect(view.dom.hasAttribute(ATTR)).toBe(false);
+    });
+
+    it('suppresses the caret while a cell is opening', () => {
+        // The request moves the main selection into the table's block widget a frame before the
+        // nested editor mounts, so the caret would otherwise paint on the cell divider.
+        const view = mountView();
+
+        beginOpenRequest(view);
+        expect(view.dom.hasAttribute(ATTR)).toBe(true);
+
+        view.dispatch({ effects: clearOpenCellRequestEffect.of({ requestId: REQUEST_ID }) });
+        expect(view.dom.hasAttribute(ATTR)).toBe(false);
+    });
+
+    it('keeps the caret suppressed until both reasons are gone', () => {
+        // Clicking a cell inside an existing rectangle clears the selection and opens the cell in
+        // one transaction, so the two reasons overlap and neither may lift the suppression alone.
+        const view = mountView();
+        selectCells(view);
+        beginOpenRequest(view);
+
+        view.dispatch({ effects: clearCellSelectionEffect.of(undefined) });
+        expect(view.dom.hasAttribute(ATTR)).toBe(true);
+
+        view.dispatch({ effects: clearOpenCellRequestEffect.of({ requestId: REQUEST_ID }) });
+        expect(view.dom.hasAttribute(ATTR)).toBe(false);
+    });
+});

--- a/src/contentScript/tableWidget/cellSelectionVisuals.ts
+++ b/src/contentScript/tableWidget/cellSelectionVisuals.ts
@@ -1,6 +1,6 @@
 import type { Extension } from '@codemirror/state';
 import { EditorView } from '@codemirror/view';
-import { cellSelectionField, getCellSelection, isCellInRect, toSelectionRect } from '../tableState/cellSelectionState';
+import { getCellSelection, isCellInRect, toSelectionRect } from '../tableState/cellSelectionState';
 import { cellDragField, isCellDragInProgress } from '../tableState/cellDragState';
 import {
     CELL_TAGS,
@@ -98,30 +98,4 @@ export const cellSelectionVisuals: Extension = [
     cellDragAttribute,
     cellDragFocusOverride,
     cellDragTextSelectionSuppression,
-];
-
-/**
- * Hides the main editor's caret while a cell selection is active.
- *
- * The selection highlight is drawn on the widget's cells, but the real caret stays parked
- * at the focus cell's document position so clipboard and shortcut handling keep working.
- * `TableWidget.coordsAt` maps that position onto the cell's rectangle, so the caret paints
- * inside the rendered table — a blinking insertion point between cells, in a table where
- * typing is not what the selection is for. Suppress it and let the highlight carry the state.
- *
- * `caret-color` covers the browser's native caret; `.cm-cursorLayer` covers the one
- * `drawSelection` paints when the host editor enables it.
- */
-export const cellSelectionCaretSuppression: Extension = [
-    EditorView.editorAttributes.compute([cellSelectionField], (state): Record<string, string> =>
-        getCellSelection(state) ? { 'data-rt-cell-selection': '' } : {}
-    ),
-    EditorView.baseTheme({
-        '&[data-rt-cell-selection] .cm-content': {
-            caretColor: 'transparent',
-        },
-        '&[data-rt-cell-selection] .cm-cursorLayer': {
-            display: 'none',
-        },
-    }),
 ];

--- a/src/contentScript/tableWidget/mainCaretSuppression.ts
+++ b/src/contentScript/tableWidget/mainCaretSuppression.ts
@@ -21,9 +21,6 @@ const ATTR_CARET_SUPPRESSED = 'data-rt-caret-suppressed';
  * — a stripe on the cell divider, right where the click landed, a frame before the real caret
  * appears in the cell.
  *
- * One question with two answers rather than two extensions: both ask whether the main caret
- * should be drawn, and a cell opening out of a cell selection is both at once.
- *
  * `caret-color` covers the browser's native caret; `.cm-cursorLayer` covers the one
  * `drawSelection` paints when the host editor enables it.
  */

--- a/src/contentScript/tableWidget/mainCaretSuppression.ts
+++ b/src/contentScript/tableWidget/mainCaretSuppression.ts
@@ -1,0 +1,42 @@
+import type { Extension } from '@codemirror/state';
+import { EditorView } from '@codemirror/view';
+import { cellSelectionField, getCellSelection } from '../tableState/cellSelectionState';
+import { getPendingOpenCellRequest, openCellRequestField } from '../tableRuntime/openCellRequest';
+
+/** Marks the editor root while the main editor's caret should not be painted. */
+const ATTR_CARET_SUPPRESSED = 'data-rt-caret-suppressed';
+
+/**
+ * Hides the main editor's caret while the table owns interaction, for either of two reasons.
+ *
+ * A **cell selection** parks the real caret at the focus cell's document position so clipboard
+ * and shortcut handling keep working. `TableWidget.coordsAt` maps that position onto the cell's
+ * rectangle, so the caret paints inside the rendered table — a blinking insertion point between
+ * cells, in a table where typing is not what the selection is for. The highlight carries the
+ * state instead.
+ *
+ * A **cell being opened** moves the main selection to the cell's source offset, which is inside
+ * the table's block widget, and the nested editor mounts an animation frame later. The main
+ * editor keeps focus across that gap, so without this it paints a caret at the widget boundary
+ * — a stripe on the cell divider, right where the click landed, a frame before the real caret
+ * appears in the cell.
+ *
+ * One question with two answers rather than two extensions: both ask whether the main caret
+ * should be drawn, and a cell opening out of a cell selection is both at once.
+ *
+ * `caret-color` covers the browser's native caret; `.cm-cursorLayer` covers the one
+ * `drawSelection` paints when the host editor enables it.
+ */
+export const mainCaretSuppression: Extension = [
+    EditorView.editorAttributes.compute([cellSelectionField, openCellRequestField], (state): Record<string, string> =>
+        getCellSelection(state) || getPendingOpenCellRequest(state) ? { [ATTR_CARET_SUPPRESSED]: '' } : {}
+    ),
+    EditorView.baseTheme({
+        [`&[${ATTR_CARET_SUPPRESSED}] .cm-content`]: {
+            caretColor: 'transparent',
+        },
+        [`&[${ATTR_CARET_SUPPRESSED}] .cm-cursorLayer`]: {
+            display: 'none',
+        },
+    }),
+];

--- a/src/contentScript/tableWidget/tableWidgetExtension.ts
+++ b/src/contentScript/tableWidget/tableWidgetExtension.ts
@@ -21,7 +21,8 @@ import { cellSelectionClipboardPlugin } from '../tableRuntime/selection/cellSele
 import { cellSelectionKeyCapturePlugin } from '../tableRuntime/selection/cellSelectionKeymap';
 import { cellSelectionFocusPlugin } from '../tableRuntime/selection/cellSelectionController';
 import { cellSelectionScopeGuard } from '../tableRuntime/selection/cellSelectionScopeGuard';
-import { cellSelectionCaretSuppression, cellSelectionVisuals } from './cellSelectionVisuals';
+import { cellSelectionVisuals } from './cellSelectionVisuals';
+import { mainCaretSuppression } from './mainCaretSuppression';
 import { wholeTableSelectionVisuals } from './wholeTableSelectionVisuals';
 import { renderedTextSelectionTheme } from './renderedTextSelectionTheme';
 import { tableSelectionSnapFilter } from '../tableRuntime/selection/tableSelectionSnap';
@@ -151,7 +152,7 @@ async function registerTableWidgetExtension(
         cellSelectionClipboardPlugin,
         cellSelectionFocusPlugin,
         cellSelectionVisuals,
-        cellSelectionCaretSuppression,
+        mainCaretSuppression,
         wholeTableSelectionVisuals,
         renderedTextSelectionTheme,
         nestedEditorFocusGuard,


### PR DESCRIPTION
Clicking into a cell briefly showed the main editor's caret on the cell divider, a frame before the real caret appeared inside the cell.

An open-cell request moves the main selection to the cell's source offset, which sits inside the table's block widget, and the nested editor mounts an animation frame later. The main editor keeps focus across that gap, so it paints a caret at the widget boundary until the nested editor takes over.

The gap has always been there. Before #219 a rendered-cell press was left to the browser, whose default moved the DOM selection into the widget and dropped `view.hasFocus`, so the cursor layer was never drawn. Consuming the press keeps focus with the main editor, which is what made the gap visible.

## Changes

- Suppress the main caret for the length of an open-cell request. This covers keyboard entry as well — Tab, Enter, and table entry from the main editor all open cells through the same path.
- Fold that together with the suppression a cell selection already applies to the caret it parks in the table. Both ask one question — should the main caret be drawn — and clicking a cell inside an existing rectangle raises both at once, so sharing one attribute keeps either from clearing the other's. `cellSelectionCaretSuppression` moves out of `cellSelectionVisuals.ts` and becomes `mainCaretSuppression.ts`, whose name now matches what it does.

## Notes

A failed open leaves the caret hidden until its request clears — immediately on failure, or at the existing 1s request timeout. Bounded, and no worse than the state it replaces.

Mounting synchronously instead of on an animation frame would close the gap at the source, but the widget DOM has to exist before the cell element can be found. Not moving the main selection until the mount would too, but it is the anchor the nested editor mirrors from — too much risk for a cosmetic fix.

## Verification

`npm test` (1112 tests across 84 files), `npm run lint`, `npm run knip`, `npm run format`, and `npm run dist` pass.

The two new tests were checked against the unfixed condition and both fail without it.

Worth a look in the app: clicking a cell from an already-focused editor, which is when the flash was visible, and clicking a cell inside an existing multi-cell selection, where both suppression reasons overlap in one transaction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
