### PR TITLE
refactor: decouple button initialization from positioning and improve toolbar tests

### DIFF
--- a/src/contentScript/__tests__/tableToolbarPlugin.test.ts
+++ b/src/contentScript/__tests__/tableToolbarPlugin.test.ts
@@ -44,11 +44,7 @@ function createView(): EditorView {
     return new EditorView({
         parent,
         state: EditorState.create({
-            extensions: [
-                activeCellField,
-                hostEditorConfigFacet.of(defaultHostEditorConfig()),
-                tableToolbarPlugin,
-            ],
+            extensions: [activeCellField, hostEditorConfigFacet.of(defaultHostEditorConfig()), tableToolbarPlugin],
         }),
     });
 }

--- a/src/contentScript/__tests__/tableToolbarPlugin.test.ts
+++ b/src/contentScript/__tests__/tableToolbarPlugin.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { EditorState } from '@codemirror/state';
 import { EditorView } from '@codemirror/view';
 import { activeCellField, setActiveCellEffect, type ActiveCell } from '../tableState/activeCellState';
@@ -29,6 +29,8 @@ vi.mock('../nestedEditor/nestedEditorController', () => ({
 
 import { tableToolbarPlugin, type TableToolbarPlugin } from '../toolbar/tableToolbarPlugin';
 
+const createdViews: EditorView[] = [];
+
 function createCell(): ActiveCell {
     return {
         tableFrom: 12,
@@ -41,12 +43,14 @@ function createCell(): ActiveCell {
 function createView(): EditorView {
     const parent = document.createElement('div');
     document.body.appendChild(parent);
-    return new EditorView({
+    const view = new EditorView({
         parent,
         state: EditorState.create({
             extensions: [activeCellField, hostEditorConfigFacet.of(defaultHostEditorConfig()), tableToolbarPlugin],
         }),
     });
+    createdViews.push(view);
+    return view;
 }
 
 function createResolvedCell(activeCell: ActiveCell): ResolvedActiveCell {
@@ -92,8 +96,14 @@ function activateCell(view: EditorView, cell: ActiveCell): void {
 
 describe('tableToolbarPlugin', () => {
     beforeEach(() => {
-        document.body.innerHTML = '';
         vi.clearAllMocks();
+    });
+
+    afterEach(() => {
+        for (const view of createdViews.splice(0)) {
+            view.destroy();
+        }
+        document.body.replaceChildren();
     });
 
     it('refocuses the nested editor when a toolbar action is a no-op', () => {
@@ -112,8 +122,6 @@ describe('tableToolbarPlugin', () => {
         expect(mockGetResolvedActiveCell).toHaveBeenCalledWith(view.state);
         expect(mockRunStructuralAction).toHaveBeenCalledWith(view, 'moveRowUp', resolvedCell);
         expect(mockRefocusNestedEditor).toHaveBeenCalledWith(view);
-
-        view.destroy();
     });
 
     it('does not refocus the nested editor after a handled toolbar action', () => {
@@ -131,8 +139,6 @@ describe('tableToolbarPlugin', () => {
 
         expect(mockRunStructuralAction).toHaveBeenCalledWith(view, 'moveRowUp', resolvedCell);
         expect(mockRefocusNestedEditor).not.toHaveBeenCalled();
-
-        view.destroy();
     });
 
     it('does not run a toolbar action when the active cell no longer resolves', () => {
@@ -148,8 +154,6 @@ describe('tableToolbarPlugin', () => {
         expect(mockGetResolvedActiveCell).toHaveBeenCalledWith(view.state);
         expect(mockRunStructuralAction).not.toHaveBeenCalled();
         expect(mockRefocusNestedEditor).toHaveBeenCalledWith(view);
-
-        view.destroy();
     });
 
     it('routes the ascending sort button through the active column action', () => {
@@ -165,7 +169,5 @@ describe('tableToolbarPlugin', () => {
         getToolbarButton(plugin, 'Sort rows by column (A to Z)').click();
 
         expect(mockRunStructuralAction).toHaveBeenCalledWith(view, 'sortColumnAscending', resolvedCell);
-
-        view.destroy();
     });
 });

--- a/src/contentScript/__tests__/tableToolbarPlugin.test.ts
+++ b/src/contentScript/__tests__/tableToolbarPlugin.test.ts
@@ -47,10 +47,8 @@ function createCell(): ActiveCell {
 }
 
 function createView(): EditorView {
-    const parent = document.createElement('div');
-    document.body.appendChild(parent);
     const view = new EditorView({
-        parent,
+        parent: document.body,
         state: EditorState.create({
             extensions: [activeCellField, hostEditorConfigFacet.of(defaultHostEditorConfig()), tableToolbarPlugin],
         }),

--- a/src/contentScript/__tests__/tableToolbarPlugin.test.ts
+++ b/src/contentScript/__tests__/tableToolbarPlugin.test.ts
@@ -1,10 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { EditorState } from '@codemirror/state';
 import { EditorView } from '@codemirror/view';
-import { activeCellField, setActiveCellEffect, type ActiveCell } from '../tableState/activeCellState';
+import {
+    activeCellField,
+    clearActiveCellEffect,
+    setActiveCellEffect,
+    type ActiveCell,
+} from '../tableState/activeCellState';
 import type { ResolvedActiveCell } from '../tableRuntime/activeCell/resolvedActiveCell';
 import { defaultHostEditorConfig } from '../../contentScriptBridge/hostEditorConfigBridge';
 import { hostEditorConfigFacet } from '../services/hostEditorConfig';
+import { CLASS_FLOATING_TOOLBAR } from '../tableWidget/domHelpers';
 
 const { mockGetResolvedActiveCell, mockRunStructuralAction, mockIsNestedEditorOpen, mockRefocusNestedEditor } =
     vi.hoisted(() => ({
@@ -81,8 +87,21 @@ function getToolbarButton(view: EditorView, ariaLabel: string): HTMLButtonElemen
     return button;
 }
 
+function getToolbar(view: EditorView): HTMLElement {
+    const toolbar = view.dom.querySelector(`.${CLASS_FLOATING_TOOLBAR}`);
+    if (!(toolbar instanceof HTMLElement)) {
+        throw new Error('Missing toolbar element');
+    }
+
+    return toolbar;
+}
+
 function activateCell(view: EditorView, cell: ActiveCell): void {
     view.dispatch({ effects: setActiveCellEffect.of(cell) });
+}
+
+function clearActiveCell(view: EditorView): void {
+    view.dispatch({ effects: clearActiveCellEffect.of(undefined) });
 }
 
 describe('tableToolbarPlugin', () => {
@@ -95,6 +114,18 @@ describe('tableToolbarPlugin', () => {
             view.destroy();
         }
         document.body.replaceChildren();
+    });
+
+    it('creates toolbar buttons when a cell becomes active, before any positioning runs', () => {
+        const view = createView();
+        const toolbar = getToolbar(view);
+
+        expect(toolbar.querySelector('button')).toBeNull();
+
+        activateCell(view, createCell());
+
+        // No measure cycle has run, so this asserts button creation is independent of positioning.
+        expect(getToolbarButton(view, 'Move row up')).toBeInstanceOf(HTMLButtonElement);
     });
 
     it('refocuses the nested editor when a toolbar action is a no-op', () => {
@@ -156,5 +187,22 @@ describe('tableToolbarPlugin', () => {
         getToolbarButton(view, 'Sort rows by column (A to Z)').click();
 
         expect(mockRunStructuralAction).toHaveBeenCalledWith(view, 'sortColumnAscending', resolvedCell);
+    });
+
+    it('hides the toolbar when the active cell is cleared', () => {
+        const view = createView();
+        const toolbar = getToolbar(view);
+
+        activateCell(view, createCell());
+        // Positioning never completes here: there is no table widget to anchor to, so the
+        // toolbar is left in the hidden pre-positioning state. Stage the visible state that a
+        // successful placement would have produced, so the assertions below cannot pass by default.
+        toolbar.style.display = 'flex';
+        toolbar.style.visibility = 'visible';
+
+        clearActiveCell(view);
+
+        expect(toolbar.style.display).toBe('none');
+        expect(toolbar.style.visibility).toBe('hidden');
     });
 });

--- a/src/contentScript/__tests__/tableToolbarPlugin.test.ts
+++ b/src/contentScript/__tests__/tableToolbarPlugin.test.ts
@@ -27,7 +27,7 @@ vi.mock('../nestedEditor/nestedEditorController', () => ({
     refocusNestedEditor: mockRefocusNestedEditor,
 }));
 
-import { tableToolbarPlugin, type TableToolbarPlugin } from '../toolbar/tableToolbarPlugin';
+import { tableToolbarPlugin } from '../toolbar/tableToolbarPlugin';
 
 const createdViews: EditorView[] = [];
 
@@ -72,22 +72,13 @@ function createResolvedCell(activeCell: ActiveCell): ResolvedActiveCell {
     } as unknown as ResolvedActiveCell;
 }
 
-function getToolbarButton(plugin: TableToolbarPlugin, ariaLabel: string): HTMLButtonElement {
-    const button = plugin.dom.querySelector(`button[aria-label="${ariaLabel}"]`);
+function getToolbarButton(view: EditorView, ariaLabel: string): HTMLButtonElement {
+    const button = view.dom.querySelector(`button[aria-label="${ariaLabel}"]`);
     if (!(button instanceof HTMLButtonElement)) {
         throw new Error(`Missing toolbar button: ${ariaLabel}`);
     }
 
     return button;
-}
-
-function requireToolbarPlugin(view: EditorView): TableToolbarPlugin {
-    const plugin = view.plugin(tableToolbarPlugin);
-    if (!plugin) {
-        throw new Error('Expected table toolbar plugin');
-    }
-
-    return plugin;
 }
 
 function activateCell(view: EditorView, cell: ActiveCell): void {
@@ -108,7 +99,6 @@ describe('tableToolbarPlugin', () => {
 
     it('refocuses the nested editor when a toolbar action is a no-op', () => {
         const view = createView();
-        const plugin = requireToolbarPlugin(view);
         const cell = createCell();
         const resolvedCell = createResolvedCell(cell);
 
@@ -117,7 +107,7 @@ describe('tableToolbarPlugin', () => {
         mockRunStructuralAction.mockReturnValue(false);
         mockIsNestedEditorOpen.mockReturnValue(true);
 
-        getToolbarButton(plugin, 'Move row up').click();
+        getToolbarButton(view, 'Move row up').click();
 
         expect(mockGetResolvedActiveCell).toHaveBeenCalledWith(view.state);
         expect(mockRunStructuralAction).toHaveBeenCalledWith(view, 'moveRowUp', resolvedCell);
@@ -126,7 +116,6 @@ describe('tableToolbarPlugin', () => {
 
     it('does not refocus the nested editor after a handled toolbar action', () => {
         const view = createView();
-        const plugin = requireToolbarPlugin(view);
         const cell = createCell();
         const resolvedCell = createResolvedCell(cell);
 
@@ -135,7 +124,7 @@ describe('tableToolbarPlugin', () => {
         mockRunStructuralAction.mockReturnValue(true);
         mockIsNestedEditorOpen.mockReturnValue(true);
 
-        getToolbarButton(plugin, 'Move row up').click();
+        getToolbarButton(view, 'Move row up').click();
 
         expect(mockRunStructuralAction).toHaveBeenCalledWith(view, 'moveRowUp', resolvedCell);
         expect(mockRefocusNestedEditor).not.toHaveBeenCalled();
@@ -143,13 +132,12 @@ describe('tableToolbarPlugin', () => {
 
     it('does not run a toolbar action when the active cell no longer resolves', () => {
         const view = createView();
-        const plugin = requireToolbarPlugin(view);
 
         activateCell(view, createCell());
         mockGetResolvedActiveCell.mockReturnValue(null);
         mockIsNestedEditorOpen.mockReturnValue(true);
 
-        getToolbarButton(plugin, 'Move row up').click();
+        getToolbarButton(view, 'Move row up').click();
 
         expect(mockGetResolvedActiveCell).toHaveBeenCalledWith(view.state);
         expect(mockRunStructuralAction).not.toHaveBeenCalled();
@@ -158,7 +146,6 @@ describe('tableToolbarPlugin', () => {
 
     it('routes the ascending sort button through the active column action', () => {
         const view = createView();
-        const plugin = requireToolbarPlugin(view);
         const cell = createCell();
         const resolvedCell = createResolvedCell(cell);
 
@@ -166,7 +153,7 @@ describe('tableToolbarPlugin', () => {
         mockGetResolvedActiveCell.mockReturnValue(resolvedCell);
         mockRunStructuralAction.mockReturnValue(true);
 
-        getToolbarButton(plugin, 'Sort rows by column (A to Z)').click();
+        getToolbarButton(view, 'Sort rows by column (A to Z)').click();
 
         expect(mockRunStructuralAction).toHaveBeenCalledWith(view, 'sortColumnAscending', resolvedCell);
     });

--- a/src/contentScript/__tests__/tableToolbarPlugin.test.ts
+++ b/src/contentScript/__tests__/tableToolbarPlugin.test.ts
@@ -1,8 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { EditorView } from '@codemirror/view';
-import type { ActiveCell } from '../tableState/activeCellState';
+import { EditorState } from '@codemirror/state';
+import { EditorView } from '@codemirror/view';
+import { activeCellField, setActiveCellEffect, type ActiveCell } from '../tableState/activeCellState';
 import type { ResolvedActiveCell } from '../tableRuntime/activeCell/resolvedActiveCell';
 import { defaultHostEditorConfig } from '../../contentScriptBridge/hostEditorConfigBridge';
+import { hostEditorConfigFacet } from '../services/hostEditorConfig';
 
 const { mockGetResolvedActiveCell, mockRunStructuralAction, mockIsNestedEditorOpen, mockRefocusNestedEditor } =
     vi.hoisted(() => ({
@@ -25,7 +27,7 @@ vi.mock('../nestedEditor/nestedEditorController', () => ({
     refocusNestedEditor: mockRefocusNestedEditor,
 }));
 
-import { TableToolbarPlugin } from '../toolbar/tableToolbarPlugin';
+import { tableToolbarPlugin, type TableToolbarPlugin } from '../toolbar/tableToolbarPlugin';
 
 function createCell(): ActiveCell {
     return {
@@ -37,15 +39,18 @@ function createCell(): ActiveCell {
 }
 
 function createView(): EditorView {
-    const dom = document.createElement('div');
-    document.body.appendChild(dom);
-    return {
-        dom,
-        state: {
-            doc: { length: 0 },
-            facet: () => defaultHostEditorConfig(),
-        },
-    } as unknown as EditorView;
+    const parent = document.createElement('div');
+    document.body.appendChild(parent);
+    return new EditorView({
+        parent,
+        state: EditorState.create({
+            extensions: [
+                activeCellField,
+                hostEditorConfigFacet.of(defaultHostEditorConfig()),
+                tableToolbarPlugin,
+            ],
+        }),
+    });
 }
 
 function createResolvedCell(activeCell: ActiveCell): ResolvedActiveCell {
@@ -76,17 +81,17 @@ function getToolbarButton(plugin: TableToolbarPlugin, ariaLabel: string): HTMLBu
     return button;
 }
 
-function setCurrentActiveCell(plugin: TableToolbarPlugin, cell: ActiveCell): void {
-    Reflect.set(plugin as unknown as object, 'currentActiveCell', cell);
-}
-
-function createToolbarButtons(plugin: TableToolbarPlugin): void {
-    const createButtons = Reflect.get(plugin as unknown as object, 'createButtons');
-    if (typeof createButtons !== 'function') {
-        throw new Error('Missing createButtons on toolbar plugin');
+function requireToolbarPlugin(view: EditorView): TableToolbarPlugin {
+    const plugin = view.plugin(tableToolbarPlugin);
+    if (!plugin) {
+        throw new Error('Expected table toolbar plugin');
     }
 
-    createButtons.call(plugin);
+    return plugin;
+}
+
+function activateCell(view: EditorView, cell: ActiveCell): void {
+    view.dispatch({ effects: setActiveCellEffect.of(cell) });
 }
 
 describe('tableToolbarPlugin', () => {
@@ -97,12 +102,11 @@ describe('tableToolbarPlugin', () => {
 
     it('refocuses the nested editor when a toolbar action is a no-op', () => {
         const view = createView();
-        const plugin = new TableToolbarPlugin(view);
+        const plugin = requireToolbarPlugin(view);
         const cell = createCell();
         const resolvedCell = createResolvedCell(cell);
 
-        setCurrentActiveCell(plugin, cell);
-        createToolbarButtons(plugin);
+        activateCell(view, cell);
         mockGetResolvedActiveCell.mockReturnValue(resolvedCell);
         mockRunStructuralAction.mockReturnValue(false);
         mockIsNestedEditorOpen.mockReturnValue(true);
@@ -113,17 +117,16 @@ describe('tableToolbarPlugin', () => {
         expect(mockRunStructuralAction).toHaveBeenCalledWith(view, 'moveRowUp', resolvedCell);
         expect(mockRefocusNestedEditor).toHaveBeenCalledWith(view);
 
-        plugin.destroy();
+        view.destroy();
     });
 
     it('does not refocus the nested editor after a handled toolbar action', () => {
         const view = createView();
-        const plugin = new TableToolbarPlugin(view);
+        const plugin = requireToolbarPlugin(view);
         const cell = createCell();
         const resolvedCell = createResolvedCell(cell);
 
-        setCurrentActiveCell(plugin, cell);
-        createToolbarButtons(plugin);
+        activateCell(view, cell);
         mockGetResolvedActiveCell.mockReturnValue(resolvedCell);
         mockRunStructuralAction.mockReturnValue(true);
         mockIsNestedEditorOpen.mockReturnValue(true);
@@ -133,15 +136,14 @@ describe('tableToolbarPlugin', () => {
         expect(mockRunStructuralAction).toHaveBeenCalledWith(view, 'moveRowUp', resolvedCell);
         expect(mockRefocusNestedEditor).not.toHaveBeenCalled();
 
-        plugin.destroy();
+        view.destroy();
     });
 
     it('does not run a toolbar action when the active cell no longer resolves', () => {
         const view = createView();
-        const plugin = new TableToolbarPlugin(view);
+        const plugin = requireToolbarPlugin(view);
 
-        setCurrentActiveCell(plugin, createCell());
-        createToolbarButtons(plugin);
+        activateCell(view, createCell());
         mockGetResolvedActiveCell.mockReturnValue(null);
         mockIsNestedEditorOpen.mockReturnValue(true);
 
@@ -151,17 +153,16 @@ describe('tableToolbarPlugin', () => {
         expect(mockRunStructuralAction).not.toHaveBeenCalled();
         expect(mockRefocusNestedEditor).toHaveBeenCalledWith(view);
 
-        plugin.destroy();
+        view.destroy();
     });
 
     it('routes the ascending sort button through the active column action', () => {
         const view = createView();
-        const plugin = new TableToolbarPlugin(view);
+        const plugin = requireToolbarPlugin(view);
         const cell = createCell();
         const resolvedCell = createResolvedCell(cell);
 
-        setCurrentActiveCell(plugin, cell);
-        createToolbarButtons(plugin);
+        activateCell(view, cell);
         mockGetResolvedActiveCell.mockReturnValue(resolvedCell);
         mockRunStructuralAction.mockReturnValue(true);
 
@@ -169,6 +170,6 @@ describe('tableToolbarPlugin', () => {
 
         expect(mockRunStructuralAction).toHaveBeenCalledWith(view, 'sortColumnAscending', resolvedCell);
 
-        plugin.destroy();
+        view.destroy();
     });
 });

--- a/src/contentScript/toolbar/tableToolbarPlugin.ts
+++ b/src/contentScript/toolbar/tableToolbarPlugin.ts
@@ -88,6 +88,7 @@ export class TableToolbarPlugin {
         // Active cell appeared or disappeared
         if (!!prevActiveCell !== !!activeCell) {
             if (activeCell) {
+                this.ensureButtonsInitialized();
                 // Defer until widget DOM is ready (runs in CM's measure cycle after DOM update)
                 this.schedulePositionUpdate();
             } else {

--- a/src/contentScript/toolbar/tableToolbarPlugin.ts
+++ b/src/contentScript/toolbar/tableToolbarPlugin.ts
@@ -238,26 +238,24 @@ export class TableToolbarPlugin {
             key: this,
             read: () => null,
             write: () => {
-                void this.updatePosition();
+                this.updatePosition();
             },
         });
     }
 
-    private async updatePosition() {
-        if (!this.currentActiveCell) {
+    private updatePosition(): void {
+        if (this.destroyed) {
+            return;
+        }
+
+        const activeCell = this.currentActiveCell;
+        if (!activeCell) {
             this.cleanupPositioning();
             this.hideToolbar();
             return;
         }
 
-        this.ensureButtonsInitialized();
-        if (this.destroyed || !this.currentActiveCell) {
-            this.cleanupPositioning();
-            this.hideToolbar();
-            return;
-        }
-
-        const widgetElement = findTableWidgetElement(this.view, makeTableId(this.currentActiveCell.tableFrom));
+        const widgetElement = findTableWidgetElement(this.view, makeTableId(activeCell.tableFrom));
         const tableElement = widgetElement && findWidgetTableElement(widgetElement);
 
         if (!widgetElement || !tableElement) {

--- a/src/contentScript/toolbar/tableToolbarPlugin.ts
+++ b/src/contentScript/toolbar/tableToolbarPlugin.ts
@@ -62,7 +62,7 @@ interface ToolbarGeometry {
     viewport: ViewportBounds;
 }
 
-export class TableToolbarPlugin {
+class TableToolbarPlugin {
     dom: HTMLElement;
     private currentActiveCell: ActiveCell | null = null;
     private cleanupAutoUpdate: (() => void) | null = null;


### PR DESCRIPTION
Summary

- Initialize toolbar buttons on cell activation, independently of positioning.
- Test toolbar behavior through a real EditorView and its public DOM.
- Clean up test views reliably and keep the plugin implementation class private.

Verification: npm test, npm run lint, npm run dist.