### PR TITLE
perf: improve rendering performance and reliability

### DIFF
--- a/__mocks__/dompurify.ts
+++ b/__mocks__/dompurify.ts
@@ -1,8 +1,17 @@
 /**
- * Jest mock for DOMPurify.
- * Returns HTML unchanged since we're not testing sanitization behavior.
+ * Test double for DOMPurify. Sanitization behaviour is not what these tests cover, so the markup
+ * passes through unchanged; only the shape of the return value matters, and that has to match the
+ * real library so callers can be exercised.
  */
 export default {
     addHook: () => {},
-    sanitize: (html: string) => html,
+    sanitize: (html: string, config?: { RETURN_DOM_FRAGMENT?: boolean }) => {
+        if (!config?.RETURN_DOM_FRAGMENT) {
+            return html;
+        }
+
+        const template = document.createElement('template');
+        template.innerHTML = html;
+        return template.content;
+    },
 };

--- a/docs/Architecture/Markdown-Rendering.md
+++ b/docs/Architecture/Markdown-Rendering.md
@@ -8,9 +8,14 @@ Table cells render Markdown through Joplin's `renderMarkup` command. The decisio
 
 - Content script calls `postMessage({ type: 'renderMarkup', markdown, id })`.
 - Main plugin executes Joplin’s `renderMarkup` and returns HTML.
-- The content script runs `sanitizeHtml()` → `postProcessHtml()` before using the HTML.
+- The content script runs `sanitizeToFragment()` → `postProcessFragment()` before using the result.
 
-The renderer exposes `render(text): Promise<string>` plus cache helpers. It is created during content-script startup and installed through `markdownRenderServiceFacet`, so widgets and runtime code read the service from `view.state` instead of importing module-level mutable state.
+The renderer exposes `render(text): Promise<DocumentFragment>` plus cache helpers. It deals in nodes rather
+than markup: DOMPurify has to parse the HTML anyway, so the pipeline keeps the tree it produces instead of
+serializing it and parsing it again to display it. The cached fragment is never inserted anywhere; `render()`
+and `getCached()` both hand back a `cloneNode(true)` copy, so appending one cell's result cannot empty
+another's. Fragments are inserted with `textContent = ''` plus `appendChild` — `replaceChildren()` is missing
+from the WebView the mobile app uses — which also adopts the nodes out of DOMPurify's document. It is created during content-script startup and installed through `markdownRenderServiceFacet`, so widgets and runtime code read the service from `view.state` instead of importing module-level mutable state.
 
 ### Cache + De-dupe
 
@@ -38,18 +43,15 @@ Cells are rendered as isolated Markdown fragments. Document-scoped reference-sty
 
 ## Sanitization + Post-processing
 
-- Sanitization: `sanitizeHtml()` (`src/contentScript/services/htmlSanitizer.ts`) uses DOMPurify and a tight allowlist:
+- Sanitization: `sanitizeToFragment()` (`src/contentScript/services/htmlSanitizer.ts`) uses DOMPurify with
+  `RETURN_DOM_FRAGMENT` and a tight allowlist:
     - Allows Joplin-specific `data-*` attributes and `joplin-content://`-style URLs (`ALLOW_UNKNOWN_PROTOCOLS`).
     - Allows `<iframe>` but removes all iframes except specific `https://.../embed/...` YouTube sources.
     - Forbids `srcdoc`.
-- Post-processing: `postProcessHtml()` (`src/contentScript/services/htmlPostProcessor.ts`):
+- Post-processing: `postProcessFragment()` (`src/contentScript/services/htmlPostProcessor.ts`) edits those nodes in place:
     - Removes `.joplin-source` and `.resource-icon` elements that don’t render well inside cells.
     - Replaces KaTeX HTML with MathML to avoid duplicate/glitched rendering.
     - Footnotes: Post-processing replaces [^label] text with styled superscript links.
-    - Both passes parse the HTML into a template, which dominates the per-cell cost on the editor's thread.
-      Each is guarded by a substring test for the markers it acts on (`[^`, and the literal class names
-      `joplin-source` / `resource-icon` / `katex`), so a cell needing neither is returned untouched. The
-      markers cannot false-negative; a false positive only costs work that used to be unconditional.
 
 ## Opening Links
 

--- a/docs/Architecture/Markdown-Rendering.md
+++ b/docs/Architecture/Markdown-Rendering.md
@@ -16,7 +16,9 @@ The renderer exposes `render(text): Promise<string>` plus cache helpers. It is c
 
 To avoid excessive rendering requests to the main plugin:
 
-- FIFO cache (`MAX_CACHE_SIZE = 500`) for rendered HTML keyed by the Markdown payload.
+- LRU cache (`MAX_CACHE_SIZE`) for rendered HTML keyed by the Markdown payload. `getCached()` re-inserts on a
+  hit so eviction follows use: scrolling back revisits the most recently viewed cells, which insertion order
+  would evict first.
 - In-flight de-dupe (`pendingRequests`) so identical content only triggers one render request.
 - Skip the render request for cells no markup engine can transform (`mightContainMarkup`).
   The check is an allowlist of inert characters, not a list of markdown markers: Joplin's renderer is a
@@ -44,6 +46,10 @@ Cells are rendered as isolated Markdown fragments. Document-scoped reference-sty
     - Removes `.joplin-source` and `.resource-icon` elements that don’t render well inside cells.
     - Replaces KaTeX HTML with MathML to avoid duplicate/glitched rendering.
     - Footnotes: Post-processing replaces [^label] text with styled superscript links.
+    - Both passes parse the HTML into a template, which dominates the per-cell cost on the editor's thread.
+      Each is guarded by a substring test for the markers it acts on (`[^`, and the literal class names
+      `joplin-source` / `resource-icon` / `katex`), so a cell needing neither is returned untouched. The
+      markers cannot false-negative; a false positive only costs work that used to be unconditional.
 
 ## Opening Links
 

--- a/docs/Architecture/Markdown-Rendering.md
+++ b/docs/Architecture/Markdown-Rendering.md
@@ -18,7 +18,10 @@ To avoid excessive rendering requests to the main plugin:
 
 - FIFO cache (`MAX_CACHE_SIZE = 500`) for rendered HTML keyed by the Markdown payload.
 - In-flight de-dupe (`pendingRequests`) so identical content only triggers one render request.
-- Only request rendering for table cells that likely contain markdown formatting (`containsMarkdown` heuristic).
+- Skip the render request for cells no markup engine can transform (`mightContainMarkup`).
+  The check is an allowlist of inert characters, not a list of markdown markers: Joplin's renderer is a
+  configurable markdown-it stack, so a marker list silently renders raw for any syntax it omits. A false
+  positive costs one cached render request; a false negative shows the user raw markup.
 
 ## Cell Payload Construction
 

--- a/src/contentScript/__tests__/cellContentUtils.test.ts
+++ b/src/contentScript/__tests__/cellContentUtils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { buildRenderableContent, containsMarkdown, escapeLeadingBlockMarkers } from '../shared/cellContentUtils';
+import { buildRenderableContent, escapeLeadingBlockMarkers, mightContainMarkup } from '../shared/cellContentUtils';
 
 describe('escapeLeadingBlockMarkers', () => {
     it('escapes leading heading markers', () => {
@@ -59,34 +59,48 @@ describe('buildRenderableContent', () => {
     });
 });
 
-describe('containsMarkdown', () => {
-    it('detects HTML entities', () => {
-        expect(containsMarkdown('Test &amp; text')).toBe(true);
-        expect(containsMarkdown('Decimal: &#38; hexadecimal: &#x26;')).toBe(true);
+describe('mightContainMarkup', () => {
+    it('detects inline markdown syntax', () => {
+        expect(mightContainMarkup('**bold**')).toBe(true);
+        expect(mightContainMarkup('a `code` span')).toBe(true);
+        expect(mightContainMarkup('[link](https://example.com)')).toBe(true);
+        expect(mightContainMarkup('~~struck~~')).toBe(true);
+    });
+
+    it('detects HTML entities and tags', () => {
+        expect(mightContainMarkup('Test &amp; text')).toBe(true);
+        expect(mightContainMarkup('Decimal: &#38; hexadecimal: &#x26;')).toBe(true);
+        expect(mightContainMarkup('line<br>break')).toBe(true);
     });
 
     it('detects emoji shortcodes', () => {
-        expect(containsMarkdown(':smile:')).toBe(true);
-        expect(containsMarkdown('Status: :white_check_mark:')).toBe(true);
+        expect(mightContainMarkup(':smile:')).toBe(true);
+        expect(mightContainMarkup('Status: :white_check_mark:')).toBe(true);
     });
 
     it('detects superscript and subscript', () => {
-        expect(containsMarkdown('abc ^sup^ and def ~sub~')).toBe(true);
-        expect(containsMarkdown('H~2~O')).toBe(true);
-        expect(containsMarkdown('x^2^')).toBe(true);
+        expect(mightContainMarkup('abc ^sup^ and def ~sub~')).toBe(true);
+        expect(mightContainMarkup('H~2~O')).toBe(true);
     });
 
     it('detects KaTeX inline math', () => {
-        expect(containsMarkdown('$00$')).toBe(true);
-        expect(containsMarkdown('$ZX = Y$')).toBe(true);
+        expect(mightContainMarkup('$00$')).toBe(true);
+        expect(mightContainMarkup('$ZX = Y$')).toBe(true);
     });
 
-    it('does not treat a single dollar sign as markdown math', () => {
-        expect(containsMarkdown('Price is $5')).toBe(false);
+    it('detects typographer syntax that no marker list would catch', () => {
+        expect(mightContainMarkup('He said "hi"')).toBe(true);
+        expect(mightContainMarkup("don't")).toBe(true);
+        expect(mightContainMarkup('wait -- what')).toBe(true);
+        expect(mightContainMarkup('and so on...')).toBe(true);
     });
 
-    it('does not treat incomplete entities or ordinary colons as markdown', () => {
-        expect(containsMarkdown('Fish & chips')).toBe(false);
-        expect(containsMarkdown('Note: plain text')).toBe(false);
+    it('treats plain text as inert', () => {
+        expect(mightContainMarkup('')).toBe(false);
+        expect(mightContainMarkup('Note: plain text')).toBe(false);
+        expect(mightContainMarkup('Price is $5')).toBe(false);
+        expect(mightContainMarkup('Q3 revenue (EMEA), 42%')).toBe(false);
+        expect(mightContainMarkup('Ana Gonzalez-Ruiz')).toBe(false);
+        expect(mightContainMarkup('Größe 12 Ünicode')).toBe(false);
     });
 });

--- a/src/contentScript/__tests__/htmlPostProcessor.test.ts
+++ b/src/contentScript/__tests__/htmlPostProcessor.test.ts
@@ -9,6 +9,21 @@ function parseHtml(html: string): DocumentFragment {
 }
 
 describe('postProcessHtml', () => {
+    test('returns HTML that needs no post-processing without parsing it', () => {
+        // Single-quoted attributes survive only if the HTML was never round-tripped through a
+        // template element, so this shows both passes were skipped rather than run to no effect.
+        const html = "<p class='cell'><strong>bold</strong> and <em>italic</em></p>";
+
+        expect(postProcessHtml(html)).toBe(html);
+    });
+
+    test('still parses HTML carrying markers for either pass', () => {
+        expect(postProcessHtml('<p class=\'cell\'><span class="joplin-source">raw</span>kept</p>')).toBe(
+            '<p class="cell">kept</p>'
+        );
+        expect(postProcessHtml("<p class='cell'>see [^note]</p>")).toContain('footnote');
+    });
+
     test('removes Joplin resource icon spans but keeps placeholder resources', () => {
         const html =
             '<div class="cm-table-cell-content">' +

--- a/src/contentScript/__tests__/htmlPostProcessor.test.ts
+++ b/src/contentScript/__tests__/htmlPostProcessor.test.ts
@@ -1,6 +1,6 @@
 /** @vitest-environment jsdom */
 
-import { postProcessHtml } from '../services/htmlPostProcessor';
+import { postProcessFragment } from '../services/htmlPostProcessor';
 
 function parseHtml(html: string): DocumentFragment {
     const template = document.createElement('template');
@@ -8,22 +8,17 @@ function parseHtml(html: string): DocumentFragment {
     return template.content;
 }
 
-describe('postProcessHtml', () => {
-    test('returns HTML that needs no post-processing without parsing it', () => {
-        // Single-quoted attributes survive only if the HTML was never round-tripped through a
-        // template element, so this shows both passes were skipped rather than run to no effect.
-        const html = "<p class='cell'><strong>bold</strong> and <em>italic</em></p>";
+/** Post-processing works on nodes; these tests read the result back as markup. */
+function postProcessHtml(html: string): string {
+    const fragment = parseHtml(html);
+    postProcessFragment(fragment);
 
-        expect(postProcessHtml(html)).toBe(html);
-    });
+    const container = document.createElement('div');
+    container.appendChild(fragment);
+    return container.innerHTML;
+}
 
-    test('still parses HTML carrying markers for either pass', () => {
-        expect(postProcessHtml('<p class=\'cell\'><span class="joplin-source">raw</span>kept</p>')).toBe(
-            '<p class="cell">kept</p>'
-        );
-        expect(postProcessHtml("<p class='cell'>see [^note]</p>")).toContain('footnote');
-    });
-
+describe('postProcessFragment', () => {
     test('removes Joplin resource icon spans but keeps placeholder resources', () => {
         const html =
             '<div class="cm-table-cell-content">' +

--- a/src/contentScript/__tests__/htmlSanitizer.test.ts
+++ b/src/contentScript/__tests__/htmlSanitizer.test.ts
@@ -1,0 +1,54 @@
+/** @vitest-environment jsdom */
+
+import { describe, expect, it, vi } from 'vitest';
+
+// The suite aliases `dompurify` to a passthrough double, which cannot answer the question this
+// file exists for: the render pipeline now depends on the real library returning nodes rather
+// than markup, and on it still stripping what it always stripped.
+// The path is relative because the alias rewrites anything starting with the bare specifier.
+vi.mock('dompurify', async () => {
+    const actual = (await vi.importActual('../../../node_modules/dompurify/dist/purify.cjs.js')) as {
+        default: unknown;
+    };
+    return { default: actual.default ?? actual };
+});
+
+import { fragmentHtml } from './testUtils';
+
+const { sanitizeToFragment } = await import('../services/htmlSanitizer');
+
+describe('sanitizeToFragment', () => {
+    it('returns nodes rather than markup', () => {
+        const fragment = sanitizeToFragment('<p><strong>ok</strong></p>');
+
+        expect(fragment).toBeInstanceOf(DocumentFragment);
+        expect(fragmentHtml(fragment)).toBe('<p><strong>ok</strong></p>');
+    });
+
+    it('strips scripts and event handlers', () => {
+        const fragment = sanitizeToFragment('<script>alert(1)</script><p onclick="steal()">text</p>');
+
+        const result = fragmentHtml(fragment);
+        expect(result).not.toContain('script');
+        expect(result).not.toContain('onclick');
+        expect(result).toContain('text');
+    });
+
+    it('keeps the Joplin attributes cells rely on', () => {
+        const fragment = sanitizeToFragment('<a data-resource-id="abc" href="joplin-content://x">link</a>');
+
+        const result = fragmentHtml(fragment);
+        expect(result).toContain('data-resource-id="abc"');
+        expect(result).toContain('joplin-content://x');
+    });
+
+    it('drops iframes that are not YouTube embeds', () => {
+        const allowed = fragmentHtml(
+            sanitizeToFragment('<iframe src="https://www.youtube.com/embed/dQw4w9WgXcQ"></iframe>')
+        );
+        const blocked = fragmentHtml(sanitizeToFragment('<iframe src="https://evil.example/embed/abc"></iframe>'));
+
+        expect(allowed).toContain('<iframe');
+        expect(blocked).not.toContain('<iframe');
+    });
+});

--- a/src/contentScript/__tests__/markdownRenderer.test.ts
+++ b/src/contentScript/__tests__/markdownRenderer.test.ts
@@ -3,7 +3,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { RenderMarkupResult } from '../../contentScriptBridge/contentScriptMessages';
 import { createMarkdownRenderer, MAX_CACHE_SIZE, type RenderMarkupFn } from '../services/markdownRenderer';
-import { deferred } from './testUtils';
+import { deferred, fragmentHtml } from './testUtils';
 
 vi.mock('../../logger', () => ({
     logger: {
@@ -14,21 +14,33 @@ vi.mock('../../logger', () => ({
 }));
 
 describe('createMarkdownRenderer', () => {
-    it('sanitizes, post-processes, and caches rendered HTML', async () => {
+    it('sanitizes, post-processes, and caches rendered content', async () => {
         const renderMarkup = vi.fn<RenderMarkupFn>(async (_markdown, id) => ({
             id,
             html: '<p><strong>ok</strong><span class="joplin-source">raw</span></p>',
         }));
         const renderer = createMarkdownRenderer(renderMarkup);
 
-        const first = await renderer.render('**ok**');
-        const second = await renderer.render('**ok**');
+        const first = fragmentHtml(await renderer.render('**ok**'));
+        const second = fragmentHtml(await renderer.render('**ok**'));
 
         expect(first).toContain('<strong>ok</strong>');
         expect(first).not.toContain('joplin-source');
         expect(second).toBe(first);
         expect(renderMarkup).toHaveBeenCalledTimes(1);
-        expect(renderer.getCached('**ok**')).toBe(first);
+        expect(fragmentHtml(renderer.getCached('**ok**')!)).toBe(first);
+    });
+
+    it('hands every caller its own copy, so consuming one leaves the cache intact', async () => {
+        const renderMarkup = vi.fn<RenderMarkupFn>(async (_markdown, id) => ({ id, html: '<p>shared</p>' }));
+        const renderer = createMarkdownRenderer(renderMarkup);
+
+        // Appending a fragment moves its nodes out of it; the cache must not be what was moved.
+        const first = await renderer.render('shared');
+        document.createElement('div').appendChild(first);
+
+        expect(fragmentHtml(await renderer.render('shared'))).toBe('<p>shared</p>');
+        expect(fragmentHtml(renderer.getCached('shared')!)).toBe('<p>shared</p>');
     });
 
     it('de-dupes concurrent identical render requests', async () => {
@@ -40,8 +52,8 @@ describe('createMarkdownRenderer', () => {
         const second = renderer.render('`x`');
         pending.resolve({ id: 'render-1', html: '<p><code>x</code></p>' });
 
-        await expect(first).resolves.toContain('<code>x</code>');
-        await expect(second).resolves.toContain('<code>x</code>');
+        expect(fragmentHtml(await first)).toContain('<code>x</code>');
+        expect(fragmentHtml(await second)).toContain('<code>x</code>');
         expect(renderMarkup).toHaveBeenCalledTimes(1);
     });
 
@@ -57,10 +69,10 @@ describe('createMarkdownRenderer', () => {
         }
 
         // Read the oldest entry, then overflow the cache by one.
-        expect(renderer.getCached('value-0')).toContain('value-0');
+        expect(fragmentHtml(renderer.getCached('value-0')!)).toContain('value-0');
         await renderer.render('overflow');
 
-        expect(renderer.getCached('value-0')).toContain('value-0');
+        expect(fragmentHtml(renderer.getCached('value-0')!)).toContain('value-0');
         expect(renderer.getCached('value-1')).toBeUndefined();
     });
 
@@ -77,19 +89,19 @@ describe('createMarkdownRenderer', () => {
         }
 
         expect(renderer.getCached('value-0')).toBeUndefined();
-        expect(renderer.getCached('value-1')).toContain('value-1');
-        expect(renderer.getCached(`value-${overflow - 1}`)).toContain(`value-${overflow - 1}`);
+        expect(fragmentHtml(renderer.getCached('value-1')!)).toContain('value-1');
+        expect(fragmentHtml(renderer.getCached(`value-${overflow - 1}`)!)).toContain(`value-${overflow - 1}`);
     });
 
-    it('returns escaped fallback HTML when rendering rejects or returns an error', async () => {
+    it('returns unrendered text when rendering rejects or returns an error', async () => {
         const renderMarkup = vi
             .fn<RenderMarkupFn>()
             .mockRejectedValueOnce(new Error('boom'))
             .mockResolvedValueOnce({ id: 'render-2', html: '<img src=x onerror=alert(1)>', error: true });
         const renderer = createMarkdownRenderer(renderMarkup);
 
-        await expect(renderer.render('<b>unsafe</b>')).resolves.toBe('&lt;b&gt;unsafe&lt;/b&gt;');
-        await expect(renderer.render('<i>bad</i>')).resolves.toBe('&lt;i&gt;bad&lt;/i&gt;');
+        expect(fragmentHtml(await renderer.render('<b>unsafe</b>'))).toBe('&lt;b&gt;unsafe&lt;/b&gt;');
+        expect(fragmentHtml(await renderer.render('<i>bad</i>'))).toBe('&lt;i&gt;bad&lt;/i&gt;');
     });
 
     it('clear removes cached entries and pending request state', async () => {
@@ -108,9 +120,9 @@ describe('createMarkdownRenderer', () => {
         first.resolve({ id: 'render-1', html: '<p>stale</p>' });
         second.resolve({ id: 'render-2', html: '<p>current</p>' });
 
-        await expect(staleRender).resolves.toContain('stale');
-        await expect(currentRender).resolves.toContain('current');
+        expect(fragmentHtml(await staleRender)).toContain('stale');
+        expect(fragmentHtml(await currentRender)).toContain('current');
         expect(renderMarkup).toHaveBeenCalledTimes(2);
-        expect(renderer.getCached('**x**')).toContain('current');
+        expect(fragmentHtml(renderer.getCached('**x**')!)).toContain('current');
     });
 });

--- a/src/contentScript/__tests__/markdownRenderer.test.ts
+++ b/src/contentScript/__tests__/markdownRenderer.test.ts
@@ -2,7 +2,7 @@
 
 import { describe, expect, it, vi } from 'vitest';
 import type { RenderMarkupResult } from '../../contentScriptBridge/contentScriptMessages';
-import { createMarkdownRenderer, type RenderMarkupFn } from '../services/markdownRenderer';
+import { createMarkdownRenderer, MAX_CACHE_SIZE, type RenderMarkupFn } from '../services/markdownRenderer';
 import { deferred } from './testUtils';
 
 vi.mock('../../logger', () => ({
@@ -45,6 +45,25 @@ describe('createMarkdownRenderer', () => {
         expect(renderMarkup).toHaveBeenCalledTimes(1);
     });
 
+    it('evicts the least recently used entry, not the oldest', async () => {
+        const renderMarkup = vi.fn<RenderMarkupFn>(async (markdown, id) => ({
+            id,
+            html: `<p>${markdown}</p>`,
+        }));
+        const renderer = createMarkdownRenderer(renderMarkup);
+
+        for (let index = 0; index < MAX_CACHE_SIZE; index++) {
+            await renderer.render(`value-${index}`);
+        }
+
+        // Read the oldest entry, then overflow the cache by one.
+        expect(renderer.getCached('value-0')).toContain('value-0');
+        await renderer.render('overflow');
+
+        expect(renderer.getCached('value-0')).toContain('value-0');
+        expect(renderer.getCached('value-1')).toBeUndefined();
+    });
+
     it('evicts the oldest cache entry after the cache limit', async () => {
         const renderMarkup = vi.fn<RenderMarkupFn>(async (markdown, id) => ({
             id,
@@ -52,13 +71,14 @@ describe('createMarkdownRenderer', () => {
         }));
         const renderer = createMarkdownRenderer(renderMarkup);
 
-        for (let index = 0; index < 501; index++) {
+        const overflow = MAX_CACHE_SIZE + 1;
+        for (let index = 0; index < overflow; index++) {
             await renderer.render(`value-${index}`);
         }
 
         expect(renderer.getCached('value-0')).toBeUndefined();
         expect(renderer.getCached('value-1')).toContain('value-1');
-        expect(renderer.getCached('value-500')).toContain('value-500');
+        expect(renderer.getCached(`value-${overflow - 1}`)).toContain(`value-${overflow - 1}`);
     });
 
     it('returns escaped fallback HTML when rendering rejects or returns an error', async () => {

--- a/src/contentScript/__tests__/mouseCellDragSelection.test.ts
+++ b/src/contentScript/__tests__/mouseCellDragSelection.test.ts
@@ -19,7 +19,7 @@ import { markdownRenderServiceFacet } from '../services/markdownRenderer';
 import { createMarkdownState } from './testMarkdownState';
 import { getResolvedActiveCell, resolvedActiveCellField } from '../tableRuntime/activeCell/resolvedActiveCell';
 import { CLASS_CELL_ACTIVE, CLASS_CELL_EDITOR, CLASS_CELL_CONTENT } from '../shared/tableDomClasses';
-import { parseCellRangesFixture } from './testUtils';
+import { htmlFragment, parseCellRangesFixture } from './testUtils';
 
 const GRID_DOC = ['| H1 | H2 |', '| --- | --- |', '| a1 | a2 |'].join('\n');
 
@@ -92,7 +92,7 @@ function mountGestureView(doc = GRID_DOC): MountedGestureView {
         state: createMarkdownState(doc, [
             markdownRenderServiceFacet.of({
                 getCached: vi.fn(() => undefined),
-                render: vi.fn(async () => ''),
+                render: vi.fn(async () => htmlFragment('')),
                 clear: vi.fn(),
             }),
             activeCellField,

--- a/src/contentScript/__tests__/nestedEditorController.test.ts
+++ b/src/contentScript/__tests__/nestedEditorController.test.ts
@@ -27,6 +27,7 @@ import { markdownRenderServiceFacet, type MarkdownRenderService } from '../servi
 import { resolvedActiveCellField } from '../tableRuntime/activeCell/resolvedActiveCell';
 import { activeCellField, getActiveCell, setActiveCellEffect, type ActiveCell } from '../tableState/activeCellState';
 import { CLASS_CELL_ACTIVE, CLASS_CELL_CONTENT, CLASS_CELL_EDITOR } from '../shared/tableDomClasses';
+import { htmlFragment } from './testUtils';
 
 // jsdom does not implement Range measurement, which CodeMirror's selection layer calls.
 if (!Range.prototype.getClientRects) {
@@ -50,7 +51,7 @@ function createHarness(params: {
 }) {
     const renderer: MarkdownRenderService = {
         getCached: vi.fn(() => undefined),
-        render: vi.fn(async () => ''),
+        render: vi.fn(async () => htmlFragment('')),
         clear: vi.fn(),
     };
 
@@ -323,7 +324,7 @@ describe('nestedEditorController close', () => {
     it('tears down the nested editor and renders the cell markdown back into the content wrapper', () => {
         const doc = ['| H1 |', '| --- |', '| **bold** |'].join('\n');
         const { view, cellElement, renderer } = createHarness({ doc, activeCell: bodyCell() });
-        vi.mocked(renderer.getCached).mockReturnValue('<p><strong>bold</strong></p>');
+        vi.mocked(renderer.getCached).mockReturnValue(htmlFragment('<p><strong>bold</strong></p>'));
 
         openNestedEditor({ mainView: view, cellElement, featureSettings: FEATURE_SETTINGS });
         closeNestedEditor(view);

--- a/src/contentScript/__tests__/nestedEditorControllerRenderer.test.ts
+++ b/src/contentScript/__tests__/nestedEditorControllerRenderer.test.ts
@@ -6,6 +6,7 @@ import { markdownRenderServiceFacet, type MarkdownRenderService } from '../servi
 import { activeCellField, setActiveCellEffect } from '../tableState/activeCellState';
 import { closeNestedEditor, nestedEditorPlugin, openNestedEditor } from '../nestedEditor/nestedEditorController';
 import { createMarkdownState } from './testMarkdownState';
+import { htmlFragment } from './testUtils';
 
 describe('nestedEditorController markdown rendering', () => {
     afterEach(() => {
@@ -15,8 +16,8 @@ describe('nestedEditorController markdown rendering', () => {
     it('uses the markdown renderer supplied by the editor state facet when closing', () => {
         const tableText = ['| H1 |', '| --- |', '| **body** |'].join('\n');
         const renderer: MarkdownRenderService = {
-            getCached: vi.fn(() => '<p><strong>cached</strong></p>'),
-            render: vi.fn(async () => ''),
+            getCached: vi.fn(() => htmlFragment('<p><strong>cached</strong></p>')),
+            render: vi.fn(async () => htmlFragment('')),
             clear: vi.fn(),
         };
         let state = createMarkdownState(tableText, [
@@ -71,7 +72,7 @@ describe('nestedEditorController markdown rendering', () => {
         const doc = `${intro}${insertedTableWithSpacing}${middle}${tableText}`;
         const renderer: MarkdownRenderService = {
             getCached: vi.fn(() => undefined),
-            render: vi.fn(async () => ''),
+            render: vi.fn(async () => htmlFragment('')),
             clear: vi.fn(),
         };
         let state = createMarkdownState(doc, [

--- a/src/contentScript/__tests__/renderCellInto.test.ts
+++ b/src/contentScript/__tests__/renderCellInto.test.ts
@@ -93,6 +93,35 @@ describe('renderCellMarkdownInto', () => {
         target.remove();
     });
 
+    it.each(['https://example.com', 'http://example.com/path', 'mailto:person@example.com', 'HTTPS://example.com'])(
+        'renders a bare link into an anchor: %s',
+        async (markdown) => {
+            const rendered = deferred<DocumentFragment>();
+            const renderer = createRenderer({ render: vi.fn(() => rendered.promise) });
+            const target = createTarget();
+
+            try {
+                renderCellMarkdownInto(target, markdown, renderer);
+
+                expect(renderer.render).toHaveBeenCalledWith(markdown);
+                expect(target.textContent).toBe(markdown);
+
+                const fragment = document.createDocumentFragment();
+                const anchor = document.createElement('a');
+                anchor.setAttribute('href', markdown);
+                anchor.textContent = markdown;
+                fragment.appendChild(anchor);
+                rendered.resolve(fragment);
+                await rendered.promise;
+                await Promise.resolve();
+
+                expect(target.querySelector('a')?.getAttribute('href')).toBe(markdown);
+            } finally {
+                target.remove();
+            }
+        }
+    );
+
     it('requests a render for HTML entities and emoji shortcodes', () => {
         const renderer = createRenderer();
         const target = createTarget();

--- a/src/contentScript/__tests__/renderCellInto.test.ts
+++ b/src/contentScript/__tests__/renderCellInto.test.ts
@@ -3,12 +3,12 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { MarkdownRenderService } from '../services/markdownRenderer';
 import { renderCellMarkdownInto } from '../services/renderCellInto';
-import { deferred } from './testUtils';
+import { deferred, htmlFragment } from './testUtils';
 
 function createRenderer(overrides: Partial<MarkdownRenderService> = {}): MarkdownRenderService {
     return {
         getCached: vi.fn(() => undefined),
-        render: vi.fn(() => Promise.resolve('')),
+        render: vi.fn(() => Promise.resolve(htmlFragment(''))),
         clear: vi.fn(),
         ...overrides,
     };
@@ -24,7 +24,7 @@ function createTarget(connected = true): HTMLElement {
 
 describe('renderCellMarkdownInto', () => {
     it('writes cached HTML immediately without requesting a render', () => {
-        const renderer = createRenderer({ getCached: vi.fn(() => '<p><strong>cached</strong></p>') });
+        const renderer = createRenderer({ getCached: vi.fn(() => htmlFragment('<p><strong>cached</strong></p>')) });
         const target = createTarget();
 
         renderCellMarkdownInto(target, '**cached**', renderer);
@@ -35,7 +35,7 @@ describe('renderCellMarkdownInto', () => {
     });
 
     it('normalizes cell text before cache lookup and rendering', () => {
-        const rendered = deferred<string>();
+        const rendered = deferred<DocumentFragment>();
         const renderer = createRenderer({ render: vi.fn(() => rendered.promise) });
         const target = createTarget();
 
@@ -45,12 +45,12 @@ describe('renderCellMarkdownInto', () => {
 
         expect(renderer.getCached).toHaveBeenCalledWith('\\- a | b');
         expect(renderer.render).toHaveBeenCalledWith('\\- a | b');
-        rendered.resolve('<p>- a | b</p>');
+        rendered.resolve(htmlFragment('<p>- a | b</p>'));
         target.remove();
     });
 
     it('shows escaped text first, then swaps in the async result', async () => {
-        const rendered = deferred<string>();
+        const rendered = deferred<DocumentFragment>();
         const renderer = createRenderer({ render: vi.fn(() => rendered.promise) });
         const target = createTarget();
 
@@ -59,7 +59,7 @@ describe('renderCellMarkdownInto', () => {
         // <br> survives as a real line break; other markup is escaped.
         expect(target.innerHTML).toBe('a &lt;b&gt; **c**<br>d');
 
-        rendered.resolve('<p>rendered</p>');
+        rendered.resolve(htmlFragment('<p>rendered</p>'));
         await rendered.promise;
         await Promise.resolve();
 
@@ -68,14 +68,14 @@ describe('renderCellMarkdownInto', () => {
     });
 
     it('skips the async swap when the target left the DOM', async () => {
-        const rendered = deferred<string>();
+        const rendered = deferred<DocumentFragment>();
         const renderer = createRenderer({ render: vi.fn(() => rendered.promise) });
         const target = createTarget();
 
         renderCellMarkdownInto(target, '**body**', renderer);
         target.remove();
 
-        rendered.resolve('<p>rendered</p>');
+        rendered.resolve(htmlFragment('<p>rendered</p>'));
         await rendered.promise;
         await Promise.resolve();
 

--- a/src/contentScript/__tests__/selectionClassSync.test.ts
+++ b/src/contentScript/__tests__/selectionClassSync.test.ts
@@ -16,6 +16,7 @@ import { CLASS_CELL_SELECTED, CLASS_TABLE_WIDGET_SELECTED, getWidgetSelector } f
 import { tableDecorationField } from '../tableWidget/tableDecorationField';
 import { wholeTableSelectionVisuals } from '../tableWidget/wholeTableSelectionVisuals';
 import { createMarkdownState } from './testMarkdownState';
+import { htmlFragment } from './testUtils';
 
 class ResizeObserverMock {
     observe = vi.fn();
@@ -47,7 +48,7 @@ function mountView(): EditorView {
         state: createMarkdownState(DOC, [
             markdownRenderServiceFacet.of({
                 getCached: vi.fn(() => undefined),
-                render: vi.fn(async () => ''),
+                render: vi.fn(async () => htmlFragment('')),
                 clear: vi.fn(),
             }),
             cellSelectionField,

--- a/src/contentScript/__tests__/tableWidgetCoordsAt.test.ts
+++ b/src/contentScript/__tests__/tableWidgetCoordsAt.test.ts
@@ -13,7 +13,7 @@ import { activeCellField, setActiveCellEffect } from '../tableState/activeCellSt
 import { resolvedActiveCellField } from '../tableRuntime/activeCell/resolvedActiveCell';
 import { TableWidget } from '../tableWidget/TableWidget';
 import { tableDecorationField } from '../tableWidget/tableDecorationField';
-import { parseCellRangesFixture } from './testUtils';
+import { htmlFragment, parseCellRangesFixture } from './testUtils';
 
 class ResizeObserverMock {
     observe = vi.fn();
@@ -31,7 +31,7 @@ function createRealView(doc: string): { parent: HTMLElement; view: EditorView } 
             markdown({ extensions: [GFM] }),
             markdownRenderServiceFacet.of({
                 getCached: vi.fn(() => undefined),
-                render: vi.fn(async () => ''),
+                render: vi.fn(async () => htmlFragment('')),
                 clear: vi.fn(),
             }),
             activeCellField,
@@ -66,8 +66,8 @@ describe('TableWidget coordsAt', () => {
         const state = EditorState.create({
             extensions: [
                 markdownRenderServiceFacet.of({
-                    getCached: vi.fn(() => ''),
-                    render: vi.fn(async () => ''),
+                    getCached: vi.fn(() => htmlFragment('')),
+                    render: vi.fn(async () => htmlFragment('')),
                     clear: vi.fn(),
                 }),
             ],
@@ -281,8 +281,8 @@ describe('TableWidget coordsAt', () => {
         const state = EditorState.create({
             extensions: [
                 markdownRenderServiceFacet.of({
-                    getCached: vi.fn(() => ''),
-                    render: vi.fn(async () => ''),
+                    getCached: vi.fn(() => htmlFragment('')),
+                    render: vi.fn(async () => htmlFragment('')),
                     clear: vi.fn(),
                 }),
             ],

--- a/src/contentScript/__tests__/tableWidgetDomReuse.test.ts
+++ b/src/contentScript/__tests__/tableWidgetDomReuse.test.ts
@@ -12,7 +12,7 @@ import { TableWidget } from '../tableWidget/TableWidget';
 import { getWidgetSelector } from '../tableWidget/domHelpers';
 import { tableDecorationField } from '../tableWidget/tableDecorationField';
 import { tableHeightCache } from '../tableWidget/tableHeightCache';
-import { parseCellRangesFixture } from './testUtils';
+import { htmlFragment, parseCellRangesFixture } from './testUtils';
 
 const observerCallbacks: Array<() => void> = [];
 
@@ -64,8 +64,8 @@ function createView(): EditorView {
     const state = EditorState.create({
         extensions: [
             markdownRenderServiceFacet.of({
-                getCached: vi.fn(() => ''),
-                render: vi.fn(async () => ''),
+                getCached: vi.fn(() => htmlFragment('')),
+                render: vi.fn(async () => htmlFragment('')),
                 clear: vi.fn(),
             }),
         ],
@@ -93,7 +93,7 @@ function createRealView(doc: string): { parent: HTMLElement; view: EditorView } 
             markdown({ extensions: [GFM] }),
             markdownRenderServiceFacet.of({
                 getCached: vi.fn(() => undefined),
-                render: vi.fn(async () => ''),
+                render: vi.fn(async () => htmlFragment('')),
                 clear: vi.fn(),
             }),
             tableDecorationField,

--- a/src/contentScript/__tests__/tableWidgetMarkdownRenderer.test.ts
+++ b/src/contentScript/__tests__/tableWidgetMarkdownRenderer.test.ts
@@ -6,7 +6,7 @@ import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
 import { markdownRenderServiceFacet, type MarkdownRenderService } from '../services/markdownRenderer';
 import { MarkdownTable } from '../tableModel/MarkdownTable';
 import { TableWidget } from '../tableWidget/TableWidget';
-import { deferred, parseCellRangesFixture } from './testUtils';
+import { deferred, htmlFragment, parseCellRangesFixture } from './testUtils';
 
 class ResizeObserverMock {
     observe = vi.fn();
@@ -23,7 +23,7 @@ describe('TableWidget markdown rendering', () => {
     });
 
     it('uses the markdown renderer supplied by the editor state facet', async () => {
-        const rendered = deferred<string>();
+        const rendered = deferred<DocumentFragment>();
         const tableText = ['| H1 |', '| --- |', '| **body** |'].join('\n');
         const table = MarkdownTable.parse(tableText);
         const cellRanges = parseCellRangesFixture(tableText);
@@ -48,7 +48,7 @@ describe('TableWidget markdown rendering', () => {
         const widget = new TableWidget(table, cellRanges, tableText, 0);
         const dom = widget.toDOM(view);
         document.body.appendChild(dom);
-        rendered.resolve('<p><strong>rendered</strong></p>');
+        rendered.resolve(htmlFragment('<p><strong>rendered</strong></p>'));
         await rendered.promise;
         // The widget attaches its DOM update in a .then() on the same promise.
         // Let that chained microtask run before asserting the rendered HTML.

--- a/src/contentScript/__tests__/testUtils.ts
+++ b/src/contentScript/__tests__/testUtils.ts
@@ -33,3 +33,17 @@ export function deferred<T>(): {
 
     return { promise, resolve, reject };
 }
+
+/** Parses markup into a fragment, matching what the markdown renderer hands its callers. */
+export function htmlFragment(html: string): DocumentFragment {
+    const template = document.createElement('template');
+    template.innerHTML = html;
+    return template.content;
+}
+
+/** Reads a fragment back as markup, so assertions can stay string-based. */
+export function fragmentHtml(fragment: DocumentFragment): string {
+    const container = document.createElement('div');
+    container.appendChild(fragment);
+    return container.innerHTML;
+}

--- a/src/contentScript/services/domFragment.ts
+++ b/src/contentScript/services/domFragment.ts
@@ -1,0 +1,38 @@
+/** The only line-break tag cell content carries, matching what the table serializer writes. */
+const LINE_BREAK_TAG = '<br>';
+
+/**
+ * A fragment of literal text with `<br>` kept as a real line break.
+ *
+ * Used for content that has not been rendered: the plain-text placeholder shown while a render is
+ * in flight, and the fallback when one fails. Every part becomes a text node, so markup in the
+ * source is displayed rather than interpreted, without parsing HTML to achieve it.
+ */
+export function textFragmentPreservingBr(text: string, doc: Document = document): DocumentFragment {
+    const fragment = doc.createDocumentFragment();
+    const parts = text.split(LINE_BREAK_TAG);
+
+    for (let index = 0; index < parts.length; index++) {
+        if (index > 0) {
+            fragment.appendChild(doc.createElement('br'));
+        }
+
+        const part = parts[index];
+        if (part) {
+            fragment.appendChild(doc.createTextNode(part));
+        }
+    }
+
+    return fragment;
+}
+
+/**
+ * Replaces an element's children with a fragment's nodes.
+ *
+ * `replaceChildren()` is deliberately avoided: it is missing from the WebView the mobile app uses.
+ * Appending adopts nodes that belong to another document, which is how sanitized fragments arrive.
+ */
+export function replaceContent(target: HTMLElement, fragment: DocumentFragment): void {
+    target.textContent = '';
+    target.appendChild(fragment);
+}

--- a/src/contentScript/services/htmlPostProcessor.ts
+++ b/src/contentScript/services/htmlPostProcessor.ts
@@ -1,11 +1,29 @@
 import { buildFootnoteHref } from '../shared/footnoteAnchor';
 
 /**
+ * Markers for the elements `cleanupAndOptimizeHtml` rewrites. Each is the literal class name a
+ * selector matches, so markup without them cannot match either.
+ */
+const CLEANUP_MARKERS = ['joplin-source', 'resource-icon', 'katex'] as const;
+
+/** Opening of a footnote reference (`[^label]`); any match of the pattern contains it. */
+const FOOTNOTE_REF_OPENING = '[^';
+
+/**
  * Post-process rendered HTML to fix Joplin-specific display issues.
  * Includes KaTeX optimization and footnote reference conversion.
+ *
+ * Each pass parses the HTML into a template, which is the bulk of the per-cell cost on the
+ * editor's own thread. Most cells contain nothing either pass acts on, so both are guarded by a
+ * substring test: the markers below cannot false-negative, and a false positive only costs the
+ * work that used to be unconditional.
  */
 export function postProcessHtml(html: string): string {
-    return cleanupAndOptimizeHtml(convertFootnoteRefs(html));
+    const withFootnotes = html.includes(FOOTNOTE_REF_OPENING) ? convertFootnoteRefs(html) : html;
+
+    return CLEANUP_MARKERS.some((marker) => withFootnotes.includes(marker))
+        ? cleanupAndOptimizeHtml(withFootnotes)
+        : withFootnotes;
 }
 
 /**

--- a/src/contentScript/services/htmlPostProcessor.ts
+++ b/src/contentScript/services/htmlPostProcessor.ts
@@ -1,53 +1,36 @@
 import { buildFootnoteHref } from '../shared/footnoteAnchor';
 
 /**
- * Markers for the elements `cleanupAndOptimizeHtml` rewrites. Each is the literal class name a
- * selector matches, so markup without them cannot match either.
- */
-const CLEANUP_MARKERS = ['joplin-source', 'resource-icon', 'katex'] as const;
-
-/** Opening of a footnote reference (`[^label]`); any match of the pattern contains it. */
-const FOOTNOTE_REF_OPENING = '[^';
-
-/**
- * Post-process rendered HTML to fix Joplin-specific display issues.
+ * Post-process rendered content to fix Joplin-specific display issues.
  * Includes KaTeX optimization and footnote reference conversion.
  *
- * Each pass parses the HTML into a template, which is the bulk of the per-cell cost on the
- * editor's own thread. Most cells contain nothing either pass acts on, so both are guarded by a
- * substring test: the markers below cannot false-negative, and a false positive only costs the
- * work that used to be unconditional.
+ * Operates on the sanitized nodes in place. The string form used to parse the markup twice, once
+ * per pass, which was the bulk of the per-cell cost on the editor's own thread; querying a tree
+ * that already exists costs nothing by comparison, so neither pass needs a guard.
  */
-export function postProcessHtml(html: string): string {
-    const withFootnotes = html.includes(FOOTNOTE_REF_OPENING) ? convertFootnoteRefs(html) : html;
-
-    return CLEANUP_MARKERS.some((marker) => withFootnotes.includes(marker))
-        ? cleanupAndOptimizeHtml(withFootnotes)
-        : withFootnotes;
+export function postProcessFragment(fragment: DocumentFragment): void {
+    convertFootnoteRefs(fragment);
+    cleanupAndOptimize(fragment);
 }
 
 /**
- * Post-process rendered HTML to fix Joplin-specific display issues.
  * - Removes .joplin-source elements (raw text)
  * - Removes broken resource icon spans
  * - Extracts inner MathML from KaTeX structures to avoid duplicate/glitched rendering
  * - Removes <annotation> tags which might contain raw TeX
  */
-function cleanupAndOptimizeHtml(html: string): string {
-    const template = document.createElement('template');
-    template.innerHTML = html;
-
+function cleanupAndOptimize(fragment: DocumentFragment): void {
     // Remove Joplin source blocks
-    template.content.querySelectorAll('.joplin-source').forEach((el) => el.remove());
+    fragment.querySelectorAll('.joplin-source').forEach((el) => el.remove());
 
     // Joplin resource links sometimes render an icon span that depends on editor-global
     // font/icon CSS (e.g. Font Awesome). Inside table cells this can degrade into a
     // broken glyph (often a question mark). Remove the icon element but keep the
     // resource link text and any placeholders.
-    template.content.querySelectorAll('.resource-icon').forEach((el) => el.remove());
+    fragment.querySelectorAll('.resource-icon').forEach((el) => el.remove());
 
     // Optimize KaTeX: Replace HTML/CSS representation with clean MathML
-    template.content.querySelectorAll('.katex').forEach((katexElement) => {
+    fragment.querySelectorAll('.katex').forEach((katexElement) => {
         const math = katexElement.querySelector('math');
         if (math) {
             // Remove annotations (often contains raw TeX)
@@ -70,8 +53,6 @@ function cleanupAndOptimizeHtml(html: string): string {
             }
         }
     });
-
-    return template.innerHTML;
 }
 
 /**
@@ -91,21 +72,15 @@ const LITERAL_TEXT_TAGS = new Set(['CODE', 'PRE']);
  * Markdown-it-footnote auto-numbers by first appearance, which breaks when
  * rendering cells independently. Instead, we convert any remaining [^label]
  * text into styled superscript links that preserve the original label.
+ *
+ * Recurses over text nodes, skipping code/pre elements.
  */
-function convertFootnoteRefs(html: string): string {
-    const template = document.createElement('template');
-    template.innerHTML = html;
-    processFootnotesInNode(template.content);
-    return template.innerHTML;
-}
-
-/** Recursively process text nodes, skipping code/pre elements */
-function processFootnotesInNode(node: Node): void {
+function convertFootnoteRefs(node: Node): void {
     for (const child of Array.from(node.childNodes)) {
         if (child.nodeType === Node.ELEMENT_NODE) {
             const el = child as Element;
             if (!LITERAL_TEXT_TAGS.has(el.tagName)) {
-                processFootnotesInNode(el);
+                convertFootnoteRefs(el);
             }
             continue;
         }

--- a/src/contentScript/services/htmlSanitizer.ts
+++ b/src/contentScript/services/htmlSanitizer.ts
@@ -46,9 +46,14 @@ DOMPurify.addHook('afterSanitizeElements', (node) => {
  * - Allows specific attributes needed for internal links/images/videos
  * - Allows unknown protocols for joplin-content://
  * - Relies on DOMPurify's safe defaults to block dangerous tags/attributes
+ *
+ * Returns nodes rather than a string: DOMPurify has to parse the markup either way, so handing
+ * back the tree it already built saves serializing it and parsing it again to display it. The
+ * nodes belong to DOMPurify's own document until something appends them, which adopts them.
  */
-export function sanitizeHtml(html: string): string {
+export function sanitizeToFragment(html: string): DocumentFragment {
     return DOMPurify.sanitize(html, {
+        RETURN_DOM_FRAGMENT: true,
         ALLOW_UNKNOWN_PROTOCOLS: true,
         ADD_TAGS: [IFRAME_TAG],
         ADD_ATTR: [

--- a/src/contentScript/services/markdownRenderer.ts
+++ b/src/contentScript/services/markdownRenderer.ts
@@ -23,8 +23,8 @@ export interface MarkdownRenderService {
 }
 
 // Cache for rendered markdown to avoid redundant rendering.
-// Limited to MAX_CACHE_SIZE entries with FIFO eviction to prevent unbounded memory growth.
-const MAX_CACHE_SIZE = 500;
+// Limited to MAX_CACHE_SIZE entries with LRU eviction to prevent unbounded memory growth.
+export const MAX_CACHE_SIZE = 500;
 
 /**
  * Default renderer used only when the extension wiring has not installed a real service.
@@ -62,7 +62,17 @@ class DefaultMarkdownRenderer implements MarkdownRenderService {
     constructor(private readonly renderMarkup: RenderMarkupFn) {}
 
     getCached(text: string): string | undefined {
-        return this.renderCache.get(text);
+        const html = this.renderCache.get(text);
+        if (html === undefined) {
+            return undefined;
+        }
+
+        // Re-insert so eviction follows use rather than insertion. Scrolling back through a
+        // document revisits the cells viewed most recently, which are the ones insertion order
+        // evicts first.
+        this.renderCache.delete(text);
+        this.renderCache.set(text, html);
+        return html;
     }
 
     clear(): void {
@@ -74,7 +84,8 @@ class DefaultMarkdownRenderer implements MarkdownRenderService {
 
     private setCacheEntry(key: string, value: string): void {
         if (this.renderCache.size >= MAX_CACHE_SIZE) {
-            // Delete oldest entry (Map maintains insertion order)
+            // Delete the least recently used entry (Map maintains insertion order, and
+            // getCached() re-inserts on a hit)
             const firstKey = this.renderCache.keys().next().value;
             if (firstKey !== undefined) {
                 this.renderCache.delete(firstKey);
@@ -95,7 +106,7 @@ class DefaultMarkdownRenderer implements MarkdownRenderService {
      * Returns cached result if available, otherwise sends request to main plugin.
      */
     async render(markdown: string): Promise<string> {
-        const cached = this.renderCache.get(markdown);
+        const cached = this.getCached(markdown);
         if (cached !== undefined) {
             return cached;
         }

--- a/src/contentScript/services/markdownRenderer.ts
+++ b/src/contentScript/services/markdownRenderer.ts
@@ -1,9 +1,9 @@
 import { Facet } from '@codemirror/state';
 import { logger } from '../../logger';
 import type { RenderMarkupResult } from '../../contentScriptBridge/contentScriptMessages';
-import { escapeHtmlPreservingBr } from '../shared/cellContentUtils';
-import { sanitizeHtml } from './htmlSanitizer';
-import { postProcessHtml } from './htmlPostProcessor';
+import { textFragmentPreservingBr } from './domFragment';
+import { sanitizeToFragment } from './htmlSanitizer';
+import { postProcessFragment } from './htmlPostProcessor';
 
 /**
  * Markdown rendering service that communicates with the main plugin
@@ -17,8 +17,12 @@ export type RenderMarkupFn = (markdown: string, id: string) => Promise<RenderMar
  * Allows decoupling widgets/editors from the specific caching/rendering implementation.
  */
 export interface MarkdownRenderService {
-    render(text: string): Promise<string>;
-    getCached(text: string): string | undefined;
+    /**
+     * Both accessors hand back a fresh copy: the cached fragment is never inserted anywhere, so
+     * appending one caller's result cannot empty another cell's content.
+     */
+    render(text: string): Promise<DocumentFragment>;
+    getCached(text: string): DocumentFragment | undefined;
     clear(): void;
 }
 
@@ -32,8 +36,8 @@ export const MAX_CACHE_SIZE = 500;
  */
 const fallbackMarkdownRenderer: MarkdownRenderService = {
     render(text) {
-        logger.warn('Markdown renderer service missing, returning escaped markdown');
-        return Promise.resolve(escapeHtmlPreservingBr(text));
+        logger.warn('Markdown renderer service missing, returning unrendered markdown');
+        return Promise.resolve(textFragmentPreservingBr(text));
     },
     getCached() {
         return undefined;
@@ -54,16 +58,17 @@ export const markdownRenderServiceFacet = Facet.define<MarkdownRenderService, Ma
  * Default renderer implementation using instance-local cache and render transport.
  */
 class DefaultMarkdownRenderer implements MarkdownRenderService {
-    private readonly renderCache = new Map<string, string>();
-    private readonly pendingRequests = new Map<string, { promise?: Promise<string> }>();
+    /** Canonical fragments, never handed out directly. `cloneNode` copies are what callers get. */
+    private readonly renderCache = new Map<string, DocumentFragment>();
+    private readonly pendingRequests = new Map<string, { promise?: Promise<DocumentFragment> }>();
     private requestIdCounter = 0;
     private generation = 0;
 
     constructor(private readonly renderMarkup: RenderMarkupFn) {}
 
-    getCached(text: string): string | undefined {
-        const html = this.renderCache.get(text);
-        if (html === undefined) {
+    getCached(text: string): DocumentFragment | undefined {
+        const cached = this.renderCache.get(text);
+        if (cached === undefined) {
             return undefined;
         }
 
@@ -71,8 +76,8 @@ class DefaultMarkdownRenderer implements MarkdownRenderService {
         // document revisits the cells viewed most recently, which are the ones insertion order
         // evicts first.
         this.renderCache.delete(text);
-        this.renderCache.set(text, html);
-        return html;
+        this.renderCache.set(text, cached);
+        return cloneFragment(cached);
     }
 
     clear(): void {
@@ -82,7 +87,7 @@ class DefaultMarkdownRenderer implements MarkdownRenderService {
         this.generation++;
     }
 
-    private setCacheEntry(key: string, value: string): void {
+    private setCacheEntry(key: string, value: DocumentFragment): void {
         if (this.renderCache.size >= MAX_CACHE_SIZE) {
             // Delete the least recently used entry (Map maintains insertion order, and
             // getCached() re-inserts on a hit)
@@ -102,15 +107,22 @@ class DefaultMarkdownRenderer implements MarkdownRenderService {
     }
 
     /**
-     * Render markdown to HTML asynchronously.
-     * Returns cached result if available, otherwise sends request to main plugin.
+     * Render markdown asynchronously.
+     * Returns cached content if available, otherwise sends a request to the main plugin.
      */
-    async render(markdown: string): Promise<string> {
+    async render(markdown: string): Promise<DocumentFragment> {
         const cached = this.getCached(markdown);
         if (cached !== undefined) {
             return cached;
         }
 
+        // Concurrent callers share the request but not its result, so each takes its own copy of
+        // the fragment the request resolves to.
+        return cloneFragment(await this.renderCanonical(markdown));
+    }
+
+    /** The shared, never-inserted fragment for a payload: the cache entry, or the pending one. */
+    private renderCanonical(markdown: string): Promise<DocumentFragment> {
         const pending = this.pendingRequests.get(markdown);
         if (pending?.promise) {
             return pending.promise;
@@ -118,24 +130,25 @@ class DefaultMarkdownRenderer implements MarkdownRenderService {
 
         const id = this.generateRequestId();
         const generation = this.generation;
-        const pendingRequest: { promise?: Promise<string> } = {};
+        const pendingRequest: { promise?: Promise<DocumentFragment> } = {};
         const promise = (async () => {
             try {
                 const result = await this.renderMarkup(markdown, id);
 
                 if (result && !result.error && typeof result.html === 'string') {
                     // Clean pipeline: sanitize -> post-process
-                    const html = postProcessHtml(sanitizeHtml(result.html));
+                    const fragment = sanitizeToFragment(result.html);
+                    postProcessFragment(fragment);
                     if (this.generation === generation && this.pendingRequests.get(markdown) === pendingRequest) {
-                        this.setCacheEntry(markdown, html);
+                        this.setCacheEntry(markdown, fragment);
                     }
-                    return html;
+                    return fragment;
                 }
 
-                return escapeHtmlPreservingBr(markdown);
+                return textFragmentPreservingBr(markdown);
             } catch (error) {
                 logger.error('Failed to render markdown:', error);
-                return escapeHtmlPreservingBr(markdown);
+                return textFragmentPreservingBr(markdown);
             } finally {
                 if (this.pendingRequests.get(markdown) === pendingRequest) {
                     this.pendingRequests.delete(markdown);
@@ -147,6 +160,11 @@ class DefaultMarkdownRenderer implements MarkdownRenderService {
         this.pendingRequests.set(markdown, pendingRequest);
         return promise;
     }
+}
+
+/** Copies a cached fragment so the caller owns nodes it can append without emptying the cache. */
+function cloneFragment(fragment: DocumentFragment): DocumentFragment {
+    return fragment.cloneNode(true) as DocumentFragment;
 }
 
 export function createMarkdownRenderer(renderMarkup: RenderMarkupFn): MarkdownRenderService {

--- a/src/contentScript/services/renderCellInto.ts
+++ b/src/contentScript/services/renderCellInto.ts
@@ -1,4 +1,4 @@
-import { buildRenderableContent, containsMarkdown, escapeHtmlPreservingBr } from '../shared/cellContentUtils';
+import { buildRenderableContent, escapeHtmlPreservingBr, mightContainMarkup } from '../shared/cellContentUtils';
 import type { MarkdownRenderService } from './markdownRenderer';
 import { logger } from '../../logger';
 
@@ -25,8 +25,8 @@ export function renderCellMarkdownInto(target: HTMLElement, markdown: string, re
     // Show content with <br> rendered as line breaks while async render runs
     target.innerHTML = escapeHtmlPreservingBr(displayText);
 
-    // Check if content likely contains markdown (optimization)
-    if (!containsMarkdown(cacheKey)) {
+    // Plain text can't be transformed by the renderer, so skip the round-trip (optimization)
+    if (!mightContainMarkup(cacheKey)) {
         return;
     }
 

--- a/src/contentScript/services/renderCellInto.ts
+++ b/src/contentScript/services/renderCellInto.ts
@@ -1,4 +1,5 @@
-import { buildRenderableContent, escapeHtmlPreservingBr, mightContainMarkup } from '../shared/cellContentUtils';
+import { buildRenderableContent, mightContainMarkup } from '../shared/cellContentUtils';
+import { replaceContent, textFragmentPreservingBr } from './domFragment';
 import type { MarkdownRenderService } from './markdownRenderer';
 import { logger } from '../../logger';
 
@@ -7,23 +8,23 @@ import { logger } from '../../logger';
  *
  * Shared by the table widget (which renders into a freshly created content wrapper) and the
  * nested editor controller (which renders back into the wrapper it took over on activation),
- * so both paths stay identical: cached HTML is written synchronously, and a cache miss shows
- * escaped text first and swaps in the rendered HTML when it arrives.
+ * so both paths stay identical: cached content is written synchronously, and a cache miss shows
+ * plain text first and swaps in the rendered content when it arrives.
  *
  * The caller owns the target element; this function only writes its content.
  */
 export function renderCellMarkdownInto(target: HTMLElement, markdown: string, renderer: MarkdownRenderService): void {
     const { displayText, cacheKey } = buildRenderableContent(markdown);
 
-    // Check if we have cached rendered HTML for the normalized cell content
+    // Check if we have cached rendered content for the normalized cell content
     const cached = renderer.getCached(cacheKey);
     if (cached !== undefined) {
-        target.innerHTML = cached;
+        replaceContent(target, cached);
         return;
     }
 
     // Show content with <br> rendered as line breaks while async render runs
-    target.innerHTML = escapeHtmlPreservingBr(displayText);
+    replaceContent(target, textFragmentPreservingBr(displayText, target.ownerDocument));
 
     // Plain text can't be transformed by the renderer, so skip the round-trip (optimization)
     if (!mightContainMarkup(cacheKey)) {
@@ -33,11 +34,11 @@ export function renderCellMarkdownInto(target: HTMLElement, markdown: string, re
     // Request async rendering and update when ready
     void renderer
         .render(cacheKey)
-        .then((html) => {
+        .then((fragment) => {
             // Only update if the target is still in the DOM.
             // Note: Height re-measurement is handled automatically by ResizeObserver.
             if (target.isConnected) {
-                target.innerHTML = html;
+                replaceContent(target, fragment);
             }
         })
         .catch((error) => {

--- a/src/contentScript/shared/cellContentUtils.ts
+++ b/src/contentScript/shared/cellContentUtils.ts
@@ -100,6 +100,9 @@ const PAIRED_ACTIVATORS = ['$', ':'] as const;
  */
 const REPEATED_ACTIVATOR_PATTERN = /([.-])\1/;
 
+/** Bare links such as `https://example.com` and `mailto:person@example.com` need linkification. */
+const BARE_LINK_PATTERN = /https?:\/\/|mailto:/i;
+
 function hasPairedActivator(text: string): boolean {
     return PAIRED_ACTIVATORS.some((char) => text.indexOf(char) !== text.lastIndexOf(char));
 }
@@ -112,5 +115,10 @@ function hasPairedActivator(text: string): boolean {
  * negative shows the user raw markup that Joplin's viewer would have rendered.
  */
 export function mightContainMarkup(text: string): boolean {
-    return !INERT_CHARACTERS_PATTERN.test(text) || hasPairedActivator(text) || REPEATED_ACTIVATOR_PATTERN.test(text);
+    return (
+        !INERT_CHARACTERS_PATTERN.test(text) ||
+        hasPairedActivator(text) ||
+        REPEATED_ACTIVATOR_PATTERN.test(text) ||
+        BARE_LINK_PATTERN.test(text)
+    );
 }

--- a/src/contentScript/shared/cellContentUtils.ts
+++ b/src/contentScript/shared/cellContentUtils.ts
@@ -91,41 +91,39 @@ export function escapeHtmlPreservingBr(text: string): string {
 }
 
 /**
- * Substrings that suggest inline markdown formatting.
- * Checked as an order-independent disjunction, so each entry must not be
- * subsumed by a shorter one (e.g. '**' would be dead next to '*').
+ * Characters that cannot activate markup on their own.
+ *
+ * This is an allowlist by design: Joplin's renderer is a configurable stack of markdown-it
+ * plugins, so enumerating active syntax is unmaintainable (every plugin Joplin adds would
+ * silently render raw in cells). Anything outside this set forces a render request instead.
+ *
+ * Deliberately excluded: quotes (`'` / `"`), because a single one is active under the
+ * typographer setting, and `&`, because it opens HTML entities.
  */
-const MARKDOWN_MARKERS = [
-    '*', // bold / italic
-    '_', // bold / italic
-    '`', // code
-    '[', // links and images
-    '~', // strikethrough / subscript
-    '^', // superscript
-    '<', // HTML tags
-    '==', // highlights
-    '++', // insert
-    '\\', // escaped text
-    'mailto:', // mailto links
-    'http', // bare links
-] as const;
-
-/** HTML named/numeric entities and Joplin emoji shortcodes (for example, `&amp;` and `:smile:`). */
-const HTML_ENTITY_PATTERN = /&(?:#\d+|#x[\da-f]+|[a-z][\da-z]+);/i;
-const EMOJI_SHORTCODE_PATTERN = /:[a-z\d_+-]+:/i;
+const INERT_CHARACTERS_PATTERN = /^[\p{L}\p{N}\p{M}\s.,;:!?()/@#%$-]*$/u;
 
 /**
- * Quick check if content likely contains markdown formatting
- * Avoids unnecessary render requests for plain text
+ * Characters inert in isolation but active when they recur: `$math$`, `:emoji:`.
  */
-export function containsMarkdown(text: string): boolean {
-    // KaTeX needs a delimiter pair ($...$ / $$...$$), so a lone '$' shouldn't trigger a render.
-    const hasMathDelimiterPair = text.includes('$') && text.indexOf('$') !== text.lastIndexOf('$');
+const PAIRED_ACTIVATORS = ['$', ':'] as const;
 
-    return (
-        MARKDOWN_MARKERS.some((marker) => text.includes(marker)) ||
-        hasMathDelimiterPair ||
-        HTML_ENTITY_PATTERN.test(text) ||
-        EMOJI_SHORTCODE_PATTERN.test(text)
-    );
+/**
+ * Characters inert in isolation but active when repeated adjacently, under the
+ * typographer setting: `...` (ellipsis), `--` (en dash).
+ */
+const REPEATED_ACTIVATOR_PATTERN = /([.-])\1/;
+
+function hasPairedActivator(text: string): boolean {
+    return PAIRED_ACTIVATORS.some((char) => text.indexOf(char) !== text.lastIndexOf(char));
+}
+
+/**
+ * Quick check for content that no markup engine can transform.
+ * Lets plain-text cells skip the async render round-trip; everything else renders.
+ *
+ * Errs toward rendering: a false positive costs one cached render request, while a false
+ * negative shows the user raw markup that Joplin's viewer would have rendered.
+ */
+export function mightContainMarkup(text: string): boolean {
+    return !INERT_CHARACTERS_PATTERN.test(text) || hasPairedActivator(text) || REPEATED_ACTIVATOR_PATTERN.test(text);
 }

--- a/src/contentScript/shared/cellContentUtils.ts
+++ b/src/contentScript/shared/cellContentUtils.ts
@@ -78,19 +78,6 @@ export function buildRenderableContent(cellText: string): RenderableContent {
 }
 
 /**
- * Escapes HTML entities but preserves <br> tags as actual line breaks.
- * Used as a fallback when the render cache misses, so that multi-line
- * content doesn't flash raw <br> text while the async renderer runs.
- */
-export function escapeHtmlPreservingBr(text: string): string {
-    return text
-        .replace(/&/g, '&amp;')
-        .replace(/</g, '&lt;')
-        .replace(/>/g, '&gt;')
-        .replace(/&lt;br&gt;/g, '<br>');
-}
-
-/**
  * Characters that cannot activate markup on their own.
  *
  * This is an allowlist by design: Joplin's renderer is a configurable stack of markdown-it


### PR DESCRIPTION
- Replace containsMarkdown with a more forgiving check that still allows plain text cells to skip rendering in most cases, but is less likely to prevent rendering cells that contain formatting that joplin's renderMarkup would render.

- Optimize the render cache to use LRU eviction and reduce unnecessary post-processing. Maintain rendered cells as nodes to eliminate redundant parsing.