### PR TITLE
fix: drop stale cell renders that resolve after a newer one

### DIFF
--- a/src/contentScript/__tests__/renderCellInto.test.ts
+++ b/src/contentScript/__tests__/renderCellInto.test.ts
@@ -80,6 +80,60 @@ describe('renderCellMarkdownInto', () => {
         expect(target.innerHTML).toBe('**body**');
     });
 
+    it('ignores an async result that a later render superseded', async () => {
+        const stale = deferred<DocumentFragment>();
+        const fresh = deferred<DocumentFragment>();
+        const renderer = createRenderer({
+            render: vi.fn().mockReturnValueOnce(stale.promise).mockReturnValueOnce(fresh.promise),
+        });
+        const target = createTarget();
+
+        renderCellMarkdownInto(target, '**stale**', renderer);
+        renderCellMarkdownInto(target, '**fresh**', renderer);
+
+        fresh.resolve(htmlFragment('<p>fresh</p>'));
+        stale.resolve(htmlFragment('<p>stale</p>'));
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(target.innerHTML).toBe('<p>fresh</p>');
+        target.remove();
+    });
+
+    it('ignores an async result superseded by a cache hit', async () => {
+        const stale = deferred<DocumentFragment>();
+        const renderer = createRenderer({ render: vi.fn(() => stale.promise) });
+        const target = createTarget();
+
+        renderCellMarkdownInto(target, '**stale**', renderer);
+
+        renderer.getCached = vi.fn(() => htmlFragment('<p>cached</p>'));
+        renderCellMarkdownInto(target, '**cached**', renderer);
+
+        stale.resolve(htmlFragment('<p>stale</p>'));
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(target.innerHTML).toBe('<p>cached</p>');
+        target.remove();
+    });
+
+    it('ignores an async result superseded by a plain-text render', async () => {
+        const stale = deferred<DocumentFragment>();
+        const renderer = createRenderer({ render: vi.fn(() => stale.promise) });
+        const target = createTarget();
+
+        renderCellMarkdownInto(target, '**stale**', renderer);
+        renderCellMarkdownInto(target, 'plain text', renderer);
+
+        stale.resolve(htmlFragment('<p>stale</p>'));
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(target.innerHTML).toBe('plain text');
+        target.remove();
+    });
+
     it('does not request a render for plain text', () => {
         const renderer = createRenderer();
         const target = createTarget();

--- a/src/contentScript/services/renderCellInto.ts
+++ b/src/contentScript/services/renderCellInto.ts
@@ -4,6 +4,23 @@ import type { MarkdownRenderService } from './markdownRenderer';
 import { logger } from '../../logger';
 
 /**
+ * The newest render request each target has seen.
+ *
+ * A target outlives any single request and is written by more than one caller: the table widget
+ * renders into a cell's content wrapper, and the nested editor renders into that same wrapper when
+ * it closes. Without this, a slow earlier render resolves last and paints stale content over the
+ * newer result.
+ */
+const renderGeneration = new WeakMap<HTMLElement, number>();
+
+/** Claims the target for a new request, invalidating any render still in flight for it. */
+function claimGeneration(target: HTMLElement): number {
+    const generation = (renderGeneration.get(target) ?? 0) + 1;
+    renderGeneration.set(target, generation);
+    return generation;
+}
+
+/**
  * Renders a cell's markdown into an existing element.
  *
  * Shared by the table widget (which renders into a freshly created content wrapper) and the
@@ -15,6 +32,9 @@ import { logger } from '../../logger';
  */
 export function renderCellMarkdownInto(target: HTMLElement, markdown: string, renderer: MarkdownRenderService): void {
     const { displayText, cacheKey } = buildRenderableContent(markdown);
+    // Claimed for every call, including the synchronous ones below: they write the target too,
+    // so an older pending render must not outlive them either.
+    const generation = claimGeneration(target);
 
     // Check if we have cached rendered content for the normalized cell content
     const cached = renderer.getCached(cacheKey);
@@ -35,9 +55,9 @@ export function renderCellMarkdownInto(target: HTMLElement, markdown: string, re
     void renderer
         .render(cacheKey)
         .then((fragment) => {
-            // Only update if the target is still in the DOM.
+            // Only update if this is still the target's latest request and it is in the DOM.
             // Note: Height re-measurement is handled automatically by ResizeObserver.
-            if (target.isConnected) {
+            if (renderGeneration.get(target) === generation && target.isConnected) {
                 replaceContent(target, fragment);
             }
         })


### PR DESCRIPTION
A cell's content wrapper is written by both the table widget and the nested editor when it closes, so a slow earlier render could resolve last and paint stale content over the newer result. Each call now claims a generation for the target, and an async result applies only while it still holds it.