### PR TITLE
feat: pair explicitly closed inline HTML tags in rendered selections

### DIFF
--- a/src/contentScript/__tests__/clickCursorPlacement.test.ts
+++ b/src/contentScript/__tests__/clickCursorPlacement.test.ts
@@ -432,6 +432,7 @@ describe('syntax-aware click placement', () => {
         ['one<br>[hello](url "hello")', 'one\nhello', 6, 'one\n[he|llo](url "hello")'],
         ['**raw**', '**raw**', 4, '**ra|w**'],
         ['a ==mark== b', 'a mark b', 4, 'a ==ma|rk== b'],
+        ['a <ins>test text</ins> b', 'a test text b', 4, 'a <ins>te|st text</ins> b'],
         ['a ++ins++ b', 'a ins b', 4, 'a ++in|s++ b'],
         ['==mark== and `code`', 'mark and code', 11, '==mark== and `co|de`'],
     ])('maps %s through visible source spans', (source, renderedText, renderedOffset, expected) => {
@@ -564,6 +565,69 @@ describe('rendered range mapping', () => {
         expect(rangePlacement(cellDoc('a ++ins++ b'), cell, { renderedText: 'a ins b', anchor: 0, head: 5 })).toBe(
             '[a ++ins++] b'
         );
+    });
+
+    it('closes an HTML element whose opening tag the range already holds', () => {
+        expect(
+            rangePlacement(cellDoc('a <ins>test text</ins> b'), cell, {
+                renderedText: 'a test text b',
+                anchor: 0,
+                head: 11,
+            })
+        ).toBe('[a <ins>test text</ins>] b');
+    });
+
+    it('opens an HTML element whose closing tag the range already holds', () => {
+        expect(
+            rangePlacement(cellDoc('a <ins>test text</ins> b'), cell, {
+                renderedText: 'a test text b',
+                anchor: 2,
+                head: 13,
+            })
+        ).toBe('a [<ins>test text</ins> b]');
+    });
+
+    it('pairs tags by name through markup opened inside them and never closed', () => {
+        expect(
+            rangePlacement(cellDoc('a <ins>x<span>y</ins> b'), cell, {
+                renderedText: 'a xy b',
+                anchor: 0,
+                head: 4,
+            })
+        ).toBe('[a <ins>x<span>y</ins>] b');
+    });
+
+    it('closes the inner of two elements sharing a tag name, leaving the outer alone', () => {
+        expect(
+            rangePlacement(cellDoc('<span>a<span>b</span>c</span>'), cell, {
+                renderedText: 'abc',
+                anchor: 0,
+                head: 2,
+            })
+        ).toBe('<span>[a<span>b</span>]c</span>');
+    });
+
+    it('leaves a tag the cell never closes outside a range that stops beside it', () => {
+        // Nothing pairs the void tag inwards, so the range keeps the text it covered.
+        expect(rangePlacement(cellDoc('a<img src="x.png">b'), cell, { renderedText: 'ab', anchor: 0, head: 1 })).toBe(
+            '[a]<img src="x.png">b'
+        );
+    });
+
+    it('leaves a self-closing tag owning itself', () => {
+        expect(rangePlacement(cellDoc('a<hr/>b'), cell, { renderedText: 'ab', anchor: 0, head: 1 })).toBe('[a]<hr/>b');
+    });
+
+    it('leaves a stray closing tag owning itself', () => {
+        expect(rangePlacement(cellDoc('a</ins>b'), cell, { renderedText: 'ab', anchor: 0, head: 1 })).toBe(
+            '[a]</ins>b'
+        );
+    });
+
+    it('pairs tags whose case differs between the two ends', () => {
+        expect(
+            rangePlacement(cellDoc('a <INS>test</ins> b'), cell, { renderedText: 'a test b', anchor: 0, head: 6 })
+        ).toBe('[a <INS>test</ins>] b');
     });
 
     it('pairs markers through the alignment fallback', () => {

--- a/src/contentScript/__tests__/clickCursorPlacement.test.ts
+++ b/src/contentScript/__tests__/clickCursorPlacement.test.ts
@@ -624,6 +624,38 @@ describe('rendered range mapping', () => {
         );
     });
 
+    it('keeps an underscored tag name whole rather than pairing a near miss', () => {
+        // The grammar's tag name runs to the `_`, so `<foo_bar>` and `</foo_baz>` are not a pair.
+        expect(
+            rangePlacement(cellDoc('a <foo_bar>test</foo_baz> b'), cell, {
+                renderedText: 'a test b',
+                anchor: 0,
+                head: 6,
+            })
+        ).toBe('[a <foo_bar>test]</foo_baz> b');
+    });
+
+    it('pairs a tag whose name holds an underscore', () => {
+        expect(
+            rangePlacement(cellDoc('a <foo_bar>test</foo_bar> b'), cell, {
+                renderedText: 'a test b',
+                anchor: 0,
+                head: 6,
+            })
+        ).toBe('[a <foo_bar>test</foo_bar>] b');
+    });
+
+    it('leaves a tag that closes itself across whitespace owning itself', () => {
+        // The grammar accepts `/ >` as self-closing, so it has no partner to pair with.
+        expect(
+            rangePlacement(cellDoc('a <x-tag/ >test</x-tag> b'), cell, {
+                renderedText: 'a test b',
+                anchor: 0,
+                head: 6,
+            })
+        ).toBe('[a <x-tag/ >test]</x-tag> b');
+    });
+
     it('pairs tags whose case differs between the two ends', () => {
         expect(
             rangePlacement(cellDoc('a <INS>test</ins> b'), cell, { renderedText: 'a test b', anchor: 0, head: 6 })

--- a/src/contentScript/tableRuntime/interaction/cellTextProjection.ts
+++ b/src/contentScript/tableRuntime/interaction/cellTextProjection.ts
@@ -16,10 +16,11 @@ export interface CellTextProjection {
 /**
  * A run of hidden source, with the range of the construct it belongs to.
  *
- * A paired marker - the `**` of a strong span, the `](url)` of a link - is a span whose owner
- * reaches beyond it to its partner at the other end. Syntax hidden whole, such as an entity or
- * an HTML tag, owns exactly itself and so has no partner; {@link balanceSyntaxMarkers} tells the
- * two apart by that.  All offsets are in the nested editor's decoded text.
+ * A paired marker - the `**` of a strong span, the `](url)` of a link, the `<ins>` of an
+ * explicitly closed HTML element - is a span whose owner reaches beyond it to its partner at the
+ * other end. Syntax hidden whole, such as an entity or an unmatched tag, owns exactly itself and
+ * so has no partner; {@link balanceSyntaxMarkers} tells the two apart by that. All offsets are in
+ * the nested editor's decoded text.
  */
 export interface HiddenSyntaxSpan {
     from: number;
@@ -50,9 +51,9 @@ function markerOwner(node: SyntaxNodeRef): SyntaxNodeRef | undefined {
     return MARK_NODES.has(node.name) ? (node.node.parent ?? undefined) : undefined;
 }
 
+/** Syntax hidden whole. `HTMLTag` is absent: tags are collected first, then paired by name. */
 const HIDDEN_NODES = new Set([
     'Image',
-    'HTMLTag',
     'Comment',
     'ProcessingInstruction',
     'EmphasisMark',
@@ -64,6 +65,68 @@ const HIDDEN_NODES = new Set([
     // Transformed entities are handled by alignment, never by matching their spelling.
     'Entity',
 ]);
+
+/** `<`, an optional `/`, then the tag name; anything else is markup this pairing does not model. */
+const HTML_TAG_NAME = /^<(\/?)([a-zA-Z][a-zA-Z0-9-]*)/;
+
+/** A tag that closes itself carries no partner, whatever its name. */
+const SELF_CLOSING_TAG = /\/>$/;
+
+/** An HTML tag's source range, with the name pairing matches on. */
+interface HtmlTagRef {
+    from: number;
+    to: number;
+    /** Absent for a self-closing tag and for markup the tag pattern does not recognise. */
+    name?: string;
+    closing: boolean;
+}
+
+/** Reads the name and role of a tag, which the tree provides as one opaque `HTMLTag` node. */
+function readHtmlTag(source: string, from: number, to: number): HtmlTagRef {
+    const match = HTML_TAG_NAME.exec(source);
+    const closing = match?.[1] === '/';
+    if (!match || (!closing && SELF_CLOSING_TAG.test(source))) {
+        return { from, to, closing: false };
+    }
+    return { from, to, name: match[2].toLowerCase(), closing };
+}
+
+/**
+ * Owners for tags explicitly closed in the cell, keyed by the tag's own start offset.
+ *
+ * Only source pairs count: a `<span>` with no `</span>`, a void `<img>`, a stray `</ins>` all stay
+ * unpaired and so own themselves, exactly as every HTML tag did before. HTML's implicit closing and
+ * error recovery are deliberately not reproduced - a construct that never closes in the source has
+ * no second marker a range could be missing. Tags left open inside a pair are dropped when it
+ * closes, so `<ins>a<span>b</ins>` still pairs the `<ins>`.
+ */
+function pairHtmlTags(tags: readonly HtmlTagRef[]): Map<number, SourceSpan> {
+    const owners = new Map<number, SourceSpan>();
+    const open: HtmlTagRef[] = [];
+
+    for (const tag of tags) {
+        if (tag.name === undefined) {
+            continue;
+        }
+        if (!tag.closing) {
+            open.push(tag);
+            continue;
+        }
+        let index = open.length - 1;
+        while (index >= 0 && open[index].name !== tag.name) {
+            index--;
+        }
+        if (index < 0) {
+            continue;
+        }
+        const owner: SourceSpan = { from: open[index].from, to: tag.to };
+        owners.set(open[index].from, owner);
+        owners.set(tag.from, owner);
+        open.length = index;
+    }
+
+    return owners;
+}
 
 /**
  * Projects inline syntax from the main editor into visible text. Link destinations and
@@ -93,6 +156,9 @@ export function projectCellText(
         hiddenSpans.push({ ...span, ownerFrom: ownerSpan.from, ownerTo: ownerSpan.to });
     };
 
+    // Tags are held back: an opening tag's owner is only known once its partner is reached.
+    const htmlTags: HtmlTagRef[] = [];
+
     syntaxTree(state).iterate({
         from: cell.editableFrom,
         to: cell.editableTo,
@@ -113,15 +179,25 @@ export function projectCellText(
                 }
                 return false;
             }
-            if (HIDDEN_NODES.has(node.name)) {
+            if (node.name === 'HTMLTag') {
+                const source = state.doc.sliceString(node.from, node.to);
                 // Stored line breaks become real newlines in the nested editor.
-                if (node.name !== 'HTMLTag' || state.doc.sliceString(node.from, node.to) !== '<br>') {
-                    exclude(node.from, node.to, markerOwner(node));
+                if (source !== '<br>') {
+                    htmlTags.push(readHtmlTag(source, node.from, node.to));
                 }
+                return false;
+            }
+            if (HIDDEN_NODES.has(node.name)) {
+                exclude(node.from, node.to, markerOwner(node));
                 return false;
             }
         },
     });
+
+    const htmlTagOwners = pairHtmlTags(htmlTags);
+    for (const tag of htmlTags) {
+        exclude(tag.from, tag.to, htmlTagOwners.get(tag.from));
+    }
 
     let text = '';
     const offsets: number[] = [];
@@ -142,7 +218,8 @@ export function projectCellText(
  * closing `**` of `foo and **bold**` already holds the opening `**`, and selecting that alone
  * gives the nested editor Markdown that no longer parses. So an end grows past trailing syntax
  * only when the matching leading syntax is already inside the range, and likewise at the start.
- * Syntax with no partner - an entity, an HTML tag, an image - owns itself and is never drawn in.
+ * Syntax with no partner - an entity, an image, a tag the cell never closes - owns itself and is
+ * never drawn in.
  * The loops repeat because constructs nest: `***both***` closes twice over.
  */
 export function balanceSyntaxMarkers(span: SourceSpan, hiddenSpans: readonly HiddenSyntaxSpan[]): SourceSpan {

--- a/src/contentScript/tableRuntime/interaction/cellTextProjection.ts
+++ b/src/contentScript/tableRuntime/interaction/cellTextProjection.ts
@@ -66,11 +66,23 @@ const HIDDEN_NODES = new Set([
     'Entity',
 ]);
 
-/** `<`, an optional `/`, then the tag name; anything else is markup this pairing does not model. */
-const HTML_TAG_NAME = /^<(\/?)([a-zA-Z][a-zA-Z0-9-]*)/;
+/**
+ * `<`, an optional `/`, then the tag name, matching the name and spacing the Markdown grammar
+ * itself accepts (`[a-zA-Z][\w-]*`, with optional whitespace after the `<` or the `/`). Names are
+ * read the way the tag was hidden, so `<foo_bar>` cannot be truncated into a false match for
+ * `</foo_baz>`. Anything else - a doctype, CDATA - fails to match and owns itself.
+ */
+const HTML_TAG_NAME = /^<(\/)?\s*([a-zA-Z][\w-]*)/;
 
-/** A tag that closes itself carries no partner, whatever its name. */
-const SELF_CLOSING_TAG = /\/>$/;
+/**
+ * A tag that closes itself carries no partner, whatever its name. The grammar allows whitespace
+ * between the `/` and the `>`, so `<x-tag/ >` is self-closing too.
+ *
+ * An unquoted attribute value ending in a slash - `<a href=x/>` - trips this as well, where the
+ * grammar reads the slash as part of the value. That leaves the tag unpaired, which is the
+ * behaviour every tag had before pairing existed; telling the two apart needs attribute parsing.
+ */
+const SELF_CLOSING_TAG = /\/\s*>$/;
 
 /** An HTML tag's source range, with the name pairing matches on. */
 interface HtmlTagRef {
@@ -84,7 +96,7 @@ interface HtmlTagRef {
 /** Reads the name and role of a tag, which the tree provides as one opaque `HTMLTag` node. */
 function readHtmlTag(source: string, from: number, to: number): HtmlTagRef {
     const match = HTML_TAG_NAME.exec(source);
-    const closing = match?.[1] === '/';
+    const closing = match?.[1] !== undefined;
     if (!match || (!closing && SELF_CLOSING_TAG.test(source))) {
         return { from, to, closing: false };
     }
@@ -102,22 +114,32 @@ function readHtmlTag(source: string, from: number, to: number): HtmlTagRef {
  */
 function pairHtmlTags(tags: readonly HtmlTagRef[]): Map<number, SourceSpan> {
     const owners = new Map<number, SourceSpan>();
-    const open: HtmlTagRef[] = [];
+    const open: { from: number; name: string }[] = [];
+    // How many of each name the stack holds, so a closer with no opener costs no search at all.
+    // Without it a cell of unmatched closing tags walks the whole stack for each one.
+    const openCounts = new Map<string, number>();
 
     for (const tag of tags) {
-        if (tag.name === undefined) {
+        const name = tag.name;
+        if (name === undefined) {
             continue;
         }
         if (!tag.closing) {
-            open.push(tag);
+            open.push({ from: tag.from, name });
+            openCounts.set(name, (openCounts.get(name) ?? 0) + 1);
             continue;
         }
+        if (!openCounts.get(name)) {
+            continue;
+        }
+        // The count guarantees a match, and every entry the search passes is dropped with it,
+        // so pairing a whole cell stays linear in the number of tags it holds.
         let index = open.length - 1;
-        while (index >= 0 && open[index].name !== tag.name) {
+        while (open[index].name !== name) {
             index--;
         }
-        if (index < 0) {
-            continue;
+        for (let i = index; i < open.length; i++) {
+            openCounts.set(open[i].name, (openCounts.get(open[i].name) ?? 0) - 1);
         }
         const owner: SourceSpan = { from: open[index].from, to: tag.to };
         owners.set(open[index].from, owner);


### PR DESCRIPTION
Ensure that selections for text formatted with basic inline html tags (e.g. `<ins>text</ins>`) behave the same as inline markdown (e.g. a selection partially spanning `some text <ins>some more text</ins>` includes the closing `</ins>` tag)