### PR TITLE
refactor: map cell selections through offset maps in both directions

### DIFF
--- a/docs/Architecture/Nested-Editor-Architecture.md
+++ b/docs/Architecture/Nested-Editor-Architecture.md
@@ -94,7 +94,8 @@ Response (to prevent stale document state):
 
 - **Local → Root Sanitization** (`shared/cellTextNormalization`): `\n`/`\r` → `<br>`, `|` → `\|`.
 - **Root → Local Unsanitization** (`shared/cellTextNormalization`): `<br>` → visible line breaks, `\|` → `|`.
-- **Selection Mapping** (`editorBridge/cellTextCodec`): Local/root selections are mapped through the sanitize/unsanitize transforms, not by naive offset arithmetic.
+- **Offset Maps** (`shared/cellTextNormalization`): `localToRootOffsets` and `rootToLocalOffsets` give the mapped offset for every offset in the text, from the same scan that produces the converted text, so text and offsets cannot disagree. An offset inside a spelling that converts to something shorter or longer gives the start of it.
+- **Selection Mapping** (`editorBridge/cellTextCodec`): Local/root selections read both endpoints out of the matching offset map, not by naive offset arithmetic and not by rewriting the text being measured.
 
 ### Main Editor (`editorBridge/mainEditorGuard`)
 

--- a/src/contentScript/__tests__/cellTextCodec.test.ts
+++ b/src/contentScript/__tests__/cellTextCodec.test.ts
@@ -18,6 +18,47 @@ describe('selection mapping', () => {
         expect(localSelection).toEqual({ anchor: 0, head: 'a\nb|c'.length });
     });
 
+    it('keeps a backward selection backward', () => {
+        const localText = 'a\nb|c';
+
+        expect(toRootSelection({ anchor: localText.length, head: 0 }, localText)).toEqual({
+            anchor: String.raw`a<br>b\|c`.length,
+            head: 0,
+        });
+    });
+
+    it('puts a root caret inside a stored line break at the break itself', () => {
+        // The nested editor shows `a\nb`, which has no position halfway through `<br>`.
+        const rootText = String.raw`a<br>b`;
+
+        expect(toLocalSelection({ anchor: 3, head: 3 }, rootText)).toEqual({ anchor: 1, head: 1 });
+    });
+
+    it('puts a root caret inside a pipe escape before the pipe it escapes', () => {
+        const rootText = String.raw`a\|b`;
+
+        expect(toLocalSelection({ anchor: 2, head: 2 }, rootText)).toEqual({ anchor: 1, head: 1 });
+    });
+
+    it('maps a root selection that starts and ends inside stored spellings', () => {
+        const rootText = String.raw`a<br>b\|c`;
+
+        // `a\nb|c`: both endpoints fall to the start of the spelling they landed in.
+        expect(toLocalSelection({ anchor: 3, head: 7 }, rootText)).toEqual({ anchor: 1, head: 3 });
+    });
+
+    it('escapes a pipe the caret sits in front of without stranding the caret', () => {
+        const localText = 'a|b';
+
+        // `a\|b`: the caret stays in front of the escape, not between the backslash and the pipe.
+        expect(toRootSelection({ anchor: 1, head: 1 }, localText)).toEqual({ anchor: 1, head: 1 });
+        expect(toRootSelection({ anchor: 2, head: 2 }, localText)).toEqual({ anchor: 3, head: 3 });
+    });
+
+    it('clamps selections that reach past the text they are mapped from', () => {
+        expect(toLocalSelection({ anchor: -5, head: 99 }, String.raw`a<br>b`)).toEqual({ anchor: 0, head: 3 });
+    });
+
     it('keeps trailing-space cursor positions stable for root-owned commands', () => {
         const localText = 'sometext ';
         const rootSelection = toRootSelection({ anchor: localText.length, head: localText.length }, localText);

--- a/src/contentScript/__tests__/cellTextNormalization.test.ts
+++ b/src/contentScript/__tests__/cellTextNormalization.test.ts
@@ -1,27 +1,35 @@
 import { describe, expect, it } from 'vitest';
 import {
     convertNewlinesToBr,
-    escapeUnescapedPipes,
+    escapeUnescapedPipesWithContext,
+    localToRootOffsets,
     normalizeBrTags,
     rootToLocalOffsets,
     sanitizeLocalText,
     unsanitizeRootText,
 } from '../shared/cellTextNormalization';
 
-describe('escapeUnescapedPipes', () => {
+describe('escapeUnescapedPipesWithContext', () => {
+    const escapePipes = (text: string): string => escapeUnescapedPipesWithContext(text, 0);
+
     it('escapes unescaped pipes', () => {
-        expect(escapeUnescapedPipes('a|b')).toBe(String.raw`a\|b`);
-        expect(escapeUnescapedPipes('|')).toBe(String.raw`\|`);
-        expect(escapeUnescapedPipes('a|b|c')).toBe(String.raw`a\|b\|c`);
+        expect(escapePipes('a|b')).toBe(String.raw`a\|b`);
+        expect(escapePipes('|')).toBe(String.raw`\|`);
+        expect(escapePipes('a|b|c')).toBe(String.raw`a\|b\|c`);
     });
 
     it('keeps already-escaped pipes intact', () => {
-        expect(escapeUnescapedPipes(String.raw`a\|b`)).toBe(String.raw`a\|b`);
+        expect(escapePipes(String.raw`a\|b`)).toBe(String.raw`a\|b`);
     });
 
     it('escapes pipes after even backslash runs and preserves them after odd runs', () => {
-        expect(escapeUnescapedPipes(String.raw`a\\|b`)).toBe(String.raw`a\\\|b`);
-        expect(escapeUnescapedPipes(String.raw`a\\\|b`)).toBe(String.raw`a\\\|b`);
+        expect(escapePipes(String.raw`a\\|b`)).toBe(String.raw`a\\\|b`);
+        expect(escapePipes(String.raw`a\\\|b`)).toBe(String.raw`a\\\|b`);
+    });
+
+    it('counts a backslash run the text is preceded by', () => {
+        expect(escapeUnescapedPipesWithContext('|', 1)).toBe('|');
+        expect(escapeUnescapedPipesWithContext('|', 2)).toBe(String.raw`\|`);
     });
 });
 
@@ -126,5 +134,65 @@ describe('rootToLocalOffsets', () => {
     it('matches a stored spelling exactly, so an uppercase break tag stays text', () => {
         expect(displayOffsets('a<BR>b')).toEqual([0, 1, 2, 3, 4, 5, 6]);
         expect(unsanitizeRootText('a<BR>b')).toBe('a<BR>b');
+    });
+});
+
+describe('localToRootOffsets', () => {
+    /** The offsets a plain scan of `localText` would need, character by character. */
+    const storedOffsets = (localText: string): number[] => Array.from(localToRootOffsets(localText));
+
+    it('maps display text one to one where nothing is spelled out', () => {
+        expect(storedOffsets('abc')).toEqual([0, 1, 2, 3]);
+    });
+
+    it('lands every offset in the same place the stored text puts it', () => {
+        const localText = 'a\nb|c';
+
+        // `a<br>b\|c`: the offsets after each rewrite shift by what it spells out.
+        expect(storedOffsets(localText)).toEqual([0, 1, 5, 6, 8, 9]);
+        expect(sanitizeLocalText(localText)).toHaveLength(9);
+    });
+
+    it('puts a caret before a pipe before the backslash that escapes it', () => {
+        // Otherwise the caret would land inside `\|`, where the stored text has no such position.
+        expect(storedOffsets('|')).toEqual([0, 2]);
+    });
+
+    it('leaves a caret between a backslash and the pipe it already escapes where it is', () => {
+        expect(storedOffsets(String.raw`\|`)).toEqual([0, 1, 2]);
+    });
+
+    it('gives the start of a rewritten break tag for offsets inside it', () => {
+        const offsets = localToRootOffsets('<br/>x');
+
+        expect(offsets[1]).toBe(0);
+        expect(offsets[4]).toBe(0);
+        expect(offsets[5]).toBe(4);
+    });
+
+    it('ends one past the stored text, so a range can reach the end of the cell', () => {
+        const localText = 'a\nb';
+
+        expect(localToRootOffsets(localText)[localText.length]).toBe(sanitizeLocalText(localText).length);
+    });
+
+    it('maps the only offset in an empty cell to zero', () => {
+        expect(storedOffsets('')).toEqual([0]);
+    });
+
+    it('treats a CRLF as the one line break it is stored as', () => {
+        expect(storedOffsets('a\r\nb')).toEqual([0, 1, 1, 5, 6]);
+    });
+
+    it('counts emoji as UTF-16 code units on both sides of a rewrite', () => {
+        expect(storedOffsets('\u{1F600}\n\u{1F600}')).toEqual([0, 1, 2, 6, 7, 8]);
+    });
+
+    it('agrees with the round trip about where the end of the cell is', () => {
+        const localText = 'a\nb|c';
+        const rootText = sanitizeLocalText(localText);
+
+        expect(unsanitizeRootText(rootText)).toBe(localText);
+        expect(rootToLocalOffsets(rootText)[localToRootOffsets(localText)[3]]).toBe(3);
     });
 });

--- a/src/contentScript/editorBridge/cellTextCodec.ts
+++ b/src/contentScript/editorBridge/cellTextCodec.ts
@@ -2,9 +2,9 @@ import { Transaction } from '@codemirror/state';
 import {
     convertNewlinesToBr,
     escapeUnescapedPipesWithContext,
+    localToRootOffsets,
     normalizeBrTags,
-    sanitizeLocalText,
-    unsanitizeRootText,
+    rootToLocalOffsets,
 } from '../shared/cellTextNormalization';
 import { clamp } from '../shared/numberUtils';
 
@@ -23,52 +23,27 @@ export interface SanitizeChangesResult {
     changes: SimpleChange[];
 }
 
-const SELECTION_MARK = '\u0000';
-
-function toSpan(selection: LocalSelection): { from: number; to: number; forward: boolean } {
+/**
+ * Reads both endpoints out of an offset map built once for the whole cell.
+ *
+ * Each endpoint is mapped on its own, so a backward selection stays backward, and every value
+ * the map holds is a real offset in the text it maps into - the map never needs the text it
+ * measures to be altered first, so there is nothing to clamp away afterwards.
+ */
+function mapSelection(selection: LocalSelection, offsets: Int32Array): LocalSelection {
+    const lastOffset = offsets.length - 1;
     return {
-        from: Math.min(selection.anchor, selection.head),
-        to: Math.max(selection.anchor, selection.head),
-        forward: selection.anchor <= selection.head,
+        anchor: offsets[clamp(selection.anchor, 0, lastOffset)],
+        head: offsets[clamp(selection.head, 0, lastOffset)],
     };
-}
-
-function clampSelection(selection: LocalSelection, textLength: number): LocalSelection {
-    return {
-        anchor: clamp(selection.anchor, 0, textLength),
-        head: clamp(selection.head, 0, textLength),
-    };
-}
-
-function mapSelectionThroughTransform(
-    selection: LocalSelection,
-    text: string,
-    transform: (value: string) => string
-): LocalSelection {
-    const { from, to, forward } = toSpan(selection);
-    const marked = `${text.slice(0, from)}${SELECTION_MARK}${text.slice(from, to)}${SELECTION_MARK}${text.slice(to)}`;
-    const transformed = transform(marked);
-    const mappedFrom = transformed.indexOf(SELECTION_MARK);
-    const mappedTo = transformed.lastIndexOf(SELECTION_MARK) - 1;
-    if (mappedFrom < 0 || mappedTo < -1) {
-        return { anchor: 0, head: 0 };
-    }
-
-    return forward ? { anchor: mappedFrom, head: mappedTo } : { anchor: mappedTo, head: mappedFrom };
 }
 
 export function toRootSelection(localSelection: LocalSelection, localText: string): LocalSelection {
-    return clampSelection(
-        mapSelectionThroughTransform(localSelection, localText, sanitizeLocalText),
-        sanitizeLocalText(localText).length
-    );
+    return mapSelection(localSelection, localToRootOffsets(localText));
 }
 
 export function toLocalSelection(rootSelection: LocalSelection, rootText: string): LocalSelection {
-    return clampSelection(
-        mapSelectionThroughTransform(rootSelection, rootText, unsanitizeRootText),
-        unsanitizeRootText(rootText).length
-    );
+    return mapSelection(rootSelection, rootToLocalOffsets(rootText));
 }
 
 function countTrailingBackslashesInDoc(doc: Transaction['startState']['doc'], pos: number): number {

--- a/src/contentScript/shared/cellTextNormalization.ts
+++ b/src/contentScript/shared/cellTextNormalization.ts
@@ -1,12 +1,22 @@
-const NON_CANONICAL_BR_PATTERN = /<br\s*\/>/gi;
-const LINE_BREAK_PATTERN = /\r\n|\n|\r/g;
+const NON_CANONICAL_BR_SOURCE = String.raw`<br\s*\/>`;
+const LINE_BREAK_SOURCE = String.raw`\r\n|\n|\r`;
+
+const NON_CANONICAL_BR_PATTERN = new RegExp(NON_CANONICAL_BR_SOURCE, 'gi');
+const LINE_BREAK_PATTERN = new RegExp(LINE_BREAK_SOURCE, 'g');
+
+/** Sticky twins of the patterns above, for matching one run at a known offset. */
+const NON_CANONICAL_BR_AT_PATTERN = new RegExp(NON_CANONICAL_BR_SOURCE, 'iy');
+const LINE_BREAK_AT_PATTERN = new RegExp(LINE_BREAK_SOURCE, 'y');
+
+const CANONICAL_BR = '<br>';
+const ESCAPED_PIPE = String.raw`\|`;
 
 export function normalizeBrTags(text: string): string {
-    return text.replace(NON_CANONICAL_BR_PATTERN, '<br>');
+    return text.replace(NON_CANONICAL_BR_PATTERN, CANONICAL_BR);
 }
 
 export function convertNewlinesToBr(text: string): string {
-    return text.replace(LINE_BREAK_PATTERN, '<br>');
+    return text.replace(LINE_BREAK_PATTERN, CANONICAL_BR);
 }
 
 /** Escapes pipes, accounting for a backslash run immediately before `text`. */
@@ -23,7 +33,7 @@ export function escapeUnescapedPipesWithContext(text: string, precedingBackslash
 
         if (ch === '|') {
             const isAlreadyEscaped = backslashRun % 2 === 1;
-            result += isAlreadyEscaped ? '|' : '\\|';
+            result += isAlreadyEscaped ? '|' : ESCAPED_PIPE;
             backslashRun = 0;
             continue;
         }
@@ -35,19 +45,87 @@ export function escapeUnescapedPipesWithContext(text: string, precedingBackslash
     return result;
 }
 
-/** Escapes pipes in standalone text, where no preceding document context exists. */
-export function escapeUnescapedPipes(text: string): string {
-    return escapeUnescapedPipesWithContext(text, 0);
+/** The text `pattern` spells out at `index`, or null where it matches nothing there. */
+function matchAt(pattern: RegExp, text: string, index: number): string | null {
+    pattern.lastIndex = index;
+    return pattern.exec(text)?.[0] ?? null;
+}
+
+/**
+ * Walks `localText` as the runs it is stored as, handing each run's source length and stored
+ * spelling to `visit`.
+ *
+ * The single source of truth for writing cell text: {@link sanitizeLocalText} produces the text
+ * and {@link localToRootOffsets} the offsets that go with it, from one walk apiece over this
+ * scan, so the two cannot disagree about where a character went. One walk stands in for
+ * normalizing break tags, converting newlines and escaping pipes in sequence, because neither
+ * rewrite emits a newline or a pipe for a later pass to act on, and a `<br>` it writes ends the
+ * backslash run exactly as that tag's four characters would.
+ *
+ * Runs are single UTF-16 code units, so an astral character is walked as its two halves and
+ * offsets stay in the units CodeMirror counts.
+ */
+function scanLocalRuns(localText: string, visit: (index: number, consumed: number, stored: string) => void): void {
+    let backslashRun = 0;
+
+    for (let index = 0; index < localText.length;) {
+        const lineBreak =
+            matchAt(NON_CANONICAL_BR_AT_PATTERN, localText, index) ?? matchAt(LINE_BREAK_AT_PATTERN, localText, index);
+        if (lineBreak !== null) {
+            visit(index, lineBreak.length, CANONICAL_BR);
+            index += lineBreak.length;
+            backslashRun = 0;
+            continue;
+        }
+
+        const char = localText[index];
+        if (char === '|') {
+            visit(index, 1, backslashRun % 2 === 1 ? '|' : ESCAPED_PIPE);
+            backslashRun = 0;
+        } else {
+            visit(index, 1, char);
+            backslashRun = char === '\\' ? backslashRun + 1 : 0;
+        }
+        index++;
+    }
 }
 
 /**
  * Converts arbitrary text into a value that is safe to store in a table cell: line breaks
  * become `<br>` and unescaped pipes are escaped, so neither can break out of the row.
  *
- * `unsanitizeRootText` is the inverse; keep the two escaping conventions in sync.
+ * {@link unsanitizeRootText} is the inverse; the two scans they read from carry the same
+ * escaping conventions, so keep the tables in sync.
  */
 export function sanitizeLocalText(localText: string): string {
-    return escapeUnescapedPipes(convertNewlinesToBr(normalizeBrTags(localText)));
+    let rootText = '';
+
+    scanLocalRuns(localText, (_index, _consumed, stored) => {
+        rootText += stored;
+    });
+
+    return rootText;
+}
+
+/**
+ * Stored offset for every offset in `localText`, including one past its end.
+ *
+ * Offsets inside display text that is stored as something else all give the start of its stored
+ * spelling: a newline is written `<br>`, so a caret cannot be halfway through it, and a caret
+ * before a pipe lands before the backslash that escapes it. Mapping a range reads both ends from
+ * this array, built once for the whole cell.
+ */
+export function localToRootOffsets(localText: string): Int32Array {
+    const offsets = new Int32Array(localText.length + 1);
+    let root = 0;
+
+    scanLocalRuns(localText, (index, consumed, stored) => {
+        offsets.fill(root, index, index + consumed);
+        root += stored.length;
+    });
+
+    offsets[localText.length] = root;
+    return offsets;
 }
 
 /**
@@ -58,8 +136,8 @@ export function sanitizeLocalText(localText: string): string {
  * this table, so the two cannot disagree about where a character went.
  */
 const STORED_TO_DISPLAY: ReadonlyArray<readonly [stored: string, display: string]> = [
-    ['<br>', '\n'],
-    ['\\|', '|'],
+    [CANONICAL_BR, '\n'],
+    [ESCAPED_PIPE, '|'],
 ];
 
 /** The substitution `rootText` spells out at `index`, or null where it spells none. */
@@ -97,9 +175,6 @@ export function unsanitizeRootText(rootText: string): string {
  * Offsets inside a stored spelling all give the start of what it displays as: `<br>` is one
  * newline in the nested editor, so there is nowhere else in the display text for its middle to
  * be. Mapping a range reads both ends from this array, built once for the whole cell.
- * Unlike the selection codec, which inserts markers at both endpoints before transforming
- * the text, this map does not interrupt substitutions. For example, offset 1 in `<br>x`
- * maps to 0 here but to 1 in the codec, where the marker prevents `<br>` from decoding.
  */
 export function rootToLocalOffsets(rootText: string): Int32Array {
     const offsets = new Int32Array(rootText.length + 1);


### PR DESCRIPTION
## Problem

Selection mapping between the main editor and the nested cell editor spliced a NUL marker into the text at each endpoint, ran the sanitize/unsanitize transform over the marked string, then read the endpoints back out of the result.

That mutates the text it is measuring:

- A marker inside `<br>` stops the tag matching, so it never converts.
- A marker between a backslash and a pipe resets the backslash run that decides whether the pipe is already escaped.

The mapped offset could therefore be a position in a string that doesn't exist, with `clampSelection` silently pinning it to the end of the text rather than failing.

Observable effect: a main-editor caret sitting inside a stored `<br>` opened the nested editor with the caret at the **end of the cell** instead of at the line break.

| root text | root offset | local text | before | after |
|---|---|---|---|---|
| `a<br>b` | 3 (mid-`<br>`) | `a\nb` | 3 (end of doc) | 1 (the break) |
| `<br>x` | 2 | `\nx` | 2 | 0 |
| `a\|b` | 1 (mid-escape) | `a\|b` | 1 | 0 |

## Approach

`rootToLocalOffsets` already mapped root → local without touching the text. This adds its mirror, `localToRootOffsets`, and drives both directions off the maps.

`sanitizeLocalText` now shares one scan (`scanLocalRuns`) with its offset map, the same way `unsanitizeRootText` shares one with `rootToLocalOffsets` — so text and offsets can't disagree about where a character went. That single walk stands in for the three sequential passes (break-tag normalize → newline convert → pipe escape), which is sound because neither rewrite emits a newline or pipe for a later pass to act on, and a written `<br>` ends the backslash run exactly as its four characters would.

The marker machinery, the endpoint span juggling, and the post-hoc clamping all go. Selection direction now falls out of mapping each endpoint independently rather than being reconstructed. The only clamping left is a genuine bounds check on the *input* offsets.

`escapeUnescapedPipes` had no callers left in `src/` once `sanitizeLocalText` moved to the scan, so it's removed; its tests call `escapeUnescapedPipesWithContext(text, 0)` directly. (knip wouldn't have flagged it — test files are entry points in the config.)

## Tests

New coverage for the cases that were previously wrong: caret inside `<br>`, caret inside `\|`, a range with both endpoints inside stored spellings, backward-selection preservation, and out-of-range clamping. Plus a `localToRootOffsets` suite covering CRLF, non-canonical `<br/>`, backslash-run parity, empty cells, and astral characters as UTF-16 code units.

No existing test pinned the marker behavior, so nothing needed rewriting to accommodate the swap — all 1129 tests pass.

## Docs

`Nested-Editor-Architecture.md` described selections as "mapped through the sanitize/unsanitize transforms", which was the mechanism being removed. Updated, and the divergence paragraph in the `rootToLocalOffsets` doc comment is deleted since it documented a difference that no longer exists.

## Verification

`npm test` (1129 passed), `npm run lint`, `npm run knip`, `tsc --noEmit` clean over `src/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)